### PR TITLE
Ensure _list_bucket uses continuation token for subsequent pages

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -536,7 +536,7 @@ def _list_bucket(bucket_name, prefix='', accept_key=lambda k: True):
 
     while True:
         # list_objects_v2 doesn't like a None value for ContinuationToken
-        # so we don't set if if we don't have one.
+        # so we don't set it if we don't have one.
         if ctoken:
             response = client.list_objects_v2(Bucket=bucket_name, Prefix=prefix, ContinuationToken=ctoken)
         else:

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -535,7 +535,12 @@ def _list_bucket(bucket_name, prefix='', accept_key=lambda k: True):
     ctoken = None
 
     while True:
-        response = client.list_objects_v2(Bucket=bucket_name, Prefix=prefix)
+        # list_objects_v2 doesn't like a None value for ContinuationToken
+        # so we don't set if if we don't have one.
+        if ctoken:
+            response = client.list_objects_v2(Bucket=bucket_name, Prefix=prefix, ContinuationToken=ctoken)
+        else:
+            response = client.list_objects_v2(Bucket=bucket_name, Prefix=prefix)
         try:
             content = response['Contents']
         except KeyError:

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -391,7 +391,6 @@ class IterBucketTest(unittest.TestCase):
         expected = ['key_%d' % x for x in range(num_keys)]
         self.assertEqual(sorted(keys), sorted(expected))
 
-    @unittest.skip('this test takes too long for some unknown reason')
     def test_list_bucket_long(self):
         num_keys = 1010
         populate_bucket(num_keys=num_keys)


### PR DESCRIPTION
When trying to `s3_iter_bucket` a large set of objects (more than 1000), we found we were given the same set of 1000 over and over again, _forever_.

The issue was that the continuation token to fetch the next page, although it was being captured, was not being given to subsequent invocations of `list_objects_v2`. This pull request makes sure that if we have a continuation token, that we use it.

Unfortunately, I have been unable to run the test suite but this change should fix the test "[test_list_bucket_long](https://github.com/RaRe-Technologies/smart_open/blob/master/smart_open/tests/test_s3.py#L394-L402)" which is currently being skipped because it was taking "too long". Probably because it would run forever.