### PR TITLE
Fix url parsing for `S3`

### DIFF
--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -84,7 +84,7 @@ DEFAULT_ERRORS = 'strict'
 
 
 Uri = collections.namedtuple(
-    'Uri', 
+    'Uri',
     (
         'scheme',
         'uri_path',
@@ -488,7 +488,7 @@ def _parse_uri_s3x(parsed_uri):
     try:
         uri = parsed_uri.netloc + parsed_uri.path
         # Separate authentication from URI if exist
-        if ':' in uri.split('@')[0]:
+        if ':' in uri.split('@')[0] and '@' in uri:
             auth, uri = uri.split('@', 1)
             access_id, access_secret = auth.split(':')
         else:

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -128,6 +128,15 @@ class ParseUriTest(unittest.TestCase):
         self.assertEqual(parsed_uri.access_id, "")
         self.assertEqual(parsed_uri.access_secret, "")
 
+    def test_s3_uri_with_colon_in_key_name(self):
+        """ Correctly parse the s3 url if there is a colon in the key or dir """
+        parsed_uri = smart_open_lib._parse_uri("s3://mybucket/mydir/my:key")
+        self.assertEqual(parsed_uri.scheme, "s3")
+        self.assertEqual(parsed_uri.bucket_id, "mybucket")
+        self.assertEqual(parsed_uri.key_id, "mydir/my:key")
+        self.assertEqual(parsed_uri.access_id, None)
+        self.assertEqual(parsed_uri.access_secret, None)
+
 
 class SmartOpenHttpTest(unittest.TestCase):
     """


### PR DESCRIPTION
Add test for colon in key name of s3 uri. Apply bug fix on line 491 of `smart_open/smart_open_lib.py`. To my knowledge, other tests are still passing and this didn't introduce any regressions.

Let me know if there's anything else to do. For now we just downgraded to 1.6.0, but hoping to see this in the next release. Thanks!