### PR TITLE
Clean up kwargs

### DIFF
--- a/smart_open/http.py
+++ b/smart_open/http.py
@@ -16,26 +16,9 @@ the client (us) has to decompress them with the appropriate algorithm.
 
 
 class BufferedInputBase(io.BufferedIOBase):
-    """
-    Implement streamed reader from a web site.
-    Supports Kerberos and Basic HTTP authentication.
-    """
+    """Implement streamed reader from a web site."""
 
-    def __init__(self, url, mode='r', kerberos=False, user=None, password=None):
-        """
-        If Kerberos is True, will attempt to use the local Kerberos credentials.
-        Otherwise, will try to use "basic" HTTP authentication via username/password.
-
-        If none of those are set, will connect unauthenticated.
-        """
-        if kerberos:
-            import requests_kerberos
-            auth = requests_kerberos.HTTPKerberosAuth()
-        elif user is not None and password is not None:
-            auth = (user, password)
-        else:
-            auth = None
-
+    def __init__(self, url, mode='r', auth=None):
         self.response = requests.get(url, auth=auth, stream=True, headers=_HEADERS)
 
         if not self.response.ok:

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -318,10 +318,34 @@ def smarter_open(
         #
         ignore_extension=False,
         auth=None,
+        min_part_size=None,
         s3_resource=None,
         s3_multipart_upload_kwargs=None,
-        min_part_size=None,
         ):
+    """Open `uri` for reading or writing.
+
+    Accepts the same parameters as the built-in open function from Python 3,
+    and a few extra parameters that enable you to customize smart_open
+    behavior.
+
+    Behaves mostly the same as the original smart_open function, with two major
+    differences:
+
+        1. Fewer parameters
+        2. Default mode is "r" (read text)
+
+    :param bool ignore_extension: Do not infer compression type from extension.
+    :param auth: The auth object to pass to the requests library when working
+        over HTTP.  May be a tuple containing the username and password,
+        a HTTPKerberosAuth, or anything else accepted by the requests library.
+    :param boto3.s3.ServiceResource s3_resource: The resource for accessing S3.
+    :param dict s3_multipart_upload_kwargs: Additional keyword parameters to
+        pass to the initiate_multipart_upload function when writing to S3.
+    :param int min_part_size: The minimum part size to use when working
+        with chunk-based storage systems e.g. S3.
+
+    :returns: A file-like object
+    """
     logger.debug('%r', locals())
     kwargs = _capture_kwargs(**locals())
 

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -432,11 +432,17 @@ def _open_binary_stream(uri, mode, kwargs):
             # with out compressed/uncompressed estimation.
             #
             filename = P.basename(urlparse.urlparse(uri).path)
+
+            if kwargs.kerberos:
+                import requests_kerberos
+                auth = requests_kerberos.HTTPKerberosAuth()
+            elif kwargs.user is not None and kwargs.password is not None:
+                auth = (kwargs.user, kwargs.password)
+            else:
+                auth = None
+
             if mode == 'rb':
-                fobj = smart_open_http.BufferedInputBase(
-                    uri, kerberos=kwargs.kerberos,
-                    user=kwargs.user, password=kwargs.password
-                )
+                fobj = smart_open_http.BufferedInputBase(uri, auth=auth)
                 return fobj, filename
             else:
                 raise NotImplementedError(unsupported)

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -322,8 +322,17 @@ def _shortcut_open(uri, mode, kwargs):
         return None
 
     open_kwargs = {}
-    if kwargs.errors is not None:
+    if kwargs.errors is not None and 'b' not in mode:
+        #
+        # Ignore errors parameter if we're reading binary.  This logic is
+        # necessary because:
+        #
+        #   - open complains if you pass non-null errors in binary mode
+        #   - our default mode is rb (incompatible with default Python open)
+        #   - our default errors is non-null (to match default Python open)
+        #
         open_kwargs['errors'] = kwargs.errors
+
     if kwargs.encoding is not None:
         open_kwargs['encoding'] = kwargs.encoding
         mode = mode.replace('b', '')

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1029,15 +1029,14 @@ class S3OpenTest(unittest.TestCase):
         s3.create_bucket(Bucket='bucket')
         uri = smart_open_lib._parse_uri("s3://bucket/key.gz")
 
+        resource = mock.Mock()
+        session = mock.Mock(resource=mock.Mock(return_value=resource))
+
         with mock.patch('smart_open.smart_open_s3.open') as mock_open:
-            smart_open.smart_open("s3://bucket/key.gz", "wb")
+            smart_open.smart_open("s3://bucket/key.gz", "wb", s3_session=session)
             mock_open.assert_called_with(
                 'bucket', 'key.gz', 'wb',
-                aws_access_key_id=None,
-                aws_secret_access_key=None,
-                session=None,
-                profile_name=None,
-                endpoint_url=None,
+                resource=resource,
                 min_part_size=smart_open.smart_open_s3.DEFAULT_MIN_PART_SIZE,
                 multipart_upload_kwargs=None,
             )
@@ -1053,17 +1052,16 @@ class S3OpenTest(unittest.TestCase):
         with smart_open.smart_open(key, "wb") as fout:
             fout.write(text.encode("utf-8"))
 
+        resource = mock.Mock()
+        session = mock.Mock(resource=mock.Mock(return_value=resource))
+
         with mock.patch('smart_open.smart_open_s3.open') as mock_open:
-            smart_open.smart_open(key, "r")
+            smart_open.smart_open(key, "r", s3_session=session)
             mock_open.assert_called_with(
                 'bucket', 'key.gz', 'rb',
-                aws_access_key_id=None,
-                aws_secret_access_key=None,
-                session=None,
-                profile_name=None,
-                endpoint_url=None,
-                multipart_upload_kwargs=None,
+                resource=resource,
                 min_part_size=smart_open.smart_open_s3.DEFAULT_MIN_PART_SIZE,
+                multipart_upload_kwargs=None,
             )
 
     @mock_s3

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -358,21 +358,21 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object = smart_open.smart_open(prefix+full_path, read_mode)
         smart_open_object.__iter__()
         # called with the correct path?
-        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1, errors='strict')
+        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1)
 
         full_path = '/tmp/test#hash##more.txt'
         read_mode = "rb"
         smart_open_object = smart_open.smart_open(prefix+full_path, read_mode)
         smart_open_object.__iter__()
         # called with the correct path?
-        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1, errors='strict')
+        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1)
 
         full_path = 'aa#aa'
         read_mode = "rb"
         smart_open_object = smart_open.smart_open(full_path, read_mode)
         smart_open_object.__iter__()
         # called with the correct path?
-        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1, errors='strict')
+        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1)
 
     @mock.patch(_IO_OPEN if six.PY2 else _BUILTIN_OPEN)
     def test_file_errors(self, mock_smart_open):
@@ -392,7 +392,7 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object = smart_open.smart_open('/tmp/somefile', 'rb', buffering=0)
         smart_open_object.__iter__()
         # called with the correct expanded path?
-        mock_smart_open.assert_called_with('/tmp/somefile', 'rb', buffering=0, errors='strict')
+        mock_smart_open.assert_called_with('/tmp/somefile', 'rb', buffering=0)
 
     @unittest.skip('smart_open does not currently accept additional positional args')
     @mock.patch(_BUILTIN_OPEN)
@@ -400,7 +400,7 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object = smart_open.smart_open('/tmp/somefile', 'rb', 0)
         smart_open_object.__iter__()
         # called with the correct expanded path?
-        mock_smart_open.assert_called_with('/tmp/somefile', 'rb', buffering=0, errors='strict')
+        mock_smart_open.assert_called_with('/tmp/somefile', 'rb', buffering=0)
 
     # couldn't find any project for mocking up HDFS data
     # TODO: we want to test also a content of the files, not just fnc call params
@@ -626,14 +626,14 @@ class SmartOpenTest(unittest.TestCase):
         with mock.patch(_BUILTIN_OPEN, mock.Mock(return_value=self.bytesio)) as mock_open:
             with smart_open.smart_open("blah", "rb") as fin:
                 self.assertEqual(fin.read(), self.as_bytes)
-                mock_open.assert_called_with("blah", "rb", buffering=-1, errors='strict')
+                mock_open.assert_called_with("blah", "rb", buffering=-1)
 
     def test_expanded_path(self):
         short_path = "~/blah"
         full_path = os.path.expanduser(short_path)
         with mock.patch(_BUILTIN_OPEN, mock.Mock(return_value=self.stringio)) as mock_open:
             with smart_open.smart_open(short_path, "rb") as fin:
-                mock_open.assert_called_with(full_path, "rb", buffering=-1, errors='strict')
+                mock_open.assert_called_with(full_path, "rb", buffering=-1)
 
     def test_incorrect(self):
         # incorrect file mode
@@ -669,7 +669,7 @@ class SmartOpenTest(unittest.TestCase):
     def test_append_binary_absolute_path(self):
         with mock.patch(_BUILTIN_OPEN, mock.Mock(return_value=self.bytesio)) as mock_open:
             with smart_open.smart_open("/some/file.txt", "wb+") as fout:
-                mock_open.assert_called_with("/some/file.txt", "wb+", buffering=-1, errors='strict')
+                mock_open.assert_called_with("/some/file.txt", "wb+", buffering=-1)
                 fout.write(self.as_bytes)
 
     @mock.patch('boto3.Session')

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1149,22 +1149,22 @@ class S3OpenTest(unittest.TestCase):
 class ShortcutOpenTest(unittest.TestCase):
     def test_ignore_errors_when_reading_binary(self):
         kwargs = smart_open.smart_open_lib.Kwargs(
+            mode='rb',
             buffering=-1,
             encoding=None,
             errors='strict',
             ignore_extension=False,
+            newline='\n',
+            closefd=True,
+            opener=None,
             min_part_size=52428800,
-            kerberos=False, user=None,
-            password=None,
-            host=None,
-            s3_min_part_size=52428800,
-            s3_upload=None,
-            s3_session=None,
-            profile_name=None,
+            auth=(None, None),
+            s3_multipart_upload_kwargs=None,
+            s3_resource=None,
         )
 
         fpath = os.path.join(CURR_DIR, 'test_data/crime-and-punishment.txt')
-        with smart_open.smart_open_lib._shortcut_open(fpath, 'rb', kwargs) as infile:
+        with smart_open.smart_open_lib._shortcut_open(fpath, kwargs.mode, kwargs) as infile:
             data = infile.read()
         self.assertEqual(len(data), 3061)
         self.assertEqual(data[:10], b'\xd0\x92 \xd0\xbd\xd0\xb0\xd1\x87\xd0')

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1146,6 +1146,30 @@ class S3OpenTest(unittest.TestCase):
         self.assertEqual(text, actual)
 
 
+class ShortcutOpenTest(unittest.TestCase):
+    def test_ignore_errors_when_reading_binary(self):
+        kwargs = smart_open.smart_open_lib.Kwargs(
+            buffering=-1,
+            encoding=None,
+            errors='strict',
+            ignore_extension=False,
+            min_part_size=52428800,
+            kerberos=False, user=None,
+            password=None,
+            host=None,
+            s3_min_part_size=52428800,
+            s3_upload=None,
+            s3_session=None,
+            profile_name=None,
+        )
+
+        fpath = os.path.join(CURR_DIR, 'test_data/crime-and-punishment.txt')
+        with smart_open.smart_open_lib._shortcut_open(fpath, 'rb', kwargs) as infile:
+            data = infile.read()
+        self.assertEqual(len(data), 3061)
+        self.assertEqual(data[:10], b'\xd0\x92 \xd0\xbd\xd0\xb0\xd1\x87\xd0')
+
+
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)
     unittest.main()

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -242,8 +242,8 @@ class SmartOpenReadTest(unittest.TestCase):
     def test_shortcut(self):
         fpath = os.path.join(CURR_DIR, 'test_data/crime-and-punishment.txt')
         with mock.patch('smart_open.smart_open_lib.open') as mock_open:
-            smart_open.smart_open(fpath, 'r').read()
-        mock_open.assert_called_with(fpath, 'r', buffering=-1, errors='strict')
+            smart_open.smart_open(fpath, 'rb').read()
+        mock_open.assert_called_with(fpath, 'rb', buffering=-1)
 
     def test_open_with_keywords(self):
         """This test captures Issue #142."""

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -243,7 +243,7 @@ class SmartOpenReadTest(unittest.TestCase):
         fpath = os.path.join(CURR_DIR, 'test_data/crime-and-punishment.txt')
         with mock.patch('smart_open.smart_open_lib.open') as mock_open:
             smart_open.smart_open(fpath, 'r').read()
-        mock_open.assert_called_with(fpath, 'r', buffering=-1)
+        mock_open.assert_called_with(fpath, 'r', buffering=-1, errors='strict', encoding=None)
 
     def test_open_with_keywords(self):
         """This test captures Issue #142."""
@@ -358,24 +358,21 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object = smart_open.smart_open(prefix+full_path, read_mode)
         smart_open_object.__iter__()
         # called with the correct path?
-        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1)
+        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1, errors='strict', encoding=None)
 
         full_path = '/tmp/test#hash##more.txt'
         read_mode = "rb"
         smart_open_object = smart_open.smart_open(prefix+full_path, read_mode)
         smart_open_object.__iter__()
         # called with the correct path?
-        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1)
+        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1, errors='strict', encoding=None)
 
         full_path = 'aa#aa'
         read_mode = "rb"
         smart_open_object = smart_open.smart_open(full_path, read_mode)
         smart_open_object.__iter__()
         # called with the correct path?
-        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1)
-
-        short_path = "~/tmp/test.txt"
-        full_path = os.path.expanduser(short_path)
+        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1, errors='strict', encoding=None)
 
     @mock.patch(_IO_OPEN if six.PY2 else _BUILTIN_OPEN)
     def test_file_errors(self, mock_smart_open):
@@ -395,7 +392,7 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object = smart_open.smart_open('/tmp/somefile', 'rb', buffering=0)
         smart_open_object.__iter__()
         # called with the correct expanded path?
-        mock_smart_open.assert_called_with('/tmp/somefile', 'rb', buffering=0)
+        mock_smart_open.assert_called_with('/tmp/somefile', 'rb', buffering=0, errors='strict', encoding=None)
 
     @unittest.skip('smart_open does not currently accept additional positional args')
     @mock.patch(_BUILTIN_OPEN)
@@ -403,7 +400,7 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object = smart_open.smart_open('/tmp/somefile', 'rb', 0)
         smart_open_object.__iter__()
         # called with the correct expanded path?
-        mock_smart_open.assert_called_with('/tmp/somefile', 'rb', buffering=0)
+        mock_smart_open.assert_called_with('/tmp/somefile', 'rb', buffering=0, errors='strict', encoding=None)
 
     # couldn't find any project for mocking up HDFS data
     # TODO: we want to test also a content of the files, not just fnc call params
@@ -526,29 +523,36 @@ class SmartOpenS3KwargsTest(unittest.TestCase):
     @mock.patch('boto3.Session')
     def test_no_kwargs(self, mock_session):
         smart_open.smart_open('s3://mybucket/mykey')
-        mock_session.assert_called_with(profile_name=None)
-        mock_session.return_value.resource.assert_called_with('s3')
+        mock_session.assert_called_with(
+            profile_name=None, aws_access_key_id=None, aws_secret_access_key=None
+        )
+        mock_session.return_value.resource.assert_called_with('s3', endpoint_url=None)
 
     @mock.patch('boto3.Session')
     def test_credentials(self, mock_session):
         smart_open.smart_open('s3://access_id:access_secret@mybucket/mykey')
-        mock_session.assert_called_with(profile_name=None)
-        mock_session.return_value.resource.assert_called_with(
-            's3', aws_access_key_id='access_id', aws_secret_access_key='access_secret'
+        mock_session.assert_called_with(
+            profile_name=None, aws_access_key_id='access_id', aws_secret_access_key='access_secret'
         )
+        mock_session.return_value.resource.assert_called_with('s3', endpoint_url=None)
 
     @mock.patch('boto3.Session')
     def test_profile(self, mock_session):
         smart_open.smart_open('s3://mybucket/mykey', profile_name='my_credentials')
-        mock_session.assert_called_with(profile_name='my_credentials')
-        mock_session.return_value.resource.assert_called_with('s3')
+        mock_session.assert_called_with(
+            profile_name='my_credentials', aws_access_key_id=None, aws_secret_access_key=None
+        )
+        mock_session.return_value.resource.assert_called_with('s3', endpoint_url=None)
 
     @mock.patch('boto3.Session')
     def test_host(self, mock_session):
         smart_open.smart_open("s3://access_id:access_secret@mybucket/mykey", host='aa.domain.com')
+        mock_session.assert_called_with(
+            aws_access_key_id='access_id', aws_secret_access_key='access_secret',
+            profile_name=None,
+        )
         mock_session.return_value.resource.assert_called_with(
-            's3', aws_access_key_id='access_id', aws_secret_access_key='access_secret',
-            endpoint_url='http://aa.domain.com'
+            's3', endpoint_url='http://aa.domain.com'
         )
 
     @mock.patch('boto3.Session')
@@ -616,20 +620,20 @@ class SmartOpenTest(unittest.TestCase):
         with mock.patch(patch, mock.Mock(return_value=self.stringio)) as mock_open:
             with smart_open.smart_open("blah", "r", encoding='utf-8') as fin:
                 self.assertEqual(fin.read(), self.as_text)
-                mock_open.assert_called_with("blah", "r", buffering=-1, encoding='utf-8')
+                mock_open.assert_called_with("blah", "r", buffering=-1, encoding='utf-8', errors='strict')
 
     def test_binary(self):
         with mock.patch(_BUILTIN_OPEN, mock.Mock(return_value=self.bytesio)) as mock_open:
             with smart_open.smart_open("blah", "rb") as fin:
                 self.assertEqual(fin.read(), self.as_bytes)
-                mock_open.assert_called_with("blah", "rb", buffering=-1)
+                mock_open.assert_called_with("blah", "rb", buffering=-1, encoding=None, errors='strict')
 
     def test_expanded_path(self):
         short_path = "~/blah"
         full_path = os.path.expanduser(short_path)
         with mock.patch(_BUILTIN_OPEN, mock.Mock(return_value=self.stringio)) as mock_open:
             with smart_open.smart_open(short_path, "rb") as fin:
-                mock_open.assert_called_with(full_path, "rb", buffering=-1)
+                mock_open.assert_called_with(full_path, "rb", buffering=-1, encoding=None, errors='strict')
 
     def test_incorrect(self):
         # incorrect file mode
@@ -645,27 +649,27 @@ class SmartOpenTest(unittest.TestCase):
         patch = _IO_OPEN if six.PY2 else _BUILTIN_OPEN
         with mock.patch(patch, mock.Mock(return_value=self.stringio)) as mock_open:
             with smart_open.smart_open("blah", "w", encoding='utf-8') as fout:
-                mock_open.assert_called_with("blah", "w", buffering=-1, encoding='utf-8')
+                mock_open.assert_called_with("blah", "w", buffering=-1, encoding='utf-8', errors='strict')
                 fout.write(self.as_text)
 
     def test_write_utf8_absolute_path(self):
         patch = _IO_OPEN if six.PY2 else _BUILTIN_OPEN
         with mock.patch(patch, mock.Mock(return_value=self.stringio)) as mock_open:
             with smart_open.smart_open("/some/file.txt", "w", encoding='utf-8') as fout:
-                mock_open.assert_called_with("/some/file.txt", "w", buffering=-1, encoding='utf-8')
+                mock_open.assert_called_with("/some/file.txt", "w", buffering=-1, encoding='utf-8', errors='strict')
                 fout.write(self.as_text)
 
     def test_append_utf8(self):
         patch = _IO_OPEN if six.PY2 else _BUILTIN_OPEN
         with mock.patch(patch, mock.Mock(return_value=self.stringio)) as mock_open:
             with smart_open.smart_open("/some/file.txt", "w+", encoding='utf-8') as fout:
-                mock_open.assert_called_with("/some/file.txt", "w+", buffering=-1, encoding='utf-8')
+                mock_open.assert_called_with("/some/file.txt", "w+", buffering=-1, encoding='utf-8', errors='strict')
                 fout.write(self.as_text)
 
     def test_append_binary_absolute_path(self):
         with mock.patch(_BUILTIN_OPEN, mock.Mock(return_value=self.bytesio)) as mock_open:
             with smart_open.smart_open("/some/file.txt", "wb+") as fout:
-                mock_open.assert_called_with("/some/file.txt", "wb+", buffering=-1)
+                mock_open.assert_called_with("/some/file.txt", "wb+", buffering=-1, encoding=None, errors='strict')
                 fout.write(self.as_bytes)
 
     @mock.patch('boto3.Session')
@@ -1027,7 +1031,11 @@ class S3OpenTest(unittest.TestCase):
 
         with mock.patch('smart_open.smart_open_s3.open') as mock_open:
             smart_open.smart_open("s3://bucket/key.gz", "wb")
-            mock_open.assert_called_with('bucket', 'key.gz', 'wb')
+            mock_open.assert_called_with(
+                'bucket', 'key.gz', 'wb',
+                aws_access_key_id=None, aws_secret_access_key=None, profile_name=None,
+                endpoint_url=None,
+            )
 
     @mock_s3
     def test_gzip_read_mode(self):
@@ -1042,7 +1050,11 @@ class S3OpenTest(unittest.TestCase):
 
         with mock.patch('smart_open.smart_open_s3.open') as mock_open:
             smart_open.smart_open(key, "r")
-            mock_open.assert_called_with('bucket', 'key.gz', 'rb')
+            mock_open.assert_called_with(
+                'bucket', 'key.gz', 'rb',
+                aws_access_key_id=None, aws_secret_access_key=None, profile_name=None,
+                endpoint_url=None,
+            )
 
     @mock_s3
     def test_read_encoding(self):


### PR DESCRIPTION
We used to liberally pass arbitrary keyword arguments (e.g. **kwargs). This is a bad practice because it's difficult to keep track of function parameters and ensure they're being passed down to the right function.

This PR starts to clean up our use of arbitrary keyword arguments.