### PR TITLE
specify calling_format to OrdinaryCallingFormat makes it support dots in the bucket name

### DIFF
--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -122,6 +122,7 @@ def smart_open(uri, mode="rb", **kw):
             s3_connection = boto.connect_s3(aws_access_key_id=parsed_uri.access_id,
                                             aws_secret_access_key=parsed_uri.access_secret,
                                             calling_format=OrdinaryCallingFormat())
+
             bucket = s3_connection.get_bucket(parsed_uri.bucket_id)
             if mode in ('r', 'rb'):
                 key = bucket.get_key(parsed_uri.key_id)

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -32,6 +32,7 @@ elif sys.version_info[0] == 3:
     import http.client as httplib
 
 from boto.compat import BytesIO, urlsplit, six
+from boto.s3.connection import OrdinaryCallingFormat
 import boto.s3.key
 
 logger = logging.getLogger(__name__)
@@ -118,7 +119,9 @@ def smart_open(uri, mode="rb", **kw):
             # compression, if any, is determined by the filename extension (.gz, .bz2)
             return file_smart_open(parsed_uri.uri_path, mode)
         elif parsed_uri.scheme in ("s3", "s3n"):
-            s3_connection = boto.connect_s3(aws_access_key_id=parsed_uri.access_id, aws_secret_access_key=parsed_uri.access_secret)
+            s3_connection = boto.connect_s3(aws_access_key_id=parsed_uri.access_id,
+                                            aws_secret_access_key=parsed_uri.access_secret,
+                                            calling_format=OrdinaryCallingFormat())
             bucket = s3_connection.get_bucket(parsed_uri.bucket_id)
             if mode in ('r', 'rb'):
                 key = bucket.get_key(parsed_uri.key_id)


### PR DESCRIPTION
This would fix #52 
