### PR TITLE
Fix bug #95 and expand test coverage to catch it

### DIFF
--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -353,8 +353,7 @@ class S3ReadStreamInner(object):
             return self.read_from_buffer(size)
 
         # If the stream is finished and no unused raw data, return what we have
-        if self.stream.closed or self.finished:
-            self.finished = True
+        if self.finished:
             return self.read_from_buffer(size)
 
         # Consume new data in chunks and return it.
@@ -465,7 +464,6 @@ class S3OpenRead(object):
         """
         if whence != 0 or offset != 0:
             raise NotImplementedError("seek other than offset=0 not implemented yet")
-        self.read_key.close(fast=True)
         self._open_reader()
 
     def __enter__(self):

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -302,6 +302,12 @@ class SmartOpenReadTest(unittest.TestCase):
 
         smart_open_object.seek(0)
         self.assertEqual(content, smart_open_object.read(-1)) # same thing
+        
+        smart_open_object.seek(0)
+        self.assertEqual(content[:4], smart_open_object.read(4)) # Read 4 bytes
+
+        smart_open_object.seek(0)
+        self.assertEqual(content[:content.find(b'\n')+1], smart_open_object.readline()) # Read 1 line 
 
 
 class S3ReadStreamInnerTest(unittest.TestCase):


### PR DESCRIPTION
More info [here](https://github.com/RaRe-Technologies/smart_open/pull/115) and [here](https://github.com/RaRe-Technologies/smart_open/issues/95)

A couple things that should be changed in the future:
- An unreferenced attribute self.closed should be removed or,
- self.stream.closed (removed in this commit) needs to be replaced with an alternative that actually does what it was intended to do. And maybe it's functioning is tied to the above attribute

Also, this will be my first (successful :crossed_fingers:)  PR :smile: 