### PR TITLE
Fixing readline() behavior when EOF has been reached.

### DIFF
--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -339,6 +339,15 @@ class S3ReadStream(io.BufferedReader):
         self.stream = _S3ReadStream(key)
         super(S3ReadStream, self).__init__(self.stream)
 
+        #
+        # Generator behavior changed in Python 3.
+        # Instead of g.next(), Python 3.x expects next(g) or g.__next__().
+        # http://stackoverflow.com/questions/1073396/is-generator-next-visible-in-python-3-0
+        # This is a patch to keep things working in Python 3.x.
+        #
+        if sys.version_info[0] == 3:
+            self.next = self.__next__
+
     def read(self, *args, **kwargs):
         # Patch read to return '' instead of raise Value Error
         try:

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -384,7 +384,7 @@ class S3OpenRead(object):
         try:
             return self.reader.next()
         except StopIteration:
-            return None
+            return b""
 
     def read(self, size=None):
         """

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -339,15 +339,6 @@ class S3ReadStream(io.BufferedReader):
         self.stream = _S3ReadStream(key)
         super(S3ReadStream, self).__init__(self.stream)
 
-        #
-        # Generator behavior changed in Python 3.
-        # Instead of g.next(), Python 3.x expects next(g) or g.__next__().
-        # http://stackoverflow.com/questions/1073396/is-generator-next-visible-in-python-3-0
-        # This is a patch to keep things working in Python 3.x.
-        #
-        if sys.version_info[0] == 3:
-            self.next = self.__next__
-
     def read(self, *args, **kwargs):
         # Patch read to return '' instead of raise Value Error
         try:
@@ -390,10 +381,7 @@ class S3OpenRead(object):
             yield line
 
     def readline(self):
-        try:
-            return self.reader.next()
-        except StopIteration:
-            return b""
+        return self.reader.readline()
 
     def read(self, size=None):
         """

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -244,6 +244,57 @@ class SmartOpenReadTest(unittest.TestCase):
         self.assertEqual(content, smart_open_object.read(-1)) # same thing
 
 
+class S3OpenReadTest(unittest.TestCase):
+
+    @mock_s3
+    def test_readline(self):
+        """Does readline() return the correct file content?"""
+        conn = boto.connect_s3()
+        conn.create_bucket("mybucket")
+        test_string = u"hello žluťoučký world!\nhow are you?".encode('utf8')
+        with smart_open.smart_open("s3://mybucket/mykey", "wb") as fout:
+            fout.write(test_string)
+
+        mykey = conn.get_bucket("mybucket").get_key("mykey")
+        reader = smart_open.S3OpenRead(mykey)
+        self.assertEquals(
+            reader.readline(), u"hello žluťoučký world!\n".encode("utf-8")
+        )
+        self.assertEquals(reader.readline(), "how are you?")
+
+    @mock_s3
+    def test_readline_iter(self):
+        """Does __iter__ return the correct file content?"""
+        conn = boto.connect_s3()
+        conn.create_bucket("mybucket")
+        lines = [u"всем привет!\n", u"что нового?"]
+        with smart_open.smart_open("s3://mybucket/mykey", "wb") as fout:
+            fout.write("".join(lines).encode("utf-8"))
+
+        mykey = conn.get_bucket("mybucket").get_key("mykey")
+        reader = smart_open.S3OpenRead(mykey)
+
+        actual_lines = [l.decode("utf-8") for l in reader]
+        self.assertEquals(2, len(actual_lines))
+        self.assertEquals(lines[0], actual_lines[0])
+        self.assertEquals(lines[1], actual_lines[1])
+
+    @mock_s3
+    def test_readline_eof(self):
+        """Does readline() return empty string on EOF?"""
+        conn = boto.connect_s3()
+        conn.create_bucket("mybucket")
+        with smart_open.smart_open("s3://mybucket/mykey", "wb"):
+            pass
+
+        mykey = conn.get_bucket("mybucket").get_key("mykey")
+        reader = smart_open.S3OpenRead(mykey)
+
+        self.assertEquals(reader.readline(), "")
+        self.assertEquals(reader.readline(), "")
+        self.assertEquals(reader.readline(), "")
+
+
 class S3IterLinesTest(unittest.TestCase):
     """
     Test s3_iter_lines.

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -260,7 +260,7 @@ class S3OpenReadTest(unittest.TestCase):
         self.assertEquals(
             reader.readline(), u"hello žluťoučký world!\n".encode("utf-8")
         )
-        self.assertEquals(reader.readline(), "how are you?")
+        self.assertEquals(reader.readline(), b"how are you?")
 
     @mock_s3
     def test_readline_iter(self):
@@ -290,9 +290,9 @@ class S3OpenReadTest(unittest.TestCase):
         mykey = conn.get_bucket("mybucket").get_key("mykey")
         reader = smart_open.S3OpenRead(mykey)
 
-        self.assertEquals(reader.readline(), "")
-        self.assertEquals(reader.readline(), "")
-        self.assertEquals(reader.readline(), "")
+        self.assertEquals(reader.readline(), b"")
+        self.assertEquals(reader.readline(), b"")
+        self.assertEquals(reader.readline(), b"")
 
 
 class S3IterLinesTest(unittest.TestCase):


### PR DESCRIPTION
readline returns empty string once EOF has been reached.
It shouldn't _ever_ return None, because it breaks code like this:

    buf += reader.readline()

with a TypeError.