### PR TITLE
Accept `multipart_upload` parameters (supports ServerSideEncryption) for `S3`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,13 +100,13 @@ There are a few optional keyword arguments that are useful only for S3 access.
 
   >>> smart_open.smart_open('s3://', host='s3.amazonaws.com')
   >>> smart_open.smart_open('s3://', profile_name='my-profile')
-  >>> smart_open.smart_open('s3://', multipart_upload={
+  >>> smart_open.smart_open('s3://', s3_upload={
       'ServerSideEncryption': 'AES256'
   })
 
 The `host` and `profile` arguments are both passed to `boto.s3_connect()` as keyword arguments.
 
-The `multipart_upload` argument accepts a dict of any parameters accepted by `initiate_multipart_upload <https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.ObjectSummary.initiate_multipart_upload/>`_.
+The `s3_upload` argument accepts a dict of any parameters accepted by `initiate_multipart_upload <https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.ObjectSummary.initiate_multipart_upload/>`_.
 
 The S3 reader supports gzipped content, as long as the key is obviously a gzipped file (e.g. ends with ".gz").
 

--- a/README.rst
+++ b/README.rst
@@ -100,8 +100,14 @@ There are a few optional keyword arguments that are useful only for S3 access.
 
   >>> smart_open.smart_open('s3://', host='s3.amazonaws.com')
   >>> smart_open.smart_open('s3://', profile_name='my-profile')
+  >>> smart_open.smart_open('s3://', multipart_upload={
+      'ServerSideEncryption': 'AES256'
+  })
 
-These are both passed to `boto.s3_connect()` as keyword arguments.
+The `host` and `profile` arguments are both passed to `boto.s3_connect()` as keyword arguments.
+
+The `multipart_upload` argument accepts a dict of any parameters accepted by `initiate_multipart_upload <https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.ObjectSummary.initiate_multipart_upload/>`_.
+
 The S3 reader supports gzipped content, as long as the key is obviously a gzipped file (e.g. ends with ".gz").
 
 Why?

--- a/README.rst
+++ b/README.rst
@@ -100,9 +100,7 @@ There are a few optional keyword arguments that are useful only for S3 access.
 
   >>> smart_open.smart_open('s3://', host='s3.amazonaws.com')
   >>> smart_open.smart_open('s3://', profile_name='my-profile')
-  >>> smart_open.smart_open('s3://', s3_upload={
-      'ServerSideEncryption': 'AES256'
-  })
+  >>> smart_open.smart_open('s3://', s3_upload={ 'ServerSideEncryption': 'AES256' })
 
 The `host` and `profile` arguments are both passed to `boto.s3_connect()` as keyword arguments.
 

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -339,7 +339,7 @@ class BufferedOutputBase(io.BufferedIOBase):
 
     Implements the io.BufferedIOBase interface of the standard library."""
 
-    def __init__(self, bucket, key, min_part_size=DEFAULT_MIN_PART_SIZE, **kwargs):
+    def __init__(self, bucket, key, min_part_size=DEFAULT_MIN_PART_SIZE, multipart_upload=None, **kwargs):
         if min_part_size < MIN_MIN_PART_SIZE:
             logger.warning("S3 requires minimum part size >= 5MB; \
 multipart upload may fail")
@@ -356,7 +356,7 @@ multipart upload may fail")
             raise ValueError('the bucket %r does not exist, or is forbidden for access' % bucket)
         self._object = s3.Object(bucket, key)
         self._min_part_size = min_part_size
-        self._mp = self._object.initiate_multipart_upload()
+        self._mp = self._object.initiate_multipart_upload(**(multipart_upload or {}))
 
         self._buf = io.BytesIO()
         self._total_bytes = 0

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -339,7 +339,7 @@ class BufferedOutputBase(io.BufferedIOBase):
 
     Implements the io.BufferedIOBase interface of the standard library."""
 
-    def __init__(self, bucket, key, min_part_size=DEFAULT_MIN_PART_SIZE, multipart_upload=None, **kwargs):
+    def __init__(self, bucket, key, min_part_size=DEFAULT_MIN_PART_SIZE, s3_upload=None, **kwargs):
         if min_part_size < MIN_MIN_PART_SIZE:
             logger.warning("S3 requires minimum part size >= 5MB; \
 multipart upload may fail")
@@ -356,7 +356,7 @@ multipart upload may fail")
             raise ValueError('the bucket %r does not exist, or is forbidden for access' % bucket)
         self._object = s3.Object(bucket, key)
         self._min_part_size = min_part_size
-        self._mp = self._object.initiate_multipart_upload(**(multipart_upload or {}))
+        self._mp = self._object.initiate_multipart_upload(**(s3_upload or {}))
 
         self._buf = io.BytesIO()
         self._total_bytes = 0

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -488,7 +488,7 @@ class SmartOpenS3KwargsTest(unittest.TestCase):
         )
 
     def test_s3_upload(self, mock_session):
-        smart_open.smart_open("s3://bucket/key", 'wb', multipart_upload={
+        smart_open.smart_open("s3://bucket/key", 'wb', s3_upload={
             'ServerSideEncryption': 'AES256',
             'ContentType': 'application/json'
         })
@@ -631,13 +631,12 @@ class SmartOpenTest(unittest.TestCase):
         s3.create_bucket(Bucket='mybucket')
 
         # Write data, with multipart_upload options
-        multipart_upload = {
-            'ContentType': 'text/plain',
-            'ContentEncoding': 'gzip'
-        }
         write_stream = smart_open.smart_open(
             's3://mybucket/crime-and-punishment.txt.gz', 'wb',
-            multipart_upload=multipart_upload
+            s3_upload={
+                'ContentType': 'text/plain',
+                'ContentEncoding': 'gzip'
+            }
         )
         with write_stream as fout:
             fout.write(data)

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -487,6 +487,25 @@ class SmartOpenS3KwargsTest(unittest.TestCase):
             endpoint_url='http://aa.domain.com'
         )
 
+    def test_s3_upload(self, mock_session):
+        smart_open.smart_open("s3://bucket/key", 'wb', multipart_upload={
+            'ServerSideEncryption': 'AES256',
+            'ContentType': 'application/json'
+        })
+
+        # Locate the s3.Object instance (mock)
+        s3_resource = mock_session.return_value.resource.return_value
+        s3_object = s3_resource.Object.return_value
+
+        # Check that `initiate_multipart_upload` was called
+        # with the desired args
+        s3_object.initiate_multipart_upload.assert_called_with(
+            ServerSideEncryption='AES256',
+            ContentType='application/json'
+        )
+
+
+
 
 class SmartOpenTest(unittest.TestCase):
     """
@@ -598,6 +617,34 @@ class SmartOpenTest(unittest.TestCase):
         output = list(smart_open.smart_open("s3://mybucket/newkey", "rb"))
 
         self.assertEqual(output, [test_string])
+
+    @mock_s3
+    def test_s3_metadata_write(self):
+        # Read local file fixture
+        path = os.path.join(CURR_DIR, 'test_data/crime-and-punishment.txt.gz')
+        data = ""
+        with smart_open.smart_open(path, 'rb') as fd:
+            data = fd.read()
+
+        # Create a test bucket
+        s3 = boto3.resource('s3')
+        s3.create_bucket(Bucket='mybucket')
+
+        # Write data, with multipart_upload options
+        multipart_upload = {
+            'ContentType': 'text/plain',
+            'ContentEncoding': 'gzip'
+        }
+        write_stream = smart_open.smart_open(
+            's3://mybucket/crime-and-punishment.txt.gz', 'wb',
+            multipart_upload=multipart_upload
+        )
+        with write_stream as fout:
+            fout.write(data)
+
+        key = s3.Object('mybucket', 'crime-and-punishment.txt.gz')
+        self.assertIn('text/plain', key.content_type)
+        self.assertEqual(key.content_encoding, 'gzip')
 
     @mock_s3
     def test_write_bad_encoding_strict(self):

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -505,8 +505,6 @@ class SmartOpenS3KwargsTest(unittest.TestCase):
         )
 
 
-
-
 class SmartOpenTest(unittest.TestCase):
     """
     Test reading and writing from/into files.


### PR DESCRIPTION
Accept a `multipart_upload` parameter for S3 operations. Accepts the same arguments as [S3.initiate_multipart_upload](https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.ObjectSummary.initiate_multipart_upload). Allows for, among other things, using S3 server-side encryption.

eg.

```python
smart_open('s3://path/to/file', 'wb', multipart_upload={
  'ServerSideEncryption': 'AES256'
})
```