### PR TITLE
Makes xz decompression an optional dependency in python<3.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,6 @@ Other examples of URLs that ``smart_open`` accepts::
     file:///home/user/file.bz2
     [ssh|scp|sftp]://username@host//path/file
     [ssh|scp|sftp]://username@host/path/file
-    file:///home/user/file.xz
 
 .. _doctools_after_examples:
 
@@ -161,20 +160,31 @@ The tests are also run automatically with `Travis CI <https://travis-ci.org/RaRe
 Supported Compression Formats
 -----------------------------
 
-``smart_open`` allows reading and writing gzip, bzip2 and xz files. (For python<3.3, use `pip install smart_open[xz]` for xz support.)
+``smart_open`` allows reading and writing gzip and bzip2 files.
 They are transparently handled over HTTP, S3, and other protocols, too, based on the extension of the file being opened.
-You can easily add support for other file extensions and compression formats:
+You can easily add support for other file extensions and compression formats.
+For example, to open xz-compressed files:
 
 .. code-block:: python
 
-    def _handle_lzma(file_obj, mode):
-        import lzma
-        return lzma.LZMAFile(filename=file_obj, mode=mode, format=lzma.FORMAT_ALONE)
-
+    import lzma, os
     from smart_open import open, register_compressor
-    register_compressor('.lzma', _handle_lzma)
-    with open('file.lzma', ...) as fin:
-        pass
+
+    def _handle_xz(file_obj, mode):
+        return lzma.LZMAFile(filename=file_obj,
+                                mode=mode,
+                                format=lzma.FORMAT_XZ)
+
+    register_compressor('.xz', _handle_xz)
+
+    data_path = './smart_open/tests/test_data/crime-and-punishment.txt.xz'
+    with open(data_path) as f:
+        crime_and_punishment = f.read()
+
+``lzma`` is in the standard library in Python 3.3 and greater.
+For 2.7, use `backports.lzma`_.
+
+.. _backports.lzma: https://pypi.org/project/backports.lzma/
 
 Transport-specific Options
 --------------------------

--- a/README.rst
+++ b/README.rst
@@ -161,7 +161,7 @@ The tests are also run automatically with `Travis CI <https://travis-ci.org/RaRe
 Supported Compression Formats
 -----------------------------
 
-``smart_open`` allows reading and writing gzip, bzip2 and xz files.
+``smart_open`` allows reading and writing gzip, bzip2 and xz files. (For python<3.3, use `pip install smart_open[xz]` for xz support.)
 They are transparently handled over HTTP, S3, and other protocols, too, based on the extension of the file being opened.
 You can easily add support for other file extensions and compression formats:
 

--- a/help.txt
+++ b/help.txt
@@ -50,8 +50,7 @@ FUNCTIONS
         
         - ``.gz``
         - ``.bz2``
-        - ``.xz``
-        
+
         The function depends on the file extension to determine the appropriate codec.
         
         Parameters

--- a/setup.py
+++ b/setup.py
@@ -57,11 +57,13 @@ setup(
         'bz2file',
         'requests',
         'boto3',
-        'backports.lzma;python_version<"3.3"',
     ],
     tests_require=tests_require,
     extras_require={
         'test': tests_require,
+        'xz': [
+            'backports.lzma;python_version<"3.3"',
+        ]
     },
 
     test_suite="smart_open.tests",

--- a/setup.py
+++ b/setup.py
@@ -61,9 +61,6 @@ setup(
     tests_require=tests_require,
     extras_require={
         'test': tests_require,
-        'xz': [
-            'backports.lzma;python_version<"3.3"',
-        ]
     },
 
     test_suite="smart_open.tests",

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -112,10 +112,16 @@ def _handle_xz(file_obj, mode):
     # Delay import of compressor library until we actually need it
     #
     try:
-        import lzma
+        if sys.version_info >= (3, 3):
+            import lzma
+        else:
+            # py<3.3
+            from backports import lzma
     except ImportError:
-        # py<3.3
-        from backports import lzma
+        logger.error("Optional xz decompression library not installed. "
+                     "Install with `pip install smart_open[xz].")
+        raise
+
     return lzma.LZMAFile(filename=file_obj, mode=mode, format=lzma.FORMAT_XZ)
 
 

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -107,30 +107,11 @@ def _handle_gzip(file_obj, mode):
     return gzip.GzipFile(fileobj=file_obj, mode=mode)
 
 
-def _handle_xz(file_obj, mode):
-    #
-    # Delay import of compressor library until we actually need it
-    #
-    try:
-        if sys.version_info >= (3, 3):
-            import lzma
-        else:
-            # py<3.3
-            from backports import lzma
-    except ImportError:
-        logger.error("Optional xz decompression library not installed. "
-                     "Install with `pip install smart_open[xz].")
-        raise
-
-    return lzma.LZMAFile(filename=file_obj, mode=mode, format=lzma.FORMAT_XZ)
-
-
 #
 # NB. avoid using lambda here to make stack traces more readable.
 #
 register_compressor('.bz2', _handle_bz2)
 register_compressor('.gz', _handle_gzip)
-register_compressor('.xz', _handle_xz)
 
 
 Uri = collections.namedtuple(
@@ -230,7 +211,6 @@ def open(
 
     - ``.gz``
     - ``.bz2``
-    - ``.xz``
 
     The function depends on the file extension to determine the appropriate codec.
 
@@ -602,7 +582,6 @@ def _parse_uri(uri_as_string):
       * file:///home/user/file.bz2
       * [ssh|scp|sftp]://username@host//path/file
       * [ssh|scp|sftp]://username@host/path/file
-      * file:///home/user/file.xz
 
     """
     if os.name == 'nt':

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -33,6 +33,16 @@ SAMPLE_TEXT = 'Hello, world!'
 SAMPLE_BYTES = SAMPLE_TEXT.encode('utf-8')
 
 
+try:
+    if sys.version_info >= (3, 3):
+        import lzma
+    else:
+        from backports import lzma
+    XZ_SUPPORTED = True
+except ImportError:
+    XZ_SUPPORTED = False
+
+
 class ParseUriTest(unittest.TestCase):
     """
     Test ParseUri class.
@@ -268,6 +278,9 @@ class SmartOpenHttpTest(unittest.TestCase):
         """Can open bzip2 via http?"""
         self._test_compressed_http(".bz2", False)
 
+    @unittest.skipUnless(
+        XZ_SUPPORTED,
+        "do not test if backports.lzma not installed for python<3.3")
     def test_http_xz(self):
         """Can open xz via http?"""
         self._test_compressed_http(".xz", False)
@@ -281,6 +294,9 @@ class SmartOpenHttpTest(unittest.TestCase):
         """Can open bzip2 via http with a query appended to URI?"""
         self._test_compressed_http(".bz2", True)
 
+    @unittest.skipUnless(
+        XZ_SUPPORTED,
+        "do not test if backports.lzma not installed for python<3.3")
     def test_http_xz_query(self):
         """Can open xz via http with a query appended to URI?"""
         self._test_compressed_http(".xz", True)
@@ -1014,10 +1030,16 @@ class CompressionFormatTest(unittest.TestCase):
         """Can write and read bz2?"""
         self.write_read_assertion('.bz2')
 
+    @unittest.skipUnless(
+        XZ_SUPPORTED,
+        "do not test if backports.lzma not installed for python<3.3")
     def test_write_read_xz(self):
         """Can write and read xz2?"""
         self.write_read_assertion('.xz')
 
+    @unittest.skipUnless(
+        XZ_SUPPORTED,
+        "do not test if backports.lzma not installed for python<3.3")
     def test_read_real_xz(self):
         """Can read a real xz file."""
         base_path = os.path.join(CURR_DIR, 'test_data/crime-and-punishment.txt')

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -33,16 +33,6 @@ SAMPLE_TEXT = 'Hello, world!'
 SAMPLE_BYTES = SAMPLE_TEXT.encode('utf-8')
 
 
-try:
-    if sys.version_info >= (3, 3):
-        import lzma
-    else:
-        from backports import lzma
-    XZ_SUPPORTED = True
-except ImportError:
-    XZ_SUPPORTED = False
-
-
 class ParseUriTest(unittest.TestCase):
     """
     Test ParseUri class.
@@ -266,7 +256,7 @@ class SmartOpenHttpTest(unittest.TestCase):
         smart_open_object = smart_open.smart_open(
             'http://127.0.0.1/data%s%s' % (suffix, '?some_param=some_val' if query else ''))
 
-        # decompress the xz and get the same md5 hash
+        # decompress the file and get the same md5 hash
         self.assertEqual(smart_open_object.read(), raw_data)
 
     @unittest.skipIf(six.PY2, 'gzip support for Py2 is not implemented yet')
@@ -278,13 +268,6 @@ class SmartOpenHttpTest(unittest.TestCase):
         """Can open bzip2 via http?"""
         self._test_compressed_http(".bz2", False)
 
-    @unittest.skipUnless(
-        XZ_SUPPORTED,
-        "do not test if backports.lzma not installed for python<3.3")
-    def test_http_xz(self):
-        """Can open xz via http?"""
-        self._test_compressed_http(".xz", False)
-
     @unittest.skipIf(six.PY2, 'gzip support for Py2 is not implemented yet')
     def test_http_gz_query(self):
         """Can open gzip via http with a query appended to URI?"""
@@ -293,13 +276,6 @@ class SmartOpenHttpTest(unittest.TestCase):
     def test_http_bz2_query(self):
         """Can open bzip2 via http with a query appended to URI?"""
         self._test_compressed_http(".bz2", True)
-
-    @unittest.skipUnless(
-        XZ_SUPPORTED,
-        "do not test if backports.lzma not installed for python<3.3")
-    def test_http_xz_query(self):
-        """Can open xz via http with a query appended to URI?"""
-        self._test_compressed_http(".xz", True)
 
 
 def make_buffer(cls=six.BytesIO, initial_value=None, name=None):
@@ -1029,26 +1005,6 @@ class CompressionFormatTest(unittest.TestCase):
     def test_write_read_bz2(self):
         """Can write and read bz2?"""
         self.write_read_assertion('.bz2')
-
-    @unittest.skipUnless(
-        XZ_SUPPORTED,
-        "do not test if backports.lzma not installed for python<3.3")
-    def test_write_read_xz(self):
-        """Can write and read xz2?"""
-        self.write_read_assertion('.xz')
-
-    @unittest.skipUnless(
-        XZ_SUPPORTED,
-        "do not test if backports.lzma not installed for python<3.3")
-    def test_read_real_xz(self):
-        """Can read a real xz file."""
-        base_path = os.path.join(CURR_DIR, 'test_data/crime-and-punishment.txt')
-        head_path = os.path.join(CURR_DIR, 'test_data/crime-and-punishment.txt.xz')
-        with smart_open.smart_open(head_path) as f:
-            smart_data = f.read()
-        with open(base_path, 'rb') as f:
-            orig_data = f.read()
-        self.assertEqual(smart_data, orig_data)
 
 
 class MultistreamsBZ2Test(unittest.TestCase):


### PR DESCRIPTION
xz decompression in Python<3.3 requires liblzma which won't be available on every machine. Move xz decompression option to optional dependency (`pip install smart_open[xz]`) instead of having install fail when liblzma isn't available.

