### PR TITLE
Add retry to get_contents to address SSLError that can occur

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,12 @@
+* UNRELEASED
+
+  - Add retry around `s3_iter_bucket_process_key` to address S3 Read Timeout errors.
+
 * 1.3.5, 5th October 2016
 
   - Add MANIFEST.in required for conda-forge recip (PR #90, @tmylk)
   - Fix #92. Allow hash in filename (PR #93, @tmylk)
- 
+
 * 1.3.4, 26th August 2016
 
   - Relative path support (PR #73, @yupbank)

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -744,7 +744,7 @@ class WebHdfsOpenWrite(object):
         self.close()
 
 
-def s3_iter_bucket_process_key(key, retries = 3):
+def s3_iter_bucket_process_key(key, retries=3):
     """
     Conceptually part of `s3_iter_bucket`, but must remain top-level method because
     of pickling visibility.

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -752,7 +752,7 @@ def s3_iter_bucket_process_key(key, retries=3):
     """
     # Sometimes, https://github.com/boto/boto/issues/2409 can happen because of network issues on either side.
     # Retry up to 3 times to ensure its not a transient issue.
-    for x in xrange(0, retries + 1):
+    for x in range(0, retries + 1):
         try:
             return key, key.get_contents_as_string()
         except SSLError:

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -34,6 +34,7 @@ elif sys.version_info[0] == 3:
 
 from boto.compat import BytesIO, urlsplit, six
 import boto.s3.key
+from ssl import SSLError
 
 logger = logging.getLogger(__name__)
 
@@ -743,13 +744,23 @@ class WebHdfsOpenWrite(object):
         self.close()
 
 
-def s3_iter_bucket_process_key(key):
+def s3_iter_bucket_process_key(key, retries = 3):
     """
     Conceptually part of `s3_iter_bucket`, but must remain top-level method because
     of pickling visibility.
 
     """
-    return key, key.get_contents_as_string()
+    # Sometimes, https://github.com/boto/boto/issues/2409 can happen because of network issues on either side.
+    # Retry up to 3 times to ensure its not a transient issue.
+    for x in xrange(0, retries + 1):
+        try:
+            return key, key.get_contents_as_string()
+        except SSLError:
+            # Actually fail on last pass through the loop
+            if x == retries:
+                raise
+            # Otherwise, try again, as this might be a transient timeout
+            pass
 
 
 def s3_iter_bucket(bucket, prefix='', accept_key=lambda key: True, key_limit=None, workers=16):

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -683,8 +683,7 @@ class S3IterBucketTest(unittest.TestCase):
 
         # when get_contents_as_string always returns SSLError
         mykey.get_contents_as_string.side_effect = SSLError
-        with self.assertRaises(SSLError):
-            key, content = smart_open.s3_iter_bucket_process_key(mykey)
+        self.assertRaises(SSLError, smart_open.s3_iter_bucket_process_key, mykey)
 
         # when get_contents_as_string only returns SSLError once, can still recover
         mykey.get_contents_as_string.side_effect = [SSLError, b"contentA"]
@@ -700,13 +699,11 @@ class S3IterBucketTest(unittest.TestCase):
 
         # but not more than three times ....
         mykey.get_contents_as_string.side_effect = [SSLError, SSLError, SSLError, SSLError, b"contentA"]
-        with self.assertRaises(SSLError):
-            key, content = smart_open.s3_iter_bucket_process_key(mykey)
+        self.assertRaises(SSLError, smart_open.s3_iter_bucket_process_key, mykey)
 
         # some other exception always fails, and never retries
         mykey.get_contents_as_string.side_effect = [Exception, b"contentA"]
-        with self.assertRaises(Exception):
-            key, content = smart_open.s3_iter_bucket_process_key(mykey)
+        self.assertRaises(Exception, smart_open.s3_iter_bucket_process_key, mykey)
 
     @mock_s3
     def test_s3_iter_bucket_process_key_moto(self):

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -18,6 +18,7 @@ import mock
 from moto import mock_s3
 import responses
 import io
+from ssl import SSLError
 
 import smart_open
 from smart_open import smart_open_lib
@@ -675,6 +676,37 @@ class S3IterBucketTest(unittest.TestCase):
         self.assertEqual(key, mykey)
         self.assertEqual(content, b"contentA")
 
+    def test_s3_iter_bucket_process_key_with_SSLError_mock(self):
+        attrs = {"name" : "fileA", "get_contents_as_string.return_value" : b"contentA"}
+        mykey = mock.Mock(spec=["name", "get_contents_as_string"])
+        mykey.configure_mock(**attrs)
+
+        # when get_contents_as_string always returns SSLError
+        mykey.get_contents_as_string.side_effect = SSLError
+        with self.assertRaises(SSLError):
+            key, content = smart_open.s3_iter_bucket_process_key(mykey)
+
+        # when get_contents_as_string only returns SSLError once, can still recover
+        mykey.get_contents_as_string.side_effect = [SSLError, b"contentA"]
+        key, content = smart_open.s3_iter_bucket_process_key(mykey)
+        self.assertEqual(key, mykey)
+        self.assertEqual(content, b"contentA")
+
+        # when get_contents_as_string fails up to three times, can still recover
+        mykey.get_contents_as_string.side_effect = [SSLError, SSLError, SSLError, b"contentA"]
+        key, content = smart_open.s3_iter_bucket_process_key(mykey)
+        self.assertEqual(key, mykey)
+        self.assertEqual(content, b"contentA")
+
+        # but not more than three times ....
+        mykey.get_contents_as_string.side_effect = [SSLError, SSLError, SSLError, SSLError, b"contentA"]
+        with self.assertRaises(SSLError):
+            key, content = smart_open.s3_iter_bucket_process_key(mykey)
+
+        # some other exception always fails, and never retries
+        mykey.get_contents_as_string.side_effect = [Exception, b"contentA"]
+        with self.assertRaises(Exception):
+            key, content = smart_open.s3_iter_bucket_process_key(mykey)
 
     @mock_s3
     def test_s3_iter_bucket_process_key_moto(self):


### PR DESCRIPTION
I have been experiencing https://github.com/boto/boto/issues/2409 while using `smart_open`. This update allows us to retry three times before finally failing because of a read timeout.