### PR TITLE
bump version to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+* 1.6.0, 25th June 2018
+
+  - Accept an `s3_session` argument, to supply a custom a `boto3.Session`
+  - Accept an `s3_upload` argument, to supply custom arguments to `S3#initiate_multipart_upload`
+
 * 1.5.7, 18th March 2018
 
   - Fix author/maintainer fields in `setup.py`, avoid bug from `setuptools==39.0.0` and add workaround for `botocore` and `python==3.3`. Fix #176 (PR [#178](https://github.com/RaRe-Technologies/smart_open/pull/178) & [#177](https://github.com/RaRe-Technologies/smart_open/pull/177), [@menshikh-iv](https://github.com/menshikh-iv) & [@baldwindc](https://github.com/baldwindc))

--- a/integration-tests/test_s3.py
+++ b/integration-tests/test_s3.py
@@ -15,8 +15,8 @@ def initialize_bucket():
     subprocess.check_call(['aws', 's3', 'rm', '--recursive', _S3_URL])
 
 
-def write_read(key, content, write_mode, read_mode, encoding=None, **kwargs):
-    with smart_open.smart_open(key, write_mode, encoding=encoding, **kwargs) as fout:
+def write_read(key, content, write_mode, read_mode, encoding=None, s3_upload=None, **kwargs):
+    with smart_open.smart_open(key, write_mode, encoding=encoding, s3_upload=s3_upload, **kwargs) as fout:
         fout.write(content)
     with smart_open.smart_open(key, read_mode, encoding=encoding, **kwargs) as fin:
         actual = fin.read()

--- a/integration-tests/test_s3.py
+++ b/integration-tests/test_s3.py
@@ -89,7 +89,7 @@ def test_s3_encrypted_file(benchmark):
 
     key = _S3_URL + '/sanity.txt'
     text = 'с гранатою в кармане, с чекою в руке'
-    actual = benchmark(write_read, key, text, 'w', 'r', 'utf-8', multipart_upload={
+    actual = benchmark(write_read, key, text, 'w', 'r', 'utf-8', s3_upload={
         'ServerSideEncryption': 'AES256'
     })
     assert actual == text

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ tests_require = [
 
 setup(
     name='smart_open',
-    version='1.5.7',
+    version='1.6.0',
     description='Utils for streaming large files (S3, HDFS, gzip, bz2...)',
     long_description=read('README.rst'),
 


### PR DESCRIPTION
Hoping we can get a new tagged version release.

----

* 1.6.0, 25th June 2018

  - Accept an `s3_session` argument, to supply a custom a `boto3.Session`
  - Accept an `s3_upload` argument, to supply custom arguments to `S3#initiate_multipart_upload`