### PR TITLE
Added ability to pass ContentType and ContentEncoding to the uploading S3 object.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ target/
 # vim
 *.swp
 *.swo
+
+# Pycharm
+.idea/

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -344,6 +344,10 @@ class BufferedOutputBase(io.BufferedIOBase):
             logger.warning("S3 requires minimum part size >= 5MB; \
 multipart upload may fail")
 
+        options = {}
+        if kwargs.get('metadata', None):
+            options = kwargs.pop('metadata', None)
+
         session = boto3.Session(profile_name=kwargs.pop('profile_name', None))
         s3 = session.resource('s3', **kwargs)
 
@@ -356,7 +360,7 @@ multipart upload may fail")
             raise ValueError('the bucket %r does not exist, or is forbidden for access' % bucket)
         self._object = s3.Object(bucket, key)
         self._min_part_size = min_part_size
-        self._mp = self._object.initiate_multipart_upload()
+        self._mp = self._object.initiate_multipart_upload(**options)
 
         self._buf = io.BytesIO()
         self._total_bytes = 0

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -601,14 +601,14 @@ class SmartOpenTest(unittest.TestCase):
 
     @mock_s3
     def test_s3_metadata_write(self):
-        conn = boto.connect_s3()
-        bucket = conn.create_bucket('mybucket')
+        s3 = boto3.resource('s3')
+        s3.create_bucket(Bucket='mybucket')
         data = "test data"
         options = {'metadata': {'ContentType': 'text/plain', 'ContentEncoding': 'gzip'}}
         with smart_open.smart_open('s3://mybucket/newkey.txt.gz', 'wb', **options) as fout:
             fout.write(data)
 
-        key = bucket.get_key('newkey.txt.gz')
+        key = s3.Object('mybucket', 'newkey.txt.gz')
         self.assertEqual(key.content_type, 'text/plain')
         self.assertEqual(key.content_encoding, 'gzip')
 

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -601,15 +601,18 @@ class SmartOpenTest(unittest.TestCase):
 
     @mock_s3
     def test_s3_metadata_write(self):
+        path = os.path.join(CURR_DIR, 'test_data/crime-and-punishment.txt.gz')
+        data = ""
+        with smart_open.smart_open(path, 'rb') as fd:
+            data = fd.read()
         s3 = boto3.resource('s3')
         s3.create_bucket(Bucket='mybucket')
-        data = "test data"
         options = {'metadata': {'ContentType': 'text/plain', 'ContentEncoding': 'gzip'}}
-        with smart_open.smart_open('s3://mybucket/newkey.txt.gz', 'wb', **options) as fout:
+        with smart_open.smart_open('s3://mybucket/crime-and-punishment.txt.gz', 'wb', **options) as fout:
             fout.write(data)
 
-        key = s3.Object('mybucket', 'newkey.txt.gz')
-        self.assertEqual(key.content_type, 'text/plain')
+        key = s3.Object('mybucket', 'crime-and-punishment.txt.gz')
+        self.assertIn('text/plain', key.content_type)
         self.assertEqual(key.content_encoding, 'gzip')
 
     @mock_s3

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -600,6 +600,19 @@ class SmartOpenTest(unittest.TestCase):
         self.assertEqual(output, [test_string])
 
     @mock_s3
+    def test_s3_metadata_write(self):
+        conn = boto.connect_s3()
+        bucket = conn.create_bucket('mybucket')
+        data = "test data"
+        options = {'metadata': {'ContentType': 'text/plain', 'ContentEncoding': 'gzip'}}
+        with smart_open.smart_open('s3://mybucket/newkey.txt.gz', 'wb', **options) as fout:
+            fout.write(data)
+
+        key = bucket.get_key('newkey.txt.gz')
+        self.assertEqual(key.content_type, 'text/plain')
+        self.assertEqual(key.content_encoding, 'gzip')
+
+    @mock_s3
     def test_write_bad_encoding_strict(self):
         """Should abort on encoding error."""
         text = u'欲しい気持ちが成長しすぎて'


### PR DESCRIPTION
Usage:
```
options = {'metadata': {'ContentEncoding': 'encoding_value', 'ContentType': 'type_vaule'}}
smart_open.smart_open(url, 'wb', **options)
```