### PR TITLE
BUG: include tests data in sdist + install them.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     long_description = read('README.rst'),
 
     packages=find_packages(),
+    package_data={"smart_open.tests": ["test_data/*gz"]},
 
     author = u'Radim Řehůřek',
     author_email = 'me@radimrehurek.com',


### PR DESCRIPTION
This allows running the tests from an installed smart_open without referring to the sources at all (e.g. wheel).