### PR TITLE
Raise `ValueError` if s3 key does not exist

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -96,7 +96,10 @@ class SeekableRawReader(object):
 
     def __init__(self, s3_object):
         self._object = s3_object
-        self._content_length = self._object.content_length
+        try:
+            self._content_length = self._object.content_length
+        except botocore.client.ClientError:
+            raise ValueError('the s3 key %r does not exist, or is forbidden for access' % s3_object.key)
         self.seek(0)
 
     def seek(self, position):

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -333,6 +333,11 @@ class BufferedOutputBaseTest(unittest.TestCase):
             with smart_open.s3.open('thisbucketdoesntexist', 'mykey', 'wb') as fout:
                 fout.write(expected)
 
+    def test_read_nonexisting_key(self):
+        with self.assertRaises(ValueError):
+            with smart_open.s3.open(BUCKET_NAME, 'my_nonexisting_key', 'rb') as fin:
+                fin.read()
+
     def test_double_close(self):
         create_bucket_and_key()
 


### PR DESCRIPTION
As mentioned on ISSUE https://github.com/RaRe-Technologies/smart_open/issues/174 `botocore.client.ClientError` is raised instead of `ValueError` on S3 keys that do not exists.

This PR fixes this inconsistency.

Fix #174 