### PR TITLE
add support for local file ignore_extension

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,11 @@ It is well tested (using `moto <https://github.com/spulec/moto>`_), well documen
   >>> with smart_open.smart_open('/home/radim/foo.txt.bz2', 'wb') as fout:
   ...    fout.write("some content\n")
 
+  >>> # ignore_extension flag can be used for overriding compression extension:
+  >>> with smart_open.smart_open('/home/radim/rawfile.gz', ignore_extension=True) as fout:
+  ...    print 'file md5: {}'.format(hashlib.md5(fout.read()).hexdigest())
+
+
 Since going over all (or select) keys in an S3 bucket is a very common operation,
 there's also an extra method ``smart_open.s3_iter_bucket()`` that does this efficiently,
 **processing the bucket keys in parallel** (using multiprocessing):


### PR DESCRIPTION
fix for #172 , few notes:
1. Ill will add tests if all the rest looks fine
2. i used the `ClosingGzipFile` class for S3 instead of plain `GzipFile`. reviewing the python3 code for `GzipFile` it seems to not affect but its something worth reviewing to see if it affects something (it even might be better). LMK if you want me to use for S3 the plain stdlib `GzipFile` and ill change the implementation.
3. it will be nice to add `ignore_extension` to docs, to find it in the first place I dig into the source.