### PR TITLE
Drop deprecated `sudo` from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: python
-dist: trusty
-sudo: false
 
 env:
   global:
@@ -31,7 +29,6 @@ matrix:
         - SO_S3_RESULT_URL: "s3://smart-open-py37-benchmark-results"
         - BOTO_CONFIG: "/dev/null"
       dist: xenial
-      sudo: true
 
 
 install:


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).  Also, don’t hardcode __dist: trusty__ because it is currently the Travis default but that might change soon.