### PR TITLE
Drop support for python `3.3 and `3.4` + workaround for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ matrix:
         - SO_S3_URL: "s3://smart-open-py27-benchmark"
         - SO_S3_RESULT_URL: "s3://smart-open-py27-benchmark-results"
 
-    - python: '3.3'
-
-    - python: '3.4'
-
     - python: '3.5'
 
     - python: '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,8 @@ matrix:
         - SO_S3_RESULT_URL: "s3://smart-open-py36-benchmark-results"
 
 install:
+  - pip install --upgrade setuptools
   - pip install .[test]
-  - pip uninstall --yes botocore boto3  # workaround for avoid very similar conflict as in https://github.com/venth/aws-adfs/issues/52
-  - pip install boto3
   - pip freeze
 
 

--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: System :: Distributed Computing',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def read(fname):
 
 tests_require = [
     'mock',
-    'moto==0.4.31',
+    'moto',
     'pathlib2',
     'responses',
 ]
@@ -49,7 +49,10 @@ setup(
         'boto >= 2.32',
         'bz2file',
         'requests',
-        'boto3'
+        # Temporary pin boto3 & botocore, because moto doesn't work with new version
+        # See https://github.com/spulec/moto/issues/1793
+        'boto3 < 1.8.0',
+        'botocore < 1.11.0'
     ],
     tests_require=tests_require,
     extras_require={


### PR DESCRIPTION
**Done:**

- Drop support for `3.3` and `3.4`
- Remove workaround for boto3 installation (no more needed)
- Pin boto3/botocore versions (by moto issue reason, see https://github.com/spulec/moto/issues/1793)

CC: @mpenkov @piskvorky 