### PR TITLE
Fix bug with changing `f._current_pos` when call `f.readline()`

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -232,12 +232,10 @@ class BufferedInputBase(io.BufferedIOBase):
             #
             if self._line_terminator in self._buffer:
                 next_newline = self._buffer.index(self._line_terminator)
-                the_line.write(self._buffer[:next_newline + 1])
-                self._buffer = self._buffer[next_newline + 1:]
+                the_line.write(self._read_from_buffer(next_newline + 1))
                 break
             else:
-                the_line.write(self._buffer)
-                self._buffer = b''
+                the_line.write(self._read_from_buffer(len(self._buffer)))
                 self._fill_buffer(self._buffer_size)
         return the_line.getvalue()
 

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -191,8 +191,13 @@ class SeekableBufferedInputBaseTest(unittest.TestCase):
         content = b'englishman\nin\nnew\nyork\n'
         create_bucket_and_key(contents=content)
 
-        with smart_open.s3.BufferedInputBase(BUCKET_NAME, KEY_NAME) as fin:
+        with smart_open.s3.SeekableBufferedInputBase(BUCKET_NAME, KEY_NAME) as fin:
+            fin.readline()
+            self.assertEqual(fin.tell(), content.index(b'\n')+1)
+
+            fin.seek(0)
             actual = list(fin)
+            self.assertEqual(fin.tell(), len(content))
 
         expected = [b'englishman\n', b'in\n', b'new\n', b'york\n']
         self.assertEqual(expected, actual)


### PR DESCRIPTION
Use `_read_from_buffer` to set self._current_pos