### PR TITLE
Allow BufferedOutputBase.write to accept bytearray

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -431,7 +431,7 @@ multipart upload may fail")
 
         There's buffering happening under the covers, so this may not actually
         do any HTTP transfer right away."""
-        if not isinstance(b, six.binary_type):
+        if not isinstance(b, six.binary_type) and not isinstance(b, bytearray):
             raise TypeError("input must be a binary string, got: %r", b)
 
         self._buf.write(b)


### PR DESCRIPTION
- BufferedOutputBase.write did check for six.binary_type, but this doesn't allow for writing a perfectly acceptable bytearray.
- I've confirmed this works for my purposes, but feel free to perform more robust testing.