### PR TITLE
Add support for any param accepted by initiate_multipart_upload()

### DIFF
--- a/integration-tests/test_s3.py
+++ b/integration-tests/test_s3.py
@@ -15,10 +15,10 @@ def initialize_bucket():
     subprocess.check_call(['aws', 's3', 'rm', '--recursive', _S3_URL])
 
 
-def write_read(key, content, write_mode, read_mode, encoding=None):
-    with smart_open.smart_open(key, write_mode, encoding=encoding) as fout:
+def write_read(key, content, write_mode, read_mode, encoding=None, **kwargs):
+    with smart_open.smart_open(key, write_mode, encoding=encoding, **kwargs) as fout:
         fout.write(content)
-    with smart_open.smart_open(key, read_mode, encoding=encoding) as fin:
+    with smart_open.smart_open(key, read_mode, encoding=encoding, **kwargs) as fin:
         actual = fin.read()
     return actual
 
@@ -83,3 +83,13 @@ def test_s3_performance_gz(benchmark):
     key = _S3_URL + '/performance.txt.gz'
     actual = benchmark(write_read, key, one_megabyte, 'wb', 'rb')
     assert actual == one_megabyte
+
+def test_s3_encrypted_file(benchmark):
+    initialize_bucket()
+
+    key = _S3_URL + '/sanity.txt'
+    text = 'с гранатою в кармане, с чекою в руке'
+    actual = benchmark(write_read, key, text, 'w', 'r', 'utf-8', ServerSideEncryption='AES256')
+    assert actual == text
+
+


### PR DESCRIPTION
Mostly wanted Server-side Encryption support but just as easy to accept any known param of `initiate_multipart_upload()`. I intentionally preserved the syntax style of `initiate_multipart_upload()` params.

```
with smart_open.smart_open('s3://mybucket/myfile', 'wb', ServerSideEncryption='AES256', Metadata={'a': '1', 'b': '2'}) as fh:
    fh.write(b'this is a test')
```