### PR TITLE
Resolve Issue #145, add warnings for Issue #146

### DIFF
--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -28,6 +28,7 @@ import subprocess
 import sys
 import requests
 import io
+import warnings
 
 from boto.compat import BytesIO, urlsplit, six
 import boto.s3.connection
@@ -167,6 +168,8 @@ def smart_open(uri, mode="rb", **kw):
         elif parsed_uri.scheme in ("s3", "s3n", 's3u'):
             return s3_open_uri(parsed_uri, mode, **kw)
         elif parsed_uri.scheme in ("hdfs", ):
+            if kw.get('encoding') is not None:
+                warnings.warn('Issue #146: encoding is not supported for HDFS, ignoring')
             if mode in ('r', 'rb'):
                 return HdfsOpenRead(parsed_uri, **kw)
             if mode in ('w', 'wb'):
@@ -174,6 +177,8 @@ def smart_open(uri, mode="rb", **kw):
             else:
                 raise NotImplementedError("file mode %s not supported for %r scheme", mode, parsed_uri.scheme)
         elif parsed_uri.scheme in ("webhdfs", ):
+            if kw.get('encoding') is not None:
+                warnings.warn('Issue #146: encoding is not supported for WebHDFS, ignoring')
             if mode in ('r', 'rb'):
                 return WebHdfsOpenRead(parsed_uri, **kw)
             elif mode in ('w', 'wb'):
@@ -181,6 +186,8 @@ def smart_open(uri, mode="rb", **kw):
             else:
                 raise NotImplementedError("file mode %s not supported for %r scheme", mode, parsed_uri.scheme)
         elif parsed_uri.scheme.startswith('http'):
+            if kw.get('encoding') is not None:
+                warnings.warn('Issue #146: encoding is not supported for HTTP, ignoring')
             if mode in ('r', 'rb'):
                 return HttpOpenRead(parsed_uri, **kw)
             else:

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -174,7 +174,7 @@ def smart_open(uri, mode="rb", **kw):
         elif parsed_uri.scheme in ("s3", "s3n", 's3u'):
             return s3_open_uri(parsed_uri, mode, **kw)
         elif parsed_uri.scheme in ("hdfs", ):
-            encoding = kw.pop('encoding')
+            encoding = kw.pop('encoding', None)
             if encoding is not None:
                 warnings.warn(_ISSUE_146_FSTR % {'encoding': encoding, 'scheme': parsed_uri.scheme})
             if mode in ('r', 'rb'):
@@ -184,7 +184,7 @@ def smart_open(uri, mode="rb", **kw):
             else:
                 raise NotImplementedError("file mode %s not supported for %r scheme", mode, parsed_uri.scheme)
         elif parsed_uri.scheme in ("webhdfs", ):
-            encoding = kw.pop('encoding')
+            encoding = kw.pop('encoding', None)
             if encoding is not None:
                 warnings.warn(_ISSUE_146_FSTR % {'encoding': encoding, 'scheme': parsed_uri.scheme})
             if mode in ('r', 'rb'):
@@ -194,7 +194,7 @@ def smart_open(uri, mode="rb", **kw):
             else:
                 raise NotImplementedError("file mode %s not supported for %r scheme", mode, parsed_uri.scheme)
         elif parsed_uri.scheme.startswith('http'):
-            encoding = kw.pop('encoding')
+            encoding = kw.pop('encoding', None)
             if encoding is not None:
                 warnings.warn(_ISSUE_146_FSTR % {'encoding': encoding, 'scheme': parsed_uri.scheme})
             if mode in ('r', 'rb'):

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -140,10 +140,20 @@ def smart_open(uri, mode="rb", **kw):
     """
     logger.debug('%r', locals())
 
+    #
+    # This is a work-around for the problem described in Issue #144.
+    # If the user has explicitly specified an encoding, then assume they want
+    # us to open the destination in text mode, instead of the default binary.
+    #
+    # If we change the default mode to be text, and match the normal behavior
+    # of Py2 and 3, then the above assumption will be unnecessary.
+    #
+    if kw.get('encoding') is not None and 'b' in mode:
+        mode = mode.replace('b', '')
+
     # validate mode parameter
     if not isinstance(mode, six.string_types):
         raise TypeError('mode should be a string')
-
 
     if isinstance(uri, six.string_types):
         # this method just routes the request to classes handling the specific storage

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -77,6 +77,12 @@ WEBHDFS_MIN_PART_SIZE = 50 * 1024**2  # minimum part size for HDFS multipart upl
 
 SYSTEM_ENCODING = sys.getdefaultencoding()
 
+_ISSUE_146_FSTR = (
+    "You have explicitly specified encoding=%(encoding)s, but smart_open does "
+    "not currently support decoding text via the %(scheme)s scheme. "
+    "Re-open the file without specifying an encoding to suppress this warning."
+)
+
 
 def smart_open(uri, mode="rb", **kw):
     """
@@ -168,8 +174,9 @@ def smart_open(uri, mode="rb", **kw):
         elif parsed_uri.scheme in ("s3", "s3n", 's3u'):
             return s3_open_uri(parsed_uri, mode, **kw)
         elif parsed_uri.scheme in ("hdfs", ):
-            if kw.get('encoding') is not None:
-                warnings.warn('Issue #146: encoding is not supported for HDFS, ignoring')
+            encoding = kw.pop('encoding')
+            if encoding is not None:
+                warnings.warn(_ISSUE_146_FSTR % {'encoding': encoding, 'scheme': parsed_uri.scheme})
             if mode in ('r', 'rb'):
                 return HdfsOpenRead(parsed_uri, **kw)
             if mode in ('w', 'wb'):
@@ -177,8 +184,9 @@ def smart_open(uri, mode="rb", **kw):
             else:
                 raise NotImplementedError("file mode %s not supported for %r scheme", mode, parsed_uri.scheme)
         elif parsed_uri.scheme in ("webhdfs", ):
-            if kw.get('encoding') is not None:
-                warnings.warn('Issue #146: encoding is not supported for WebHDFS, ignoring')
+            encoding = kw.pop('encoding')
+            if encoding is not None:
+                warnings.warn(_ISSUE_146_FSTR % {'encoding': encoding, 'scheme': parsed_uri.scheme})
             if mode in ('r', 'rb'):
                 return WebHdfsOpenRead(parsed_uri, **kw)
             elif mode in ('w', 'wb'):
@@ -186,8 +194,9 @@ def smart_open(uri, mode="rb", **kw):
             else:
                 raise NotImplementedError("file mode %s not supported for %r scheme", mode, parsed_uri.scheme)
         elif parsed_uri.scheme.startswith('http'):
-            if kw.get('encoding') is not None:
-                warnings.warn('Issue #146: encoding is not supported for HTTP, ignoring')
+            encoding = kw.pop('encoding')
+            if encoding is not None:
+                warnings.warn(_ISSUE_146_FSTR % {'encoding': encoding, 'scheme': parsed_uri.scheme})
             if mode in ('r', 'rb'):
                 return HttpOpenRead(parsed_uri, **kw)
             else:

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1015,6 +1015,46 @@ class S3OpenTest(unittest.TestCase):
             smart_open.s3_open_uri(uri, "r")
             mock_open.assert_called_with('bucket', 'key.gz', 'rb')
 
+    @mock_s3
+    def test_read_encoding(self):
+        """Should open the file with the correct encoding, explicit text read."""
+        conn = boto.connect_s3()
+        conn.create_bucket('test-bucket')
+        key = "s3://bucket/key.txt"
+        text = u'это знала ева, это знал адам, колеса любви едут прямо по нам'
+        with smart_open.smart_open(key, 'wb') as fout:
+            fout.write(text.encode('koi8-r'))
+        with smart_open.smart_open(key, 'r', encoding='koi8-r') as fin:
+            actual = fin.read()
+        self.assertEqual(text, actual)
+
+    @mock_s3
+    def test_read_encoding_implicit_text(self):
+        """Should open the file with the correct encoding, implicit text read."""
+        conn = boto.connect_s3()
+        conn.create_bucket('test-bucket')
+        key = "s3://bucket/key.txt"
+        text = u'это знала ева, это знал адам, колеса любви едут прямо по нам'
+        with smart_open.smart_open(key, 'wb') as fout:
+            fout.write(text.encode('koi8-r'))
+        with smart_open.smart_open(key, encoding='koi8-r') as fin:
+            actual = fin.read()
+        self.assertEqual(text, actual)
+
+    @mock_s3
+    def test_write_encoding(self):
+        """Should open the file for writing with the correct encoding."""
+        conn = boto.connect_s3()
+        conn.create_bucket('test-bucket')
+        key = "s3://bucket/key.txt"
+        text = u'какая боль, какая боль, аргентина - ямайка, 5-0'
+
+        with smart_open.smart_open(key, 'w', encoding='koi8-r') as fout:
+            fout.write(text)
+        with smart_open.smart_open(key, encoding='koi8-r') as fin:
+            actual = fin.read()
+        self.assertEqual(text, actual)
+
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -333,6 +333,17 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object.__iter__()
         mock_subprocess.Popen.assert_called_with(["hdfs", "dfs", "-text", "/tmp/test.txt"], stdout=mock_subprocess.PIPE)
 
+    @mock.patch('smart_open.smart_open_lib.subprocess')
+    def test_hdfs_encoding(self, mock_subprocess):
+        """Is HDFS line iterator called correctly?"""
+        mock_subprocess.PIPE.return_value = "test"
+        with mock.patch('warnings.warn') as warn:
+            smart_open.smart_open("hdfs:///tmp/test.txt", encoding='utf-8')
+            expected = smart_open.smart_open_lib._ISSUE_146_FSTR % {
+                'encoding': 'utf-8', 'scheme': 'hdfs'
+            }
+            warn.assert_called_with(expected)
+
     @responses.activate
     def test_webhdfs(self):
         """Is webhdfs line iterator called correctly"""
@@ -341,6 +352,18 @@ class SmartOpenReadTest(unittest.TestCase):
         iterator = iter(smart_open_object)
         self.assertEqual(next(iterator).decode("utf-8"), "line1")
         self.assertEqual(next(iterator).decode("utf-8"), "line2")
+
+    @mock.patch('smart_open.smart_open_lib.subprocess')
+    def test_webhdfs_encoding(self, mock_subprocess):
+        """Is HDFS line iterator called correctly?"""
+        url = "webhdfs://127.0.0.1:8440/path/file"
+        mock_subprocess.PIPE.return_value = "test"
+        with mock.patch('warnings.warn') as warn:
+            smart_open.smart_open(url, encoding='utf-8')
+            expected = smart_open.smart_open_lib._ISSUE_146_FSTR % {
+                'encoding': 'utf-8', 'scheme': 'webhdfs'
+            }
+            warn.assert_called_with(expected)
 
     @responses.activate
     def test_webhdfs_read(self):


### PR DESCRIPTION
Issue 145: Added tests for reading and writing encoded text files on S3. Originally planned to add the same tests for the other subsystems (HDFS, WebHDFS, HTTP), but discovered that encoding is not handled at all there (it is ignored).

Issue 146: added warnings for cases where the encoding is specified and quietly ignored.