### PR TITLE
Add optional s3 token to URI

### DIFF
--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -249,24 +249,29 @@ class SmartOpenReadTest(unittest.TestCase):
         # no credentials
         smart_open_object = smart_open.smart_open("s3://mybucket/mykey")
         smart_open_object.__iter__()
-        mock_boto.connect_s3.assert_called_with(aws_access_key_id=None, aws_secret_access_key=None, profile_name=None, host='s3.amazonaws.com')
+        mock_boto.connect_s3.assert_called_with(aws_access_key_id=None, aws_secret_access_key=None, security_token=None, profile_name=None, host='s3.amazonaws.com')
 
         # with credential
         smart_open_object = smart_open.smart_open("s3://access_id:access_secret@mybucket/mykey")
         smart_open_object.__iter__()
-        mock_boto.connect_s3.assert_called_with(aws_access_key_id="access_id", aws_secret_access_key="access_secret", profile_name=None, host='s3.amazonaws.com')
+        mock_boto.connect_s3.assert_called_with(aws_access_key_id="access_id", aws_secret_access_key="access_secret", security_token=None, profile_name=None, host='s3.amazonaws.com')
+
+        # with credential + security token
+        smart_open_object = smart_open.smart_open("s3://access_id:access_secret:token@mybucket/mykey")
+        smart_open_object.__iter__()
+        mock_boto.connect_s3.assert_called_with(aws_access_key_id="access_id", aws_secret_access_key="access_secret", security_token="token", profile_name=None, host='s3.amazonaws.com')
 
         # with credential profile
         smart_open_object = smart_open.smart_open("s3://mybucket/mykey", profile_name="my_credentials")
         smart_open_object.__iter__()
-        mock_boto.connect_s3.assert_called_with(aws_access_key_id=None, aws_secret_access_key=None, profile_name="my_credentials", host='s3.amazonaws.com')
+        mock_boto.connect_s3.assert_called_with(aws_access_key_id=None, aws_secret_access_key=None, security_token=None, profile_name="my_credentials", host='s3.amazonaws.com')
 
         # lookup bucket, key; call s3_iter_lines
         smart_open_object = smart_open.smart_open("s3://access_id:access_secret@mybucket/mykey")
         smart_open_object.__iter__()
 
         # Check that the port argument wasn't passed to the connection
-        mock_boto.connect_s3.assert_called_with(aws_access_key_id='access_id', aws_secret_access_key='access_secret', host='s3.amazonaws.com', profile_name=None)
+        mock_boto.connect_s3.assert_called_with(aws_access_key_id='access_id', aws_secret_access_key='access_secret', security_token=None, host='s3.amazonaws.com', profile_name=None)
         mock_boto.connect_s3().get_bucket.assert_called_with("mybucket")
         mock_boto.connect_s3().get_bucket().get_key.assert_called_with("mykey")
         #
@@ -277,7 +282,7 @@ class SmartOpenReadTest(unittest.TestCase):
         # with user-specified host
         smart_open_object = smart_open.smart_open("s3://access_id:access_secret@mybucket/mykey", host='aa.domain.com')
         smart_open_object.__iter__()
-        mock_boto.connect_s3.assert_called_with(aws_access_key_id="access_id", aws_secret_access_key="access_secret", profile_name=None, host='aa.domain.com')
+        mock_boto.connect_s3.assert_called_with(aws_access_key_id="access_id", aws_secret_access_key="access_secret", security_token=None, profile_name=None, host='aa.domain.com')
 
     @mock_s3
     def test_s3_iter_moto(self):
@@ -551,7 +556,7 @@ class SmartOpenTest(unittest.TestCase):
 
         # correct write mode, correct s3 URI
         smart_open.smart_open("s3://mybucket/mykey", "w")
-        mock_boto.connect_s3.assert_called_with(aws_access_key_id=None, aws_secret_access_key=None, profile_name=None, host='s3.amazonaws.com')
+        mock_boto.connect_s3.assert_called_with(aws_access_key_id=None, aws_secret_access_key=None, security_token=None, profile_name=None, host='s3.amazonaws.com')
         mock_boto.connect_s3().lookup.return_value = True
         mock_boto.connect_s3().get_bucket.assert_called_with("mybucket")
         self.assertTrue(mock_write.called)
@@ -580,8 +585,8 @@ class SmartOpenTest(unittest.TestCase):
         smart_open.smart_open("s3u://user:secret@example.com@mybucket/mykey", "w")
         mock_boto.connect_s3.assert_called_with(
             aws_access_key_id='user', aws_secret_access_key='secret',
-            profile_name=None, host='example.com', is_secure=False,
-            calling_format=mock_boto.s3.connection.OrdinaryCallingFormat())
+            security_token=None, profile_name=None, host='example.com',
+            is_secure=False, calling_format=mock_boto.s3.connection.OrdinaryCallingFormat())
         mock_boto.connect_s3().lookup.return_value = True
         mock_boto.connect_s3().get_bucket.assert_called_with("mybucket")
         self.assertTrue(mock_write.called)
@@ -597,7 +602,8 @@ class SmartOpenTest(unittest.TestCase):
         smart_open.smart_open("s3u://user:secret@example.com:2048@mybucket/mykey", "w")
         mock_boto.connect_s3.assert_called_with(
             aws_access_key_id='user', aws_secret_access_key='secret',
-            profile_name=None, host='example.com', is_secure=False, port=2048,
+            security_token=None, profile_name=None, host='example.com',
+            is_secure=False, port=2048,
             calling_format=mock_boto.s3.connection.OrdinaryCallingFormat())
         mock_boto.connect_s3().lookup.return_value = True
         mock_boto.connect_s3().get_bucket.assert_called_with("mybucket")


### PR DESCRIPTION
As a workaround to #122 one could assume the role outside `smart_open` such as:
```
client = session.create_client('sts')
response = client.assume_role(RoleArn='arn:aws:iam::EXAMPLE:/role/EXAMPLE',
    RoleSessionName='EXAMPLE',
    SerialNumber='arn:aws:iam::EXAMPLE:mfa/EXAMPLE',
    TokenCode='633369')
access_key, security_key, token = response['Credentials']['AccessKeyId'], response['Credentials']['SecretAccessKey'], response['Credentials']['SessionToken']
```
and then provide the credentials in the uri to smart_open as `s3://access_key:secure_key:token@bucket/object`. This PR adds support for the optional `token` in the URI.