### PR TITLE
S3: Accept a custom `boto3.Session` instance (support STS AssumeRole)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,15 +96,27 @@ S3-Specific Options
 
 There are a few optional keyword arguments that are useful only for S3 access.
 
+The **host** and **profile** arguments are both passed to `boto.s3_connect()` as keyword arguments:
+
 .. code-block:: python
 
   >>> smart_open.smart_open('s3://', host='s3.amazonaws.com')
   >>> smart_open.smart_open('s3://', profile_name='my-profile')
+
+
+The **s3_session** argument allows you to provide a custom `boto3.Session` instance for connecting to S3:
+
+.. code-block:: python
+
+  >>> smart_open.smart_open('s3://', s3_session=boto3.Session())
+
+
+The **s3_upload** argument accepts a dict of any parameters accepted by `initiate_multipart_upload <https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.ObjectSummary.initiate_multipart_upload/>`_:
+
+.. code-block:: python
+
   >>> smart_open.smart_open('s3://', s3_upload={ 'ServerSideEncryption': 'AES256' })
 
-The `host` and `profile` arguments are both passed to `boto.s3_connect()` as keyword arguments.
-
-The `s3_upload` argument accepts a dict of any parameters accepted by `initiate_multipart_upload <https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.ObjectSummary.initiate_multipart_upload/>`_.
 
 The S3 reader supports gzipped content, as long as the key is obviously a gzipped file (e.g. ends with ".gz").
 

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -139,7 +139,10 @@ class SeekableRawReader(object):
 class BufferedInputBase(io.BufferedIOBase):
     def __init__(self, bucket, key, buffer_size=DEFAULT_BUFFER_SIZE,
                  line_terminator=BINARY_NEWLINE, **kwargs):
-        session = boto3.Session(profile_name=kwargs.pop('profile_name', None))
+        session = kwargs.pop(
+            'session',
+            boto3.Session(profile_name=kwargs.pop('profile_name', None))
+        )
         s3 = session.resource('s3', **kwargs)
         self._object = s3.Object(bucket, key)
         self._raw_reader = RawReader(self._object)
@@ -277,7 +280,10 @@ class SeekableBufferedInputBase(BufferedInputBase):
 
     def __init__(self, bucket, key, buffer_size=DEFAULT_BUFFER_SIZE,
                  line_terminator=BINARY_NEWLINE, **kwargs):
-        session = boto3.Session(profile_name=kwargs.pop('profile_name', None))
+        session = kwargs.pop(
+            'session',
+            boto3.Session(profile_name=kwargs.pop('profile_name', None))
+        )
         s3 = session.resource('s3', **kwargs)
         self._object = s3.Object(bucket, key)
         self._raw_reader = SeekableRawReader(self._object)
@@ -344,7 +350,10 @@ class BufferedOutputBase(io.BufferedIOBase):
             logger.warning("S3 requires minimum part size >= 5MB; \
 multipart upload may fail")
 
-        session = boto3.Session(profile_name=kwargs.pop('profile_name', None))
+        session = kwargs.pop(
+            'session',
+            boto3.Session(profile_name=kwargs.pop('profile_name', None))
+        )
         s3 = session.resource('s3', **kwargs)
 
         #

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -140,7 +140,7 @@ class BufferedInputBase(io.BufferedIOBase):
     def __init__(self, bucket, key, buffer_size=DEFAULT_BUFFER_SIZE,
                  line_terminator=BINARY_NEWLINE, **kwargs):
         session = kwargs.pop(
-            'session',
+            's3_session',
             boto3.Session(profile_name=kwargs.pop('profile_name', None))
         )
         s3 = session.resource('s3', **kwargs)
@@ -281,7 +281,7 @@ class SeekableBufferedInputBase(BufferedInputBase):
     def __init__(self, bucket, key, buffer_size=DEFAULT_BUFFER_SIZE,
                  line_terminator=BINARY_NEWLINE, **kwargs):
         session = kwargs.pop(
-            'session',
+            's3_session',
             boto3.Session(profile_name=kwargs.pop('profile_name', None))
         )
         s3 = session.resource('s3', **kwargs)
@@ -351,7 +351,7 @@ class BufferedOutputBase(io.BufferedIOBase):
 multipart upload may fail")
 
         session = kwargs.pop(
-            'session',
+            's3_session',
             boto3.Session(profile_name=kwargs.pop('profile_name', None))
         )
         s3 = session.resource('s3', **kwargs)

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -461,13 +461,14 @@ class SmartOpenReadTest(unittest.TestCase):
         self.assertEqual(content, smart_open_object.read(-1))  # same thing
 
 
-@mock.patch('boto3.Session')
 class SmartOpenS3KwargsTest(unittest.TestCase):
+    @mock.patch('boto3.Session')
     def test_no_kwargs(self, mock_session):
         smart_open.smart_open('s3://mybucket/mykey')
         mock_session.assert_called_with(profile_name=None)
         mock_session.return_value.resource.assert_called_with('s3')
 
+    @mock.patch('boto3.Session')
     def test_credentials(self, mock_session):
         smart_open.smart_open('s3://access_id:access_secret@mybucket/mykey')
         mock_session.assert_called_with(profile_name=None)
@@ -475,11 +476,13 @@ class SmartOpenS3KwargsTest(unittest.TestCase):
             's3', aws_access_key_id='access_id', aws_secret_access_key='access_secret'
         )
 
+    @mock.patch('boto3.Session')
     def test_profile(self, mock_session):
         smart_open.smart_open('s3://mybucket/mykey', profile_name='my_credentials')
         mock_session.assert_called_with(profile_name='my_credentials')
         mock_session.return_value.resource.assert_called_with('s3')
 
+    @mock.patch('boto3.Session')
     def test_host(self, mock_session):
         smart_open.smart_open("s3://access_id:access_secret@mybucket/mykey", host='aa.domain.com')
         mock_session.return_value.resource.assert_called_with(
@@ -487,6 +490,7 @@ class SmartOpenS3KwargsTest(unittest.TestCase):
             endpoint_url='http://aa.domain.com'
         )
 
+    @mock.patch('boto3.Session')
     def test_s3_upload(self, mock_session):
         smart_open.smart_open("s3://bucket/key", 'wb', s3_upload={
             'ServerSideEncryption': 'AES256',
@@ -503,6 +507,28 @@ class SmartOpenS3KwargsTest(unittest.TestCase):
             ServerSideEncryption='AES256',
             ContentType='application/json'
         )
+
+    def test_session_read_mode(self):
+        """
+        Read stream should use a custom boto3.Session
+        """
+        session = boto3.Session()
+        session.resource = mock.MagicMock()
+
+        smart_open.smart_open('s3://bucket/key', s3_session=session)
+        session.resource.assert_called_with('s3')
+
+    def test_session_write_mode(self):
+        """
+        Write stream should use a custom boto3.Session
+        """
+        session = boto3.Session()
+        session.resource = mock.MagicMock()
+
+        smart_open.smart_open('s3://bucket/key', 'wb', s3_session=session)
+        session.resource.assert_called_with('s3')
+
+
 
 
 class SmartOpenTest(unittest.TestCase):

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -529,8 +529,6 @@ class SmartOpenS3KwargsTest(unittest.TestCase):
         session.resource.assert_called_with('s3')
 
 
-
-
 class SmartOpenTest(unittest.TestCase):
     """
     Test reading and writing from/into files.


### PR DESCRIPTION
Allows for [configuring credentials in any way supported by boto3](https://boto3.readthedocs.io/en/latest/guide/configuration.html), including:

- Providing a session token (for STS assumed roles)
- Using the boto3 assume role provider

This resolves the following issues and PRs:
- #199 
- #149 
- #130