### PR TITLE
Handle "+", fix file objects and refactor SmartOpenHttpTest

### DIFF
--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -390,7 +390,7 @@ def _open_binary_stream(uri, mode, **kw):
         filename = getattr(uri, 'name', 'unknown')
         return uri, filename
     else:
-        raise TypeError("don't know how to handle uri %r in mode %r" % (uri, mode))
+        raise TypeError("don't know how to handle uri %r" % uri)
 
 
 def _s3_open_uri(parsed_uri, mode, **kwargs):
@@ -587,7 +587,7 @@ def _compression_wrapper(file_obj, filename, mode):
         warnings.warn('streaming gzip support unavailable, see %s' % _ISSUE_189_URL)
         file_obj = io.BytesIO(file_obj.read())
     if ext in COMPRESSED_EXT and mode.endswith('+'):
-        raise ValueError('impossible to open in read+write+compressed mode')
+        raise ValueError('transparent (de)compression unsupported for mode %r' % mode)
 
     if ext == '.bz2':
         return BZ2File(file_obj, mode)


### PR DESCRIPTION
Signed-off-by: Vadim Markovtsev <vadim@sourced.tech>

It all started with the refactoring suggestion in https://github.com/RaRe-Technologies/smart_open/pull/260#discussion_r258734796 and went a little bit too far:

- I found out that the file objects were handled loosely. We used to check only for the existence of `read()` disregarding the actual open mode. I added `_is_stream()` function and fixed that.
- Added `name` attribute check to the file objects handler. Thus it becomes possible to open a regular stream, specify `name` and read/write compressed data. This was a prerequisite for the "file-less" `SmartOpenHttpTest`-s. 

Then I started writing the tests and found a few minor bugs:

- rw modes (r+, w+, a+) were not checked in `_compression_wrapper()`. All three compression codecs do not support reading and writing at the same time.
- rw modes were not correctly handled in `_encoding_wrapper()`: only the reader's encoder was applied. I changed that to chaining reader's and writer's encoders in rw modes.