### PR TITLE
Fix issues #152, #153 and #154

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,47 @@
+This directory contains integration tests for smart_open.
+To run the tests, you need read/write access to an S3 bucket.
+Also, you need to install py.test and its benchmarks addon:
+
+    pip install pytest pytest_benchmark
+
+Then, to run the tests, run:
+
+    SMART_OPEN_S3_URL=s3://bucket/smart_open_test py.test integration-tests/test_s3.py
+
+You may use any key name instead of "smart_open_test".
+It does not have to be an existing key.
+**The tests will remove the key prior to each test, so be sure the key doesn't contain anything important.**
+
+The tests will take several minutes to complete.
+Each test will run several times to obtain summary statistics such as min, max, mean and median.
+This allows us to detect regressions in performance.
+Here is some example output (you need a wide screen to get the best of it):
+
+```
+(smartopen)sergeyich:smart_open misha$ SMART_OPEN_S3_URL=s3://bucket/smart_open_test py.test integration-tests/test_s3.py
+=============================================== test session starts ================================================
+platform darwin -- Python 3.6.3, pytest-3.3.0, py-1.5.2, pluggy-0.6.0
+benchmark: 3.1.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
+rootdir: /Users/misha/git/smart_open, inifile:
+plugins: benchmark-3.1.1
+collected 6 items
+
+integration-tests/test_s3.py ......                                                                          [100%]
+
+
+--------------------------------------------------------------------------------------- benchmark: 6 tests --------------------------------------------------------------------------------------
+Name (time in s)                     Min                Max               Mean             StdDev             Median                IQR            Outliers     OPS            Rounds  Iterations
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+test_s3_readwrite_text            2.7593 (1.0)       3.4935 (1.0)       3.2203 (1.0)       0.3064 (1.0)       3.3202 (1.04)      0.4730 (1.0)           1;0  0.3105 (1.0)           5           1
+test_s3_readwrite_text_gzip       3.0242 (1.10)      4.6782 (1.34)      3.7079 (1.15)      0.8531 (2.78)      3.2001 (1.0)       1.5850 (3.35)          2;0  0.2697 (0.87)          5           1
+test_s3_readwrite_binary          3.0549 (1.11)      3.9062 (1.12)      3.5399 (1.10)      0.3516 (1.15)      3.4721 (1.09)      0.5532 (1.17)          2;0  0.2825 (0.91)          5           1
+test_s3_performance_gz            3.1885 (1.16)      5.2845 (1.51)      3.9298 (1.22)      0.8197 (2.68)      3.6974 (1.16)      0.9693 (2.05)          1;0  0.2545 (0.82)          5           1
+test_s3_readwrite_binary_gzip     3.3756 (1.22)      5.0423 (1.44)      4.1763 (1.30)      0.6381 (2.08)      4.0722 (1.27)      0.9209 (1.95)          2;0  0.2394 (0.77)          5           1
+test_s3_performance               7.6758 (2.78)     29.5266 (8.45)     18.8346 (5.85)     10.3003 (33.62)    21.1854 (6.62)     19.6234 (41.49)         3;0  0.0531 (0.17)          5           1
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+Legend:
+  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
+  OPS: Operations Per Second, computed as 1 / Mean
+============================================ 6 passed in 285.14 seconds ============================================
+```

--- a/integration-tests/test_s3.py
+++ b/integration-tests/test_s3.py
@@ -1,0 +1,83 @@
+from __future__ import unicode_literals
+import io
+import os
+import subprocess
+
+import smart_open
+
+_S3_URL = os.environ.get('SMART_OPEN_S3_URL')
+assert _S3_URL is not None, 'please set the SMART_OPEN_S3_URL environment variable'
+
+
+def initialize_bucket():
+    subprocess.check_call(['aws', 's3', 'rm', '--recursive', _S3_URL])
+
+
+def write_read(key, content, write_mode, read_mode):
+    with smart_open.smart_open(key, write_mode) as fout:
+        fout.write(content)
+    with smart_open.smart_open(key, read_mode) as fin:
+        actual = fin.read()
+    return actual
+
+
+def test_s3_readwrite_text(benchmark):
+    initialize_bucket()
+
+    key = _S3_URL + '/sanity.txt'
+    text = 'с гранатою в кармане, с чекою в руке'
+    actual = benchmark(write_read, key, text, 'w', 'r')
+    assert actual == text
+
+
+def test_s3_readwrite_text_gzip(benchmark):
+    initialize_bucket()
+
+    key = _S3_URL + '/sanity.txt.gz'
+    text = 'не чайки здесь запели на знакомом языке'
+    actual = benchmark(write_read, key, text, 'w', 'r')
+    assert actual == text
+
+
+def test_s3_readwrite_binary(benchmark):
+    initialize_bucket()
+
+    key = _S3_URL + '/sanity.txt'
+    binary = b'this is a test'
+    actual = benchmark(write_read, key, binary, 'wb', 'rb')
+    assert actual == binary
+
+
+def test_s3_readwrite_binary_gzip(benchmark):
+    initialize_bucket()
+
+    key = _S3_URL + '/sanity.txt.gz'
+    binary = b'this is a test'
+    actual = benchmark(write_read, key, binary, 'wb', 'rb')
+    assert actual == binary
+
+
+def test_s3_performance(benchmark):
+    initialize_bucket()
+
+    one_megabyte = io.BytesIO()
+    for _ in range(1024*128):
+        one_megabyte.write(b'01234567')
+    one_megabyte = one_megabyte.getvalue()
+
+    key = _S3_URL + '/performance.txt'
+    actual = benchmark(write_read, key, one_megabyte, 'wb', 'rb')
+    assert actual == one_megabyte
+
+
+def test_s3_performance_gz(benchmark):
+    initialize_bucket()
+
+    one_megabyte = io.BytesIO()
+    for _ in range(1024*128):
+        one_megabyte.write(b'01234567')
+    one_megabyte = one_megabyte.getvalue()
+
+    key = _S3_URL + '/performance.txt.gz'
+    actual = benchmark(write_read, key, one_megabyte, 'wb', 'rb')
+    assert actual == one_megabyte

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -29,7 +29,6 @@ MODES = (READ, READ_BINARY, WRITE, WRITE_BINARY)
 """Allowed I/O modes for working with S3."""
 
 BINARY_NEWLINE = b'\n'
-TEXT_NEWLINE = b'\n'
 DEFAULT_BUFFER_SIZE = 256 * 1024
 
 

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -58,7 +58,7 @@ def open(bucket_id, key_id, mode, **kwargs):
     s3_min_part_size = kwargs.pop("s3_min_part_size", DEFAULT_MIN_PART_SIZE)
 
     if mode in (READ, READ_BINARY):
-        fileobj = BufferedInputBase(bucket_id, key_id, **kwargs)
+        fileobj = SeekableBufferedInputBase(bucket_id, key_id, **kwargs)
     elif mode in (WRITE, WRITE_BINARY):
         fileobj = BufferedOutputBase(bucket_id, key_id, min_part_size=s3_min_part_size, **kwargs)
     else:

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Implements file-like objects for reading and writing from/to S3."""
 import boto3
+import botocore.client
 
 import io
 import logging
@@ -283,7 +284,10 @@ multipart upload may fail")
         #
         # https://stackoverflow.com/questions/26871884/how-can-i-easily-determine-if-a-boto-3-s3-bucket-resource-exists
         #
-        s3.create_bucket(Bucket=bucket)
+        try:
+            s3.meta.client.head_bucket(Bucket=bucket)
+        except botocore.client.ClientError:
+            raise ValueError('the bucket %r does not exist, or is forbidden for access' % bucket)
         self._object = s3.Object(bucket, key)
         self._min_part_size = min_part_size
         self._mp = self._object.initiate_multipart_upload()

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -41,7 +41,6 @@ IS_PY2 = (sys.version_info[0] == 2)
 
 if IS_PY2:
     import cStringIO as StringIO
-import contextlib
 
 if sys.version_info[0] == 2:
     import httplib
@@ -304,7 +303,7 @@ def _detect_codec(filename):
 
 
 def _wrap_gzip(fileobj, mode):
-    return contextlib.closing(gzip.GzipFile(fileobj=fileobj, mode=mode))
+    return gzip.GzipFile(fileobj=fileobj, mode=mode)
 
 
 def _wrap_none(fileobj, mode):

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import contextlib
 import logging
 import gzip
 import io
@@ -131,7 +130,7 @@ class BufferedInputBaseTest(unittest.TestCase):
         expected = u'раcцветали яблони и груши, поплыли туманы над рекой...'.encode('utf-8')
         buf = io.BytesIO()
         buf.close = lambda: None  # keep buffer open so that we can .getvalue()
-        with contextlib.closing(gzip.GzipFile(fileobj=buf, mode='w')) as zipfile:
+        with gzip.GzipFile(fileobj=buf, mode='w') as zipfile:
             zipfile.write(expected)
         create_bucket_and_key(contents=buf.getvalue())
 
@@ -145,12 +144,12 @@ class BufferedInputBaseTest(unittest.TestCase):
         # Make sure the buffer we wrote is legitimate gzip.
         #
         sanity_buf = io.BytesIO(buf.getvalue())
-        with contextlib.closing(gzip.GzipFile(fileobj=sanity_buf)) as zipfile:
+        with gzip.GzipFile(fileobj=sanity_buf) as zipfile:
             self.assertEqual(zipfile.read(), expected)
 
         _LOGGER.debug('starting actual test')
         with smart_open.s3.BufferedInputBase('mybucket', 'mykey') as fin:
-            with contextlib.closing(gzip.GzipFile(fileobj=fin)) as zipfile:
+            with gzip.GzipFile(fileobj=fin) as zipfile:
                 actual = zipfile.read()
 
         self.assertEqual(expected, actual)
@@ -261,11 +260,11 @@ class BufferedOutputBaseTest(unittest.TestCase):
 
         expected = u'а не спеть ли мне песню... о любви'.encode('utf-8')
         with smart_open.s3.BufferedOutputBase('mybucket', 'writekey') as fout:
-            with contextlib.closing(gzip.GzipFile(fileobj=fout, mode='w')) as zipfile:
+            with gzip.GzipFile(fileobj=fout, mode='w') as zipfile:
                 zipfile.write(expected)
 
         with smart_open.s3.BufferedInputBase('mybucket', 'writekey') as fin:
-            with contextlib.closing(gzip.GzipFile(fileobj=fin)) as zipfile:
+            with gzip.GzipFile(fileobj=fin) as zipfile:
                 actual = zipfile.read()
 
         self.assertEqual(expected, actual)

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -284,6 +284,12 @@ class BufferedOutputBaseTest(unittest.TestCase):
             actual = [line.rstrip() for line in fin]
         self.assertEqual(expected, actual)
 
+    def test_nonexisting_bucket(self):
+        expected = u"выйду ночью в поле с конём".encode('utf-8')
+        with self.assertRaises(ValueError):
+            with smart_open.s3.open('thisbucketdoesntexist', 'mykey', 'wb') as fout:
+                fout.write(expected)
+
 
 class ClampTest(unittest.TestCase):
     def test(self):

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -29,7 +29,7 @@ def create_bucket_and_key(bucket_name='mybucket', key_name='mykey', contents=Non
 
 
 @moto.mock_s3
-class BufferedInputBaseTest(unittest.TestCase):
+class SeekableBufferedInputBaseTest(unittest.TestCase):
     def setUp(self):
         # lower the multipart upload size, to speed up these tests
         self.old_min_part_size = smart_open.s3.DEFAULT_MIN_PART_SIZE
@@ -45,7 +45,7 @@ class BufferedInputBaseTest(unittest.TestCase):
         create_bucket_and_key(contents=expected)
 
         # connect to fake s3 and read from the fake key we filled above
-        fin = smart_open.s3.BufferedInputBase('mybucket', 'mykey')
+        fin = smart_open.s3.SeekableBufferedInputBase('mybucket', 'mykey')
         output = [line.rstrip(b'\n') for line in fin]
         self.assertEqual(output, expected.split(b'\n'))
 
@@ -53,7 +53,7 @@ class BufferedInputBaseTest(unittest.TestCase):
         # same thing but using a context manager
         expected = u"hello wořld\nhow are you?".encode('utf8')
         create_bucket_and_key(contents=expected)
-        with smart_open.s3.BufferedInputBase('mybucket', 'mykey') as fin:
+        with smart_open.s3.SeekableBufferedInputBase('mybucket', 'mykey') as fin:
             output = [line.rstrip(b'\n') for line in fin]
             self.assertEqual(output, expected.split(b'\n'))
 
@@ -63,7 +63,7 @@ class BufferedInputBaseTest(unittest.TestCase):
         create_bucket_and_key(contents=content)
         _LOGGER.debug('content: %r len: %r', content, len(content))
 
-        fin = smart_open.s3.BufferedInputBase('mybucket', 'mykey')
+        fin = smart_open.s3.SeekableBufferedInputBase('mybucket', 'mykey')
         self.assertEqual(content[:6], fin.read(6))
         self.assertEqual(content[6:14], fin.read(8))  # ř is 2 bytes
         self.assertEqual(content[14:], fin.read())  # read the rest
@@ -137,7 +137,7 @@ class BufferedInputBaseTest(unittest.TestCase):
         #
         # Make sure we're reading things correctly.
         #
-        with smart_open.s3.BufferedInputBase('mybucket', 'mykey') as fin:
+        with smart_open.s3.SeekableBufferedInputBase('mybucket', 'mykey') as fin:
             self.assertEqual(fin.read(), buf.getvalue())
 
         #
@@ -148,7 +148,7 @@ class BufferedInputBaseTest(unittest.TestCase):
             self.assertEqual(zipfile.read(), expected)
 
         _LOGGER.debug('starting actual test')
-        with smart_open.s3.BufferedInputBase('mybucket', 'mykey') as fin:
+        with smart_open.s3.SeekableBufferedInputBase('mybucket', 'mykey') as fin:
             with gzip.GzipFile(fileobj=fin) as zipfile:
                 actual = zipfile.read()
 
@@ -263,7 +263,7 @@ class BufferedOutputBaseTest(unittest.TestCase):
             with gzip.GzipFile(fileobj=fout, mode='w') as zipfile:
                 zipfile.write(expected)
 
-        with smart_open.s3.BufferedInputBase('mybucket', 'writekey') as fin:
+        with smart_open.s3.SeekableBufferedInputBase('mybucket', 'writekey') as fin:
             with gzip.GzipFile(fileobj=fin) as zipfile:
                 actual = zipfile.read()
 

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -73,7 +73,7 @@ class BufferedInputBaseTest(unittest.TestCase):
         content = u"hello wořld\nhow are you?".encode('utf8')
         create_bucket_and_key(contents=content)
 
-        fin = smart_open.s3.BufferedInputBase('mybucket', 'mykey')
+        fin = smart_open.s3.SeekableBufferedInputBase('mybucket', 'mykey')
         self.assertEqual(content[:6], fin.read(6))
         self.assertEqual(content[6:14], fin.read(8))  # ř is 2 bytes
 
@@ -88,7 +88,7 @@ class BufferedInputBaseTest(unittest.TestCase):
         content = u"hello wořld\nhow are you?".encode('utf8')
         create_bucket_and_key(contents=content)
 
-        fin = smart_open.s3.BufferedInputBase('mybucket', 'mykey')
+        fin = smart_open.s3.SeekableBufferedInputBase('mybucket', 'mykey')
         seek = fin.seek(6)
         self.assertEqual(seek, 6)
         self.assertEqual(fin.tell(), 6)
@@ -99,7 +99,7 @@ class BufferedInputBaseTest(unittest.TestCase):
         content = u"hello wořld\nhow are you?".encode('utf8')
         create_bucket_and_key(contents=content)
 
-        fin = smart_open.s3.BufferedInputBase('mybucket', 'mykey')
+        fin = smart_open.s3.SeekableBufferedInputBase('mybucket', 'mykey')
         self.assertEqual(fin.read(5), b'hello')
         seek = fin.seek(1, whence=smart_open.s3.CURRENT)
         self.assertEqual(seek, 6)
@@ -110,7 +110,7 @@ class BufferedInputBaseTest(unittest.TestCase):
         content = u"hello wořld\nhow are you?".encode('utf8')
         create_bucket_and_key(contents=content)
 
-        fin = smart_open.s3.BufferedInputBase('mybucket', 'mykey')
+        fin = smart_open.s3.SeekableBufferedInputBase('mybucket', 'mykey')
         seek = fin.seek(-4, whence=smart_open.s3.END)
         self.assertEqual(seek, len(content) - 4)
         self.assertEqual(fin.read(), b'you?')
@@ -119,7 +119,7 @@ class BufferedInputBaseTest(unittest.TestCase):
         content = u"hello wořld\nhow are you?".encode('utf8')
         create_bucket_and_key(contents=content)
 
-        fin = smart_open.s3.BufferedInputBase('mybucket', 'mykey')
+        fin = smart_open.s3.SeekableBufferedInputBase('mybucket', 'mykey')
         fin.read()
         eof = fin.tell()
         self.assertEqual(eof, len(content))

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -155,6 +155,26 @@ class BufferedInputBaseTest(unittest.TestCase):
 
         self.assertEqual(expected, actual)
 
+    def test_readline(self):
+        content = b'englishman\nin\nnew\nyork\n'
+        create_bucket_and_key(contents=content)
+
+        with smart_open.s3.BufferedInputBase('mybucket', 'mykey') as fin:
+            actual = list(fin)
+
+        expected = [b'englishman\n', b'in\n', b'new\n', b'york\n']
+        self.assertEqual(expected, actual)
+
+    def test_readline_tiny_buffer(self):
+        content = b'englishman\nin\nnew\nyork\n'
+        create_bucket_and_key(contents=content)
+
+        with smart_open.s3.BufferedInputBase('mybucket', 'mykey', buffer_size=8) as fin:
+            actual = list(fin)
+
+        expected = [b'englishman\n', b'in\n', b'new\n', b'york\n']
+        self.assertEqual(expected, actual)
+
 
 @moto.mock_s3
 class BufferedOutputBaseTest(unittest.TestCase):

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -977,12 +977,15 @@ class S3OpenTest(unittest.TestCase):
         text = u"физкульт-привет!"
         key.set_contents_from_string(text.encode("utf-8"))
 
-        with smart_open.s3_open_key(key, "r") as fin:
-            self.assertEqual(fin.read(), u"физкульт-привет!")
+        with smart_open.s3_open_key(key, "rb") as fin:
+            self.assertEqual(fin.read(), text.encode('utf-8'))
+
+        with smart_open.s3_open_key(key, "r", encoding='utf-8') as fin:
+            self.assertEqual(fin.read(), text)
 
         parsed_uri = smart_open.ParseUri("s3://bucket/key")
-        with smart_open.s3_open_uri(parsed_uri, "r") as fin:
-            self.assertEqual(fin.read(), u"физкульт-привет!")
+        with smart_open.s3_open_uri(parsed_uri, "r", encoding='utf-8') as fin:
+            self.assertEqual(fin.read(), text)
 
     def test_bad_mode(self):
         """Bad mode should raise and exception."""

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1042,7 +1042,7 @@ class S3OpenTest(unittest.TestCase):
     def test_read_encoding(self):
         """Should open the file with the correct encoding, explicit text read."""
         conn = boto.connect_s3()
-        conn.create_bucket('test-bucket')
+        conn.create_bucket('bucket')
         key = "s3://bucket/key.txt"
         text = u'это знала ева, это знал адам, колеса любви едут прямо по нам'
         with smart_open.smart_open(key, 'wb') as fout:
@@ -1055,7 +1055,7 @@ class S3OpenTest(unittest.TestCase):
     def test_read_encoding_implicit_text(self):
         """Should open the file with the correct encoding, implicit text read."""
         conn = boto.connect_s3()
-        conn.create_bucket('test-bucket')
+        conn.create_bucket('bucket')
         key = "s3://bucket/key.txt"
         text = u'это знала ева, это знал адам, колеса любви едут прямо по нам'
         with smart_open.smart_open(key, 'wb') as fout:
@@ -1068,7 +1068,7 @@ class S3OpenTest(unittest.TestCase):
     def test_write_encoding(self):
         """Should open the file for writing with the correct encoding."""
         conn = boto.connect_s3()
-        conn.create_bucket('test-bucket')
+        conn.create_bucket('bucket')
         key = "s3://bucket/key.txt"
         text = u'какая боль, какая боль, аргентина - ямайка, 5-0'
 

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -420,6 +420,7 @@ class SmartOpenReadTest(unittest.TestCase):
 
         self.assertEqual(content[14:], smart_open_object.read())  # read the rest
 
+    @unittest.skip('seek functionality for S3 currently disabled because of Issue #152')
     @mock_s3
     def test_s3_seek_moto(self):
         """Does seeking in S3 files work correctly?"""

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -293,29 +293,29 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object = smart_open.smart_open(prefix+full_path, read_mode)
         smart_open_object.__iter__()
         # called with the correct path?
-        mock_smart_open.assert_called_with(full_path, read_mode, encoding=None)
+        mock_smart_open.assert_called_with(full_path, read_mode, encoding=None, errors='strict')
 
         full_path = '/tmp/test#hash##more.txt'
         read_mode = "rb"
         smart_open_object = smart_open.smart_open(prefix+full_path, read_mode)
         smart_open_object.__iter__()
         # called with the correct path?
-        mock_smart_open.assert_called_with(full_path, read_mode, encoding=None)
+        mock_smart_open.assert_called_with(full_path, read_mode, encoding=None, errors='strict')
 
         full_path = 'aa#aa'
         read_mode = "rb"
         smart_open_object = smart_open.smart_open(full_path, read_mode)
         smart_open_object.__iter__()
         # called with the correct path?
-        mock_smart_open.assert_called_with(full_path, read_mode, encoding=None)
+        mock_smart_open.assert_called_with(full_path, read_mode, encoding=None, errors='strict')
 
         short_path = "~/tmp/test.txt"
         full_path = os.path.expanduser(short_path)
 
-        smart_open_object = smart_open.smart_open(prefix+short_path, read_mode)
+        smart_open_object = smart_open.smart_open(prefix+short_path, read_mode, errors='strict')
         smart_open_object.__iter__()
         # called with the correct expanded path?
-        mock_smart_open.assert_called_with(full_path, read_mode, encoding=None)
+        mock_smart_open.assert_called_with(full_path, read_mode, encoding=None, errors='strict')
 
     # couldn't find any project for mocking up HDFS data
     # TODO: we want to test also a content of the files, not just fnc call params
@@ -485,15 +485,15 @@ class SmartOpenTest(unittest.TestCase):
 
         # correct read modes
         smart_open.smart_open("blah", "r")
-        mock_file.assert_called_with("blah", "r", encoding=None)
+        mock_file.assert_called_with("blah", "r", encoding=None, errors='strict')
 
         smart_open.smart_open("blah", "rb")
-        mock_file.assert_called_with("blah", "rb", encoding=None)
+        mock_file.assert_called_with("blah", "rb", encoding=None, errors='strict')
 
         short_path = "~/blah"
         full_path = os.path.expanduser(short_path)
         smart_open.smart_open(short_path, "rb")
-        mock_file.assert_called_with(full_path, "rb", encoding=None)
+        mock_file.assert_called_with(full_path, "rb", encoding=None, errors='strict')
 
         # correct write modes, incorrect scheme
         self.assertRaises(NotImplementedError, smart_open.smart_open, "hdfs:///blah.txt", "wb+")
@@ -502,16 +502,16 @@ class SmartOpenTest(unittest.TestCase):
 
         # correct write mode, correct file:// URI
         smart_open.smart_open("blah", "w")
-        mock_file.assert_called_with("blah", "w", encoding=None)
+        mock_file.assert_called_with("blah", "w", encoding=None, errors='strict')
 
         smart_open.smart_open("file:///some/file.txt", "wb")
-        mock_file.assert_called_with("/some/file.txt", "wb", encoding=None)
+        mock_file.assert_called_with("/some/file.txt", "wb", encoding=None, errors='strict')
 
         smart_open.smart_open("file:///some/file.txt", "wb+")
-        mock_file.assert_called_with("/some/file.txt", "wb+", encoding=None)
+        mock_file.assert_called_with("/some/file.txt", "wb+", encoding=None, errors='strict')
 
         smart_open.smart_open("file:///some/file.txt", "w+")
-        mock_file.assert_called_with("/some/file.txt", "w+", encoding=None)
+        mock_file.assert_called_with("/some/file.txt", "w+", encoding=None, errors='strict')
 
     @mock.patch('boto3.Session')
     def test_s3_mode_mock(self, mock_session):
@@ -594,6 +594,32 @@ class SmartOpenTest(unittest.TestCase):
         output = list(smart_open.smart_open("s3://mybucket/newkey", "rb"))
 
         self.assertEqual(output, [test_string])
+
+    @mock_s3
+    def test_write_bad_encoding_strict(self):
+        """Should abort on encoding error."""
+        text = u'欲しい気持ちが成長しすぎて'
+
+        with self.assertRaises(UnicodeEncodeError):
+            with tempfile.NamedTemporaryFile('wb', delete=True) as infile:
+                with smart_open.smart_open(infile.name, 'w', encoding='koi8-r',
+                                           errors='strict') as fout:
+                    fout.write(text)
+
+    @mock_s3
+    def test_write_bad_encoding_replace(self):
+        """Should replace characters that failed to encode."""
+        text = u'欲しい気持ちが成長しすぎて'
+        expected = u'?' * len(text)
+
+        with tempfile.NamedTemporaryFile('wb', delete=True) as infile:
+            with smart_open.smart_open(infile.name, 'w', encoding='koi8-r',
+                                       errors='replace') as fout:
+                fout.write(text)
+            with smart_open.smart_open(infile.name, 'r', encoding='koi8-r') as fin:
+                actual = fin.read()
+
+        self.assertEqual(expected, actual)
 
 
 class WebHdfsWriteTest(unittest.TestCase):
@@ -1075,6 +1101,61 @@ class S3OpenTest(unittest.TestCase):
         with smart_open.smart_open(key, 'w', encoding='koi8-r') as fout:
             fout.write(text)
         with smart_open.smart_open(key, encoding='koi8-r') as fin:
+            actual = fin.read()
+        self.assertEqual(text, actual)
+
+    @mock_s3
+    def test_write_bad_encoding_strict(self):
+        """Should open the file for writing with the correct encoding."""
+        conn = boto.connect_s3()
+        conn.create_bucket('bucket')
+        key = "s3://bucket/key.txt"
+        text = u'欲しい気持ちが成長しすぎて'
+
+        with self.assertRaises(UnicodeEncodeError):
+            with smart_open.smart_open(key, 'w', encoding='koi8-r', errors='strict') as fout:
+                fout.write(text)
+
+    @mock_s3
+    def test_write_bad_encoding_replace(self):
+        """Should open the file for writing with the correct encoding."""
+        conn = boto.connect_s3()
+        conn.create_bucket('bucket')
+        key = "s3://bucket/key.txt"
+        text = u'欲しい気持ちが成長しすぎて'
+        expected = u'?' * len(text)
+
+        with smart_open.smart_open(key, 'w', encoding='koi8-r', errors='replace') as fout:
+            fout.write(text)
+        with smart_open.smart_open(key, encoding='koi8-r') as fin:
+            actual = fin.read()
+        self.assertEqual(expected, actual)
+
+    @mock_s3
+    def test_write_text_gzip(self):
+        """Should open the file for writing with the correct encoding."""
+        conn = boto.connect_s3()
+        conn.create_bucket('bucket')
+        key = "s3://bucket/key.txt.gz"
+        text = u'какая боль, какая боль, аргентина - ямайка, 5-0'
+
+        with smart_open.smart_open(key, 'w', encoding='utf-8') as fout:
+            fout.write(text)
+        with smart_open.smart_open(key, 'r', encoding='utf-8') as fin:
+            actual = fin.read()
+        self.assertEqual(text, actual)
+
+    @mock_s3
+    def test_write_text_gzip_key(self):
+        """Should open the boto S3 key for writing with the correct encoding."""
+        conn = boto.connect_s3()
+        mybucket = conn.create_bucket('bucket')
+        mykey = boto.s3.key.Key(mybucket, 'key.txt.gz')
+        text = u'какая боль, какая боль, аргентина - ямайка, 5-0'
+
+        with smart_open.smart_open(mykey, 'w', encoding='utf-8') as fout:
+            fout.write(text)
+        with smart_open.smart_open(mykey, 'r', encoding='utf-8') as fin:
             actual = fin.read()
         self.assertEqual(text, actual)
 


### PR DESCRIPTION
We didn't have a readline in our S3 reader, and that was slowing us down.

Here is a breakdown of the contents:

- 448192e, fa7c183, f7a8c56: Address #152 by added a .readline method. Does not solve the problem entirely - the regression still exists, but it's significantly smaller than before.
- 6f8f7b8: responding to feedback
- d453af2 and 084f43e: avoid creating buckets if they do not exist (resolves #154)
- 8017985, a3f9fe1, 2188b2b: added handling for the errors keyword argument
- 6c22ed8, 3e93fb1, 14588a5: performed a refactoring for disabling seek functionality.  This improves speed under Py3, but breaks under Py2.7 because the gzip reader needs seek under that Python version. The last commit re-enables seek, but keeps the refactoring, in case we want to do more with it later.
- 2c79505 - fix #153