### PR TITLE
Clean up keyword arguments

### DIFF
--- a/smart_open/doctools.py
+++ b/smart_open/doctools.py
@@ -1,0 +1,114 @@
+"""Common functions for working with docstrings.
+
+For internal use only.
+"""
+import inspect
+import io
+
+
+def extract_kwargs(docstring):
+    """Extract keyword argument documentation from a function's docstring.
+
+    Parameters
+    ----------
+    docstring: str
+        The docstring to extract keyword arguments from.
+
+    Returns
+    -------
+    list of (str, str, list str)
+
+    str
+        The name of the keyword argument.
+    str
+        Its type.
+    str
+        Its documentation as a list of lines.
+
+    Notes
+    -----
+    The implementation is rather fragile.  It expects the following:
+
+    1. The parameters are under an underlined Parameters section
+    2. Keyword parameters have the literal ", optional" after the type
+    3. Names and types are not indented
+    4. Descriptions are indented with 4 spaces
+    5. The Parameters section ends with an empty line.
+
+    Examples
+    --------
+
+    >>> docstring = '''The foo function.
+    ... Parameters
+    ... ----------
+    ... bar: str, optional
+    ...     This parameter is the bar.
+    ... baz: int, optional
+    ...     This parameter is the baz.
+    ...
+    ... '''
+    >>> kwargs = extract_kwargs(docstring)
+    >>> kwargs[0]
+    ('bar', 'str, optional', ['This parameter is the bar.'])
+
+    """
+    lines = inspect.cleandoc(docstring).split('\n')
+    retval = []
+
+    #
+    # 1. Find the underlined 'Parameters' section
+    # 2. Once there, continue parsing parameters until we hit an empty line
+    #
+    while lines[0] != 'Parameters':
+        lines.pop(0)
+    lines.pop(0)
+    lines.pop(0)
+
+    while lines and lines[0]:
+        name, type_ = lines.pop(0).split(':', 1)
+        description = []
+        while lines and lines[0].startswith('    '):
+            description.append(lines.pop(0).strip())
+        if 'optional' in type_:
+            retval.append((name.strip(), type_.strip(), description))
+
+    return retval
+
+
+def to_docstring(kwargs, lpad=''):
+    """Reconstruct a docstring from keyword argument info.
+
+    Basically reverses :func:`extract_kwargs`.
+
+    Parameters
+    ----------
+    kwargs: list
+        Output from the extract_kwargs function
+    lpad: str, optional
+        Padding string (from the left).
+
+    Returns
+    -------
+    str
+        The docstring snippet documenting the keyword arguments.
+
+    Examples
+    --------
+
+    >>> kwargs = [
+    ...     ('bar', 'str, optional', ['This parameter is the bar.']),
+    ...     ('baz', 'int, optional', ['This parameter is the baz.']),
+    ... ]
+    >>> print(to_docstring(kwargs), end='')
+    bar: str, optional
+        This parameter is the bar.
+    baz: int, optional
+        This parameter is the baz.
+
+    """
+    buf = io.StringIO()
+    for name, type_, description in kwargs:
+        buf.write('%s%s: %s\n' % (lpad, name, type_))
+        for line in description:
+            buf.write('%s    %s\n' % (lpad, line))
+    return buf.getvalue()

--- a/smart_open/doctools.py
+++ b/smart_open/doctools.py
@@ -1,3 +1,10 @@
+#
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 Radim Rehurek <me@radimrehurek.com>
+#
+# This code is distributed under the terms and conditions from the MIT License (MIT).
+#
 """Common functions for working with docstrings.
 
 For internal use only.

--- a/smart_open/hdfs.py
+++ b/smart_open/hdfs.py
@@ -6,6 +6,15 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
+def open(uri, mode):
+    if mode == 'rb':
+        return CliRawInputBase(uri)
+    elif mode == 'wb':
+        return CliRawOutputBase(uri)
+    else:
+        raise NotImplementedError('hdfs support for mode %r not implemented' % mode)
+
+
 class CliRawInputBase(io.RawIOBase):
     """Reads bytes from HDFS via the "hdfs dfs" command-line interface.
 

--- a/smart_open/http.py
+++ b/smart_open/http.py
@@ -14,32 +14,38 @@ Sometimes, servers compress the file for more efficient transfer, in which case
 the client (us) has to decompress them with the appropriate algorithm.
 """
 
-class BufferedInputBase(io.BufferedIOBase):
-    """
-    Implement streamed reader from a web site.
+
+def open(uri, mode, kerberos=False, user=None, password=None):
+    """Implement streamed reader from a web site.
+
     Supports Kerberos and Basic HTTP authentication.
+
+    Parameters
+    ----------
+    url: str
+        The URL to open.
+    mode: str
+        The mode to open using.
+    kerberos: boolean, optional
+        If True, will attempt to use the local Kerberos credentials
+    user: str, optional
+        The username for authenticating over HTTP
+    password: str, optional
+        The password for authenticating over HTTP
+
+    Note
+    ----
+    If neither kerberos or (user, password) are set, will connect unauthenticated.
+
     """
+    if mode == 'rb':
+        return BufferedInputBase(uri, mode, kerberos=kerberos, user=user, password=password)
+    else:
+        raise NotImplementedError('http support for mode %r not implemented' % mode)
 
+
+class BufferedInputBase(io.BufferedIOBase):
     def __init__(self, url, mode='r', kerberos=False, user=None, password=None):
-        """
-        Parameters
-        ----------
-        url: str
-            The URL to open.
-        mode: str
-            The mode to open using.
-        kerberos: boolean, optional
-            If True, will attempt to use the local Kerberos credentials
-        user: str, optional
-            The username for authenticating over HTTP
-        password: str, optional
-            The password for authenticating over HTTP
-
-        Note
-        ----
-        If neither kerberos or (user, password) are set, will connect unauthenticated.
-
-        """
         if kerberos:
             import requests_kerberos
             auth = requests_kerberos.HTTPKerberosAuth()

--- a/smart_open/http.py
+++ b/smart_open/http.py
@@ -14,7 +14,6 @@ Sometimes, servers compress the file for more efficient transfer, in which case
 the client (us) has to decompress them with the appropriate algorithm.
 """
 
-
 class BufferedInputBase(io.BufferedIOBase):
     """
     Implement streamed reader from a web site.
@@ -23,10 +22,23 @@ class BufferedInputBase(io.BufferedIOBase):
 
     def __init__(self, url, mode='r', kerberos=False, user=None, password=None):
         """
-        If Kerberos is True, will attempt to use the local Kerberos credentials.
-        Otherwise, will try to use "basic" HTTP authentication via username/password.
+        Parameters
+        ----------
+        url: str
+            The URL to open.
+        mode: str
+            The mode to open using.
+        kerberos: boolean, optional
+            If True, will attempt to use the local Kerberos credentials
+        user: str, optional
+            The username for authenticating over HTTP
+        password: str, optional
+            The password for authenticating over HTTP
 
-        If none of those are set, will connect unauthenticated.
+        Note
+        ----
+        If neither kerberos or (user, password) are set, will connect unauthenticated.
+
         """
         if kerberos:
             import requests_kerberos

--- a/smart_open/http.py
+++ b/smart_open/http.py
@@ -53,7 +53,7 @@ def open(uri, mode, kerberos=False, user=None, password=None):
 
 
 class BufferedInputBase(io.BufferedIOBase):
-    def __init__(self, url, mode='r', kerberos=False, user=None, password=None):
+    def __init__(self, url, mode='r', buffer_size=DEFAULT_BUFFER_SIZE, kerberos=False, user=None, password=None):
         if kerberos:
             import requests_kerberos
             auth = requests_kerberos.HTTPKerberosAuth()

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -383,8 +383,16 @@ class BufferedOutputBase(io.BufferedIOBase):
 
     Implements the io.BufferedIOBase interface of the standard library."""
 
-    def __init__(self, bucket, key, min_part_size=DEFAULT_MIN_PART_SIZE,
-                 s3_upload=None, session=None, resource_kwargs=dict()):
+    def __init__(
+            self,
+            bucket,
+            key,
+            min_part_size=DEFAULT_MIN_PART_SIZE,
+            s3_upload=None,
+            session=None,
+            resource_kwargs=dict(),
+            multipart_upload_kwargs=dict(),
+            ):
         if min_part_size < MIN_MIN_PART_SIZE:
             logger.warning("S3 requires minimum part size >= 5MB; \
 multipart upload may fail")
@@ -403,7 +411,7 @@ multipart upload may fail")
             raise ValueError('the bucket %r does not exist, or is forbidden for access' % bucket)
         self._object = s3.Object(bucket, key)
         self._min_part_size = min_part_size
-        self._mp = self._object.initiate_multipart_upload(**(s3_upload or {}))
+        self._mp = self._object.initiate_multipart_upload(**multipart_upload_kwargs)
 
         self._buf = io.BytesIO()
         self._total_bytes = 0

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -180,10 +180,10 @@ class SeekableRawReader(object):
 
 class BufferedInputBase(io.BufferedIOBase):
     def __init__(self, bucket, key, buffer_size=DEFAULT_BUFFER_SIZE,
-                 line_terminator=BINARY_NEWLINE, session=None, **kwargs):
+                 line_terminator=BINARY_NEWLINE, session=None, resource_kwargs=dict()):
         if session is None:
             session = boto3.Session()
-        s3 = session.resource('s3', **kwargs)
+        s3 = session.resource('s3', **resource_kwargs)
         self._object = s3.Object(bucket, key)
         self._raw_reader = RawReader(self._object)
         self._content_length = self._object.content_length

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -67,11 +67,6 @@ logger = logging.getLogger(__name__)
 
 SYSTEM_ENCODING = sys.getdefaultencoding()
 
-_ISSUE_146_FSTR = (
-    "You have explicitly specified encoding=%(encoding)s, but smart_open does "
-    "not currently support decoding text via the %(scheme)s scheme. "
-    "Re-open the file without specifying an encoding to suppress this warning."
-)
 _ISSUE_189_URL = 'https://github.com/RaRe-Technologies/smart_open/issues/189'
 
 

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -42,6 +42,7 @@ for pathlib_module in ('pathlib', 'pathlib2'):
     except ImportError:
         PATHLIB_SUPPORT = False
 
+import boto
 import boto3
 from boto.compat import BytesIO, urlsplit, six
 import six

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -160,7 +160,7 @@ def open(
         mode='r',
         buffering=-1,
         encoding=None,
-        errors='strict',
+        errors=None,
         newline=None,
         closefd=True,
         opener=None,
@@ -727,7 +727,7 @@ def _compression_wrapper(file_obj, filename, mode):
         return file_obj
 
 
-def _encoding_wrapper(fileobj, mode, encoding=None, errors='strict'):
+def _encoding_wrapper(fileobj, mode, encoding=None, errors=None):
     """Decode bytes into text, if necessary.
 
     If mode specifies binary access, does nothing, unless the encoding is
@@ -760,4 +760,8 @@ def _encoding_wrapper(fileobj, mode, encoding=None, errors='strict'):
         decoder = codecs.getreader(encoding)
     else:
         decoder = codecs.getwriter(encoding)
-    return decoder(fileobj, errors=errors)
+
+    if errors:
+        return decoder(fileobj, errors=errors)
+    else:
+        return decoder(fileobj)

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -458,7 +458,6 @@ def _shortcut_open(
         buffering=-1,
         encoding=None,
         errors=None,
-        **kw,  # TODO: remove this catch-all
         ):
     """Try to open the URI using the standard library io.open function.
 
@@ -517,7 +516,7 @@ def _open_binary_stream(uri, mode, tkwa):
 
     :arg uri: The URI to open.  May be a string, or something else.
     :arg str mode: The mode to open with.  Must be rb, wb or ab.
-    :arg tkwa: TODO: document this.
+    :arg tkwa: Keyword argumens for the transport layer.
     :returns: A file object and the filename
     :rtype: tuple
     """

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -475,7 +475,7 @@ def _shortcut_open(
         return None
 
     _, extension = P.splitext(parsed_uri.uri_path)
-    if extension in _COMPRESSOR_REGISTRY and not ignore_extension:
+    if extension in _COMPRESSOR_REGISTRY and not ignore_ext:
         return None
 
     open_kwargs = {}
@@ -843,8 +843,9 @@ def _encoding_wrapper(fileobj, mode, encoding=None, errors=None):
     if encoding is None:
         encoding = SYSTEM_ENCODING
 
+    kw = {'errors': errors} if errors else {}
     if mode[0] == 'r' or mode.endswith('+'):
-        fileobj = codecs.getreader(encoding)(fileobj, errors=errors)
+        fileobj = codecs.getreader(encoding)(fileobj, **kw)
     if mode[0] in ('w', 'a') or mode.endswith('+'):
-        fileobj = codecs.getwriter(encoding)(fileobj, errors=errors)
+        fileobj = codecs.getwriter(encoding)(fileobj, **kw)
     return fileobj

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -8,8 +8,8 @@
 
 
 """
-Utilities for streaming from several file-like data storages: S3 / HDFS / standard
-filesystem / compressed files..., using a single, Pythonic API.
+Utilities for streaming to/from several file-like data storages: S3 / HDFS / local
+filesystem / compressed files, and many more, using a simple, Pythonic API.
 
 The streaming makes heavy use of generators and pipes, to avoid loading
 full file contents into memory, allowing work with arbitrarily large files.

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -370,69 +370,7 @@ open.__doc__ = open.__doc__ % {
 
 
 def smart_open(uri, mode="rb", **kw):
-    """
-    Open the given S3 / HDFS / filesystem file pointed to by `uri` for reading or writing.
-
-    The only supported modes for now are 'rb' (read, default) and 'wb' (replace & write).
-
-    The reads/writes are memory efficient (streamed) and therefore suitable for
-    arbitrarily large files.
-
-    The `uri` can be either:
-
-    1. a URI for the local filesystem (compressed ``.gz``, ``.bz2`` or ``.xz`` files handled
-        automatically): `./lines.txt`, `/home/joe/lines.txt.gz`, `file:///home/joe/lines.txt.bz2`
-    2. a URI for HDFS: `hdfs:///some/path/lines.txt`
-    3. a URI for Amazon's S3 (can also supply credentials inside the URI):
-       `s3://my_bucket/lines.txt`, `s3://my_aws_key_id:key_secret@my_bucket/lines.txt`
-    4. an instance of the boto.s3.key.Key class.
-    5. an instance of the pathlib.Path class.
-
-    Examples::
-
-      >>> # stream lines from http; you can use context managers too:
-      >>> with smart_open.smart_open('http://www.google.com') as fin:
-      ...     for line in fin:
-      ...         print line
-
-      >>> # stream lines from S3; you can use context managers too:
-      >>> with smart_open.smart_open('s3://mybucket/mykey.txt') as fin:
-      ...     for line in fin:
-      ...         print line
-
-      >>> # you can also use a boto.s3.key.Key instance directly:
-      >>> key = boto.connect_s3().get_bucket("my_bucket").get_key("my_key")
-      >>> with smart_open.smart_open(key) as fin:
-      ...     for line in fin:
-      ...         print line
-
-      >>> # stream line-by-line from an HDFS file
-      >>> for line in smart_open.smart_open('hdfs:///user/hadoop/my_file.txt'):
-      ...    print line
-
-      >>> # stream content *into* S3:
-      >>> with smart_open.smart_open('s3://mybucket/mykey.txt', 'wb') as fout:
-      ...     for line in ['first line', 'second line', 'third line']:
-      ...          fout.write(line + '\n')
-
-      >>> # stream from/to (compressed) local files:
-      >>> for line in smart_open.smart_open('/home/radim/my_file.txt'):
-      ...    print line
-      >>> for line in smart_open.smart_open('/home/radim/my_file.txt.gz'):
-      ...    print line
-      >>> with smart_open.smart_open('/home/radim/my_file.txt.gz', 'wb') as fout:
-      ...    fout.write("hello world!\n")
-      >>> with smart_open.smart_open('/home/radim/another.txt.bz2', 'wb') as fout:
-      ...    fout.write("good bye!\n")
-      >>> with smart_open.smart_open('/home/radim/another.txt.xz', 'wb') as fout:
-      ...    fout.write("never say never!\n")
-      >>> # stream from/to (compressed) local files with Expand ~ and ~user constructions:
-      >>> for line in smart_open.smart_open('~/my_file.txt'):
-      ...    print line
-      >>> for line in smart_open.smart_open('my_file.txt'):
-      ...    print line
-
-    """
+    """Deprecated, use smart_open.open instead."""
     logger.warning('this function is deprecated, use smart_open.open instead')
 
     expected_kwargs = _inspect_kwargs(open)

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -432,12 +432,16 @@ def _shortcut_open(
         return None
 
     open_kwargs = {}
-    if errors is not None:
-        open_kwargs['errors'] = errors
 
     if encoding is not None:
         open_kwargs['encoding'] = encoding
         mode = mode.replace('b', '')
+
+    #
+    # binary mode of the builtin/stdlib open function doesn't take an errors argument
+    #
+    if errors and 'b' not in mode:
+        open_kwargs['errors'] = errors
 
     #
     # Under Py3, the built-in open accepts kwargs, and it's OK to use that.

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -166,7 +166,7 @@ def open(
         newline=None,
         closefd=True,
         opener=None,
-        ignore_extension=False,
+        ignore_ext=False,
         tkwa=dict(),
         ):
     """Open the URI object, returning a file-like object.
@@ -211,7 +211,7 @@ def open(
         Mimicks built-in open parameter of the same name.  Ignored.
     opener: object, optional
         Mimicks built-in open parameter of the same name.  Ignored.
-    ignore_extension: boolean, optional
+    ignore_ext: boolean, optional
         Disable transparent compression/decompression based on the file extension.
     tkwa: dict
         Keyword arguments for the transport layer (see notes below).
@@ -292,7 +292,7 @@ def open(
     fobj = _shortcut_open(
         uri,
         mode,
-        ignore_extension=ignore_extension,
+        ignore_ext=ignore_ext,
         buffering=buffering,
         encoding=encoding,
         errors=errors,
@@ -337,7 +337,7 @@ def open(
     except KeyError:
         binary_mode = mode
     binary, filename = _open_binary_stream(uri, binary_mode, tkwa)
-    if ignore_extension:
+    if ignore_ext:
         decompressed = binary
     else:
         decompressed = _compression_wrapper(binary, filename, mode)
@@ -373,6 +373,11 @@ def smart_open(uri, mode="rb", **kw):
     """Deprecated, use smart_open.open instead."""
     logger.warning('this function is deprecated, use smart_open.open instead')
 
+    #
+    # The new function uses a shorter name for this parameter, handle it separately.
+    #
+    ignore_extension = kw.pop('ignore_extension', False)
+
     expected_kwargs = _inspect_kwargs(open)
     scrubbed_kwargs = {}
     tkwa = {}
@@ -388,13 +393,13 @@ def smart_open(uri, mode="rb", **kw):
             #
             tkwa[key] = value
 
-    return open(uri, mode, tkwa=tkwa, **scrubbed_kwargs)
+    return open(uri, mode, ignore_ext=ignore_extension, tkwa=tkwa, **scrubbed_kwargs)
 
 
 def _shortcut_open(
         uri,
         mode,
-        ignore_extension=False,
+        ignore_ext=False,
         buffering=-1,
         encoding=None,
         errors=None,
@@ -425,7 +430,7 @@ def _shortcut_open(
         return None
 
     _, extension = P.splitext(parsed_uri.uri_path)
-    if extension in COMPRESSED_EXT and not ignore_extension:
+    if extension in COMPRESSED_EXT and not ignore_ext:
         return None
 
     open_kwargs = {}

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -91,8 +91,6 @@ _ISSUE_146_FSTR = (
 )
 _ISSUE_189_URL = 'https://github.com/RaRe-Technologies/smart_open/issues/189'
 
-DEFAULT_ERRORS = 'strict'
-
 
 Uri = collections.namedtuple(
     'Uri',
@@ -784,7 +782,7 @@ def _compression_wrapper(file_obj, filename, mode):
         return file_obj
 
 
-def _encoding_wrapper(fileobj, mode, encoding=None, errors=DEFAULT_ERRORS):
+def _encoding_wrapper(fileobj, mode, encoding=None, errors='strict'):
     """Decode bytes into text, if necessary.
 
     If mode specifies binary access, does nothing, unless the encoding is

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -354,15 +354,15 @@ def open(
 open.__doc__ = open.__doc__ % {
     's3': doctools.to_docstring(
         doctools.extract_kwargs(smart_open_s3.open.__doc__),
-        lpad='    ',
+        lpad=u'    ',
     ),
     'http': doctools.to_docstring(
         doctools.extract_kwargs(smart_open_http.open.__doc__),
-        lpad='    ',
+        lpad=u'    ',
     ),
     'webhdfs': doctools.to_docstring(
         doctools.extract_kwargs(smart_open_webhdfs.open.__doc__),
-        lpad='    ',
+        lpad=u'    ',
     ),
 }
 

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -44,7 +44,6 @@ for pathlib_module in ('pathlib', 'pathlib2'):
 
 import boto3
 from boto.compat import BytesIO, urlsplit, six
-import boto.s3.key
 import six
 from six.moves.urllib import parse as urlparse
 import sys
@@ -225,7 +224,6 @@ def open(
 
     The URI may also be one of:
 
-    - an instance of the boto.s3.key.Key class
     - an instance of the pathlib.Path class
     - a stream (anything that implements io.IOBase-like functionality)
 
@@ -293,12 +291,6 @@ def open(
 
     >>> # stream lines from S3; you can use context managers too:
     >>> with open('s3://mybucket/mykey.txt') as fin:
-    ...     for line in fin:
-    ...         print(line)
-
-    >>> # you can also use a boto.s3.key.Key instance directly:
-    >>> key = boto.connect_s3().get_bucket("my_bucket").get_key("my_key")
-    >>> with open(key) as fin:
     ...     for line in fin:
     ...         print(line)
 

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1102,6 +1102,7 @@ class S3OpenTest(unittest.TestCase):
             self.assertEqual(fin.read().decode("utf-8"), text)
 
     @mock_s3
+    @mock.patch('smart_open.smart_open_lib._inspect_kwargs', mock.Mock(return_value={}))
     def test_gzip_write_mode(self):
         """Should always open in binary mode when writing through a codec."""
         s3 = boto3.resource('s3')
@@ -1113,6 +1114,7 @@ class S3OpenTest(unittest.TestCase):
             mock_open.assert_called_with('bucket', 'key.gz', 'wb')
 
     @mock_s3
+    @mock.patch('smart_open.smart_open_lib._inspect_kwargs', mock.Mock(return_value={}))
     def test_gzip_read_mode(self):
         """Should always open in binary mode when reading through a codec."""
         s3 = boto3.resource('s3')

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -293,7 +293,7 @@ class SmartOpenHttpTest(unittest.TestCase):
 # See the _shortcut_open function for details.
 #
 _IO_OPEN = 'io.open'
-_BUILTIN_OPEN = 'smart_open.smart_open_lib.open'
+_BUILTIN_OPEN = 'smart_open.smart_open_lib._builtin_open'
 
 
 class SmartOpenReadTest(unittest.TestCase):
@@ -304,7 +304,7 @@ class SmartOpenReadTest(unittest.TestCase):
 
     def test_shortcut(self):
         fpath = os.path.join(CURR_DIR, 'test_data/crime-and-punishment.txt')
-        with mock.patch('smart_open.smart_open_lib.open') as mock_open:
+        with mock.patch('smart_open.smart_open_lib._builtin_open') as mock_open:
             smart_open.smart_open(fpath, 'r').read()
         mock_open.assert_called_with(fpath, 'r', buffering=-1, errors='strict')
 
@@ -412,7 +412,7 @@ class SmartOpenReadTest(unittest.TestCase):
         self.assertEqual(b''.join(output), test_string)
 
     # TODO: add more complex test for file://
-    @mock.patch('smart_open.smart_open_lib.open')
+    @mock.patch('smart_open.smart_open_lib._builtin_open')
     def test_file(self, mock_smart_open):
         """Is file:// line iterator called correctly?"""
         prefix = "file://"
@@ -600,7 +600,7 @@ class SmartOpenS3KwargsTest(unittest.TestCase):
     @mock.patch('boto3.Session')
     def test_host(self, mock_session):
         tkwa = {'resource_kwargs': {'endpoint_url': 'http://aa.domain.com'}}
-        smart_open.smart_open2("s3://access_id:access_secret@mybucket/mykey", tkwa=tkwa)
+        smart_open.open("s3://access_id:access_secret@mybucket/mykey", tkwa=tkwa)
         mock_session.assert_called_with(
             aws_access_key_id='access_id',
             aws_secret_access_key='access_secret',
@@ -612,7 +612,7 @@ class SmartOpenS3KwargsTest(unittest.TestCase):
 
     @mock.patch('boto3.Session')
     def test_s3_upload(self, mock_session):
-        smart_open.smart_open2(
+        smart_open.open(
             "s3://bucket/key", 'wb', tkwa={
                 'multipart_upload_kwargs': {
                     'ServerSideEncryption': 'AES256',
@@ -639,7 +639,7 @@ class SmartOpenS3KwargsTest(unittest.TestCase):
         session = boto3.Session()
         session.resource = mock.MagicMock()
 
-        smart_open.smart_open2('s3://bucket/key', tkwa={'session': session})
+        smart_open.open('s3://bucket/key', tkwa={'session': session})
         session.resource.assert_called_with('s3')
 
     def test_session_write_mode(self):
@@ -649,7 +649,7 @@ class SmartOpenS3KwargsTest(unittest.TestCase):
         session = boto3.Session()
         session.resource = mock.MagicMock()
 
-        smart_open.smart_open2('s3://bucket/key', 'wb', tkwa={'session': session})
+        smart_open.open('s3://bucket/key', 'wb', tkwa={'session': session})
         session.resource.assert_called_with('s3')
 
 
@@ -737,7 +737,7 @@ class SmartOpenTest(unittest.TestCase):
 
         # correct write mode, correct s3 URI
         tkwa = {'resource_kwargs': {'endpoint_url': 'http://s3.amazonaws.com'}}
-        smart_open.smart_open2("s3://mybucket/mykey", "w", tkwa=tkwa)
+        smart_open.open("s3://mybucket/mykey", "w", tkwa=tkwa)
         mock_session.return_value.resource.assert_called_with(
             's3', endpoint_url='http://s3.amazonaws.com'
         )
@@ -791,7 +791,7 @@ class SmartOpenTest(unittest.TestCase):
         s3.create_bucket(Bucket='mybucket')
 
         # Write data, with multipart_upload options
-        write_stream = smart_open.smart_open2(
+        write_stream = smart_open.open(
             's3://mybucket/crime-and-punishment.txt.gz', 'wb',
             tkwa={
                 'multipart_upload_kwargs': {

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -306,7 +306,7 @@ class SmartOpenReadTest(unittest.TestCase):
         fpath = os.path.join(CURR_DIR, 'test_data/crime-and-punishment.txt')
         with mock.patch('smart_open.smart_open_lib.open') as mock_open:
             smart_open.smart_open(fpath, 'r').read()
-        mock_open.assert_called_with(fpath, 'r', buffering=-1)
+        mock_open.assert_called_with(fpath, 'r', buffering=-1, errors='strict')
 
     def test_open_with_keywords(self):
         """This test captures Issue #142."""
@@ -421,21 +421,21 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object = smart_open.smart_open(prefix+full_path, read_mode)
         smart_open_object.__iter__()
         # called with the correct path?
-        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1)
+        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1, errors='strict')
 
         full_path = '/tmp/test#hash##more.txt'
         read_mode = "rb"
         smart_open_object = smart_open.smart_open(prefix+full_path, read_mode)
         smart_open_object.__iter__()
         # called with the correct path?
-        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1)
+        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1, errors='strict')
 
         full_path = 'aa#aa'
         read_mode = "rb"
         smart_open_object = smart_open.smart_open(full_path, read_mode)
         smart_open_object.__iter__()
         # called with the correct path?
-        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1)
+        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1, errors='strict')
 
         short_path = "~/tmp/test.txt"
         full_path = os.path.expanduser(short_path)
@@ -455,10 +455,10 @@ class SmartOpenReadTest(unittest.TestCase):
 
     @mock.patch(_BUILTIN_OPEN)
     def test_file_buffering(self, mock_smart_open):
-        smart_open_object = smart_open.smart_open('/tmp/somefile', 'rb', buffering=0)
+        smart_open_object = smart_open.smart_open('/tmp/somefile', 'rb', buffering=0, errors='strict')
         smart_open_object.__iter__()
         # called with the correct expanded path?
-        mock_smart_open.assert_called_with('/tmp/somefile', 'rb', buffering=0)
+        mock_smart_open.assert_called_with('/tmp/somefile', 'rb', buffering=0, errors='strict')
 
     @unittest.skip('smart_open does not currently accept additional positional args')
     @mock.patch(_BUILTIN_OPEN)
@@ -466,7 +466,7 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object = smart_open.smart_open('/tmp/somefile', 'rb', 0)
         smart_open_object.__iter__()
         # called with the correct expanded path?
-        mock_smart_open.assert_called_with('/tmp/somefile', 'rb', buffering=0)
+        mock_smart_open.assert_called_with('/tmp/somefile', 'rb', buffering=0, errors='strict')
 
     # couldn't find any project for mocking up HDFS data
     # TODO: we want to test also a content of the files, not just fnc call params
@@ -679,20 +679,20 @@ class SmartOpenTest(unittest.TestCase):
         with mock.patch(patch, mock.Mock(return_value=self.stringio)) as mock_open:
             with smart_open.smart_open("blah", "r", encoding='utf-8') as fin:
                 self.assertEqual(fin.read(), self.as_text)
-                mock_open.assert_called_with("blah", "r", buffering=-1, encoding='utf-8')
+                mock_open.assert_called_with("blah", "r", buffering=-1, encoding='utf-8', errors='strict')
 
     def test_binary(self):
         with mock.patch(_BUILTIN_OPEN, mock.Mock(return_value=self.bytesio)) as mock_open:
             with smart_open.smart_open("blah", "rb") as fin:
                 self.assertEqual(fin.read(), self.as_bytes)
-                mock_open.assert_called_with("blah", "rb", buffering=-1)
+                mock_open.assert_called_with("blah", "rb", buffering=-1, errors='strict')
 
     def test_expanded_path(self):
         short_path = "~/blah"
         full_path = os.path.expanduser(short_path)
         with mock.patch(_BUILTIN_OPEN, mock.Mock(return_value=self.stringio)) as mock_open:
             with smart_open.smart_open(short_path, "rb") as fin:
-                mock_open.assert_called_with(full_path, "rb", buffering=-1)
+                mock_open.assert_called_with(full_path, "rb", buffering=-1, errors='strict')
 
     def test_incorrect(self):
         # incorrect file mode
@@ -708,27 +708,27 @@ class SmartOpenTest(unittest.TestCase):
         patch = _IO_OPEN if six.PY2 else _BUILTIN_OPEN
         with mock.patch(patch, mock.Mock(return_value=self.stringio)) as mock_open:
             with smart_open.smart_open("blah", "w", encoding='utf-8') as fout:
-                mock_open.assert_called_with("blah", "w", buffering=-1, encoding='utf-8')
+                mock_open.assert_called_with("blah", "w", buffering=-1, encoding='utf-8', errors='strict')
                 fout.write(self.as_text)
 
     def test_write_utf8_absolute_path(self):
         patch = _IO_OPEN if six.PY2 else _BUILTIN_OPEN
         with mock.patch(patch, mock.Mock(return_value=self.stringio)) as mock_open:
             with smart_open.smart_open("/some/file.txt", "w", encoding='utf-8') as fout:
-                mock_open.assert_called_with("/some/file.txt", "w", buffering=-1, encoding='utf-8')
+                mock_open.assert_called_with("/some/file.txt", "w", buffering=-1, encoding='utf-8', errors='strict')
                 fout.write(self.as_text)
 
     def test_append_utf8(self):
         patch = _IO_OPEN if six.PY2 else _BUILTIN_OPEN
         with mock.patch(patch, mock.Mock(return_value=self.stringio)) as mock_open:
             with smart_open.smart_open("/some/file.txt", "w+", encoding='utf-8') as fout:
-                mock_open.assert_called_with("/some/file.txt", "w+", buffering=-1, encoding='utf-8')
+                mock_open.assert_called_with("/some/file.txt", "w+", buffering=-1, encoding='utf-8', errors='strict')
                 fout.write(self.as_text)
 
     def test_append_binary_absolute_path(self):
         with mock.patch(_BUILTIN_OPEN, mock.Mock(return_value=self.bytesio)) as mock_open:
             with smart_open.smart_open("/some/file.txt", "wb+") as fout:
-                mock_open.assert_called_with("/some/file.txt", "wb+", buffering=-1)
+                mock_open.assert_called_with("/some/file.txt", "wb+", buffering=-1, errors='strict')
                 fout.write(self.as_bytes)
 
     @mock.patch('boto3.Session')

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -421,21 +421,21 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object = smart_open.smart_open(prefix+full_path, read_mode)
         smart_open_object.__iter__()
         # called with the correct path?
-        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1, errors='strict')
+        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1)
 
         full_path = '/tmp/test#hash##more.txt'
         read_mode = "rb"
         smart_open_object = smart_open.smart_open(prefix+full_path, read_mode)
         smart_open_object.__iter__()
         # called with the correct path?
-        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1, errors='strict')
+        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1)
 
         full_path = 'aa#aa'
         read_mode = "rb"
         smart_open_object = smart_open.smart_open(full_path, read_mode)
         smart_open_object.__iter__()
         # called with the correct path?
-        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1, errors='strict')
+        mock_smart_open.assert_called_with(full_path, read_mode, buffering=-1)
 
         short_path = "~/tmp/test.txt"
         full_path = os.path.expanduser(short_path)
@@ -455,10 +455,10 @@ class SmartOpenReadTest(unittest.TestCase):
 
     @mock.patch(_BUILTIN_OPEN)
     def test_file_buffering(self, mock_smart_open):
-        smart_open_object = smart_open.smart_open('/tmp/somefile', 'rb', buffering=0, errors='strict')
+        smart_open_object = smart_open.smart_open('/tmp/somefile', 'rb', buffering=0)
         smart_open_object.__iter__()
         # called with the correct expanded path?
-        mock_smart_open.assert_called_with('/tmp/somefile', 'rb', buffering=0, errors='strict')
+        mock_smart_open.assert_called_with('/tmp/somefile', 'rb', buffering=0)
 
     @unittest.skip('smart_open does not currently accept additional positional args')
     @mock.patch(_BUILTIN_OPEN)
@@ -466,7 +466,7 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object = smart_open.smart_open('/tmp/somefile', 'rb', 0)
         smart_open_object.__iter__()
         # called with the correct expanded path?
-        mock_smart_open.assert_called_with('/tmp/somefile', 'rb', buffering=0, errors='strict')
+        mock_smart_open.assert_called_with('/tmp/somefile', 'rb', buffering=0)
 
     # couldn't find any project for mocking up HDFS data
     # TODO: we want to test also a content of the files, not just fnc call params
@@ -685,14 +685,14 @@ class SmartOpenTest(unittest.TestCase):
         with mock.patch(_BUILTIN_OPEN, mock.Mock(return_value=self.bytesio)) as mock_open:
             with smart_open.smart_open("blah", "rb") as fin:
                 self.assertEqual(fin.read(), self.as_bytes)
-                mock_open.assert_called_with("blah", "rb", buffering=-1, errors='strict')
+                mock_open.assert_called_with("blah", "rb", buffering=-1)
 
     def test_expanded_path(self):
         short_path = "~/blah"
         full_path = os.path.expanduser(short_path)
         with mock.patch(_BUILTIN_OPEN, mock.Mock(return_value=self.stringio)) as mock_open:
             with smart_open.smart_open(short_path, "rb") as fin:
-                mock_open.assert_called_with(full_path, "rb", buffering=-1, errors='strict')
+                mock_open.assert_called_with(full_path, "rb", buffering=-1)
 
     def test_incorrect(self):
         # incorrect file mode
@@ -728,7 +728,7 @@ class SmartOpenTest(unittest.TestCase):
     def test_append_binary_absolute_path(self):
         with mock.patch(_BUILTIN_OPEN, mock.Mock(return_value=self.bytesio)) as mock_open:
             with smart_open.smart_open("/some/file.txt", "wb+") as fout:
-                mock_open.assert_called_with("/some/file.txt", "wb+", buffering=-1, errors='strict')
+                mock_open.assert_called_with("/some/file.txt", "wb+", buffering=-1)
                 fout.write(self.as_bytes)
 
     @mock.patch('boto3.Session')

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -306,7 +306,7 @@ class SmartOpenReadTest(unittest.TestCase):
         fpath = os.path.join(CURR_DIR, 'test_data/crime-and-punishment.txt')
         with mock.patch('smart_open.smart_open_lib._builtin_open') as mock_open:
             smart_open.smart_open(fpath, 'r').read()
-        mock_open.assert_called_with(fpath, 'r', buffering=-1, errors='strict')
+        mock_open.assert_called_with(fpath, 'r', buffering=-1)
 
     def test_open_with_keywords(self):
         """This test captures Issue #142."""
@@ -679,7 +679,7 @@ class SmartOpenTest(unittest.TestCase):
         with mock.patch(patch, mock.Mock(return_value=self.stringio)) as mock_open:
             with smart_open.smart_open("blah", "r", encoding='utf-8') as fin:
                 self.assertEqual(fin.read(), self.as_text)
-                mock_open.assert_called_with("blah", "r", buffering=-1, encoding='utf-8', errors='strict')
+                mock_open.assert_called_with("blah", "r", buffering=-1, encoding='utf-8')
 
     def test_binary(self):
         with mock.patch(_BUILTIN_OPEN, mock.Mock(return_value=self.bytesio)) as mock_open:
@@ -708,21 +708,21 @@ class SmartOpenTest(unittest.TestCase):
         patch = _IO_OPEN if six.PY2 else _BUILTIN_OPEN
         with mock.patch(patch, mock.Mock(return_value=self.stringio)) as mock_open:
             with smart_open.smart_open("blah", "w", encoding='utf-8') as fout:
-                mock_open.assert_called_with("blah", "w", buffering=-1, encoding='utf-8', errors='strict')
+                mock_open.assert_called_with("blah", "w", buffering=-1, encoding='utf-8')
                 fout.write(self.as_text)
 
     def test_write_utf8_absolute_path(self):
         patch = _IO_OPEN if six.PY2 else _BUILTIN_OPEN
         with mock.patch(patch, mock.Mock(return_value=self.stringio)) as mock_open:
             with smart_open.smart_open("/some/file.txt", "w", encoding='utf-8') as fout:
-                mock_open.assert_called_with("/some/file.txt", "w", buffering=-1, encoding='utf-8', errors='strict')
+                mock_open.assert_called_with("/some/file.txt", "w", buffering=-1, encoding='utf-8')
                 fout.write(self.as_text)
 
     def test_append_utf8(self):
         patch = _IO_OPEN if six.PY2 else _BUILTIN_OPEN
         with mock.patch(patch, mock.Mock(return_value=self.stringio)) as mock_open:
             with smart_open.smart_open("/some/file.txt", "w+", encoding='utf-8') as fout:
-                mock_open.assert_called_with("/some/file.txt", "w+", buffering=-1, encoding='utf-8', errors='strict')
+                mock_open.assert_called_with("/some/file.txt", "w+", buffering=-1, encoding='utf-8')
                 fout.write(self.as_text)
 
     def test_append_binary_absolute_path(self):

--- a/smart_open/webhdfs.py
+++ b/smart_open/webhdfs.py
@@ -14,6 +14,10 @@ logger.addHandler(logging.NullHandler())
 
 WEBHDFS_MIN_PART_SIZE = 50 * 1024**2  # minimum part size for HDFS multipart uploads
 
+KWARGS = (
+    ('min_part_size', 'int', 'For writing only'),
+)
+
 
 class BufferedInputBase(io.BufferedIOBase):
     def __init__(self, uri):
@@ -84,6 +88,13 @@ class BufferedInputBase(io.BufferedIOBase):
 
 class BufferedOutputBase(io.BufferedIOBase):
     def __init__(self, uri_path, min_part_size=WEBHDFS_MIN_PART_SIZE):
+        """
+        Parameters
+        ----------
+        min_part_size: int, optional
+            For writing only.
+
+        """
         self.uri_path = uri_path
         self._closed = False
         self.min_part_size = min_part_size

--- a/smart_open/webhdfs.py
+++ b/smart_open/webhdfs.py
@@ -14,9 +14,21 @@ logger.addHandler(logging.NullHandler())
 
 WEBHDFS_MIN_PART_SIZE = 50 * 1024**2  # minimum part size for HDFS multipart uploads
 
-KWARGS = (
-    ('min_part_size', 'int', 'For writing only'),
-)
+
+def open(uri, mode, min_part_size=WEBHDFS_MIN_PART_SIZE):
+    """
+    Parameters
+    ----------
+    min_part_size: int
+        For writing only.
+
+    """
+    if mode == 'rb':
+        return BufferedInputBase(uri)
+    elif mode == 'wb':
+        return BufferedOutputBase(uri, min_part_size=min_part_size)
+    else:
+        raise NotImplementedError('webhdfs support for mode %r not implemented' % mode)
 
 
 class BufferedInputBase(io.BufferedIOBase):


### PR DESCRIPTION
My second crack at https://github.com/RaRe-Technologies/smart_open/pull/230

We used to liberally pass arbitrary keyword arguments (e.g. **kwargs). This is a bad practice because it's difficult to keep track of function parameters and ensure they're being passed down to the right function.

This PR starts to clean up our use of arbitrary keyword arguments.

Main changes:

- renamed smart_open.smart_open to smart_open.open
- renamed ignore_extension parameter to ignore_ext
- default open mode is now "r", to match standard library
- keyword arguments for that function now _completely_ match that of built-in open, with two exceptions (ignore_ext and tkwa)
- tkwa contains keyword arguments for whatever transport layer smart_open ends up using (e.g. HTTPS, S3, etc)
- Unsupported keyword arguments don't crash the library (same as old behavior) but cause a log warning (new behavior). Supported keyword arguments are identified via introspection.
- The transport keyword args are documented both in the top-level open function _and_ each individual module (S3, HTTPS, etc). There is no code duplication because of some docstring magic, hidden from the user.

Advantages:

- Simpler interface for the user, less arguments to open function
- Adding additional keyword arguments will no longer require updating the top-level interface
- Better documentation for keyword parameters (previously, they were documented via examples only)