### PR TITLE
Adding seek method to S3ReaderStream implementation

### DIFF
--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -377,6 +377,12 @@ class S3ReadStream(io.BufferedReader):
         except ValueError:
             return ''
 
+    def seek(self, position, whence=0):
+        try:
+            super(S3ReadStream, self).seek(position, whence)
+        except AttributeError:
+            pass
+
 
 class S3OpenRead(object):
     """


### PR DESCRIPTION
If I use the underlying S3ReaderStream implementation directly without using S3OpenRead, it will throw attribute error exceptions, I have followed the same path django uses for their base files, silencing that error.