### PR TITLE
Improve S3 read performance by not copying buffer

### DIFF
--- a/smart_open/bytebuffer.py
+++ b/smart_open/bytebuffer.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""Implements a byte buffer that allows callers to read data with minimal
+copying, and has a fast __len__ method. The buffer is parametrized by its
+chunk_size, which is the number of bytes that it will read in from the supplied
+reader or iterable when the buffer is being filled. As primary use case for this
+buffer is to amortize the overhead costs of transferring data over the network
+(rather than capping memory consumption), it leads to more predictable
+performance to always read the same amount of bytes each time the buffer is
+filled, hence the chunk_size parameter instead of some fixed capacity.
+
+The bytes are stored in a bytestring, and previously-read bytes are freed when
+the buffer is next filled (by slicing the bytestring into a smaller copy)."""
+
+class ByteBuffer(object):
+    def __init__(self, chunk_size):
+        """The chunk_size indicates the number of bytes that will be read from
+        the supplied reader when filling the buffer. The buffer has no maximum
+        size."""
+        self._chunk_size = chunk_size
+        self.empty()
+
+    def __len__(self):
+        """Return the number of unread bytes in the buffer"""
+        return len(self._bytes) - self._pos
+
+    def read(self, size = -1):
+        """Read up to size bytes from the buffer while advancing the read
+        position, and then return the bytes. If size is negative, return all
+        unread bytes."""
+        part = self.peek(size)
+        self._pos += len(part)
+        return part
+
+    def peek(self, size = -1):
+        """Return up to the next size bytes from the buffer, without advancing
+        the read position. If size is negative, return all unread bytes."""
+        if size < 0 or size > len(self):
+            size = len(self)
+
+        part = self._bytes[self._pos : self._pos + size]
+        return part
+
+    def empty(self):
+        """Remove all bytes from the buffer"""
+        self._bytes = b''
+        self._pos = 0
+
+    def fill(self, reader_or_iterable, size = -1):
+        """Fill the buffer with bytes from `reader_or_iterable` until one of
+        these conditions is met:
+            * size bytes have been read from reader_or_iterable (if size >= 0);
+            * chunk_size bytes have been read from reader_or_iterable;
+            * no more bytes can be read from reader_or_iterable;
+        Return number of bytes added to the buffer.
+        Note: all previously-read bytes in the buffer are removed."""
+        size = size if size >= 0 else self._chunk_size
+        size = min(size, self._chunk_size)
+
+        if self._pos != 0:
+            self._bytes = self._bytes[self._pos:]
+            self._pos = 0
+
+        if hasattr(reader_or_iterable, 'read'):
+            new_bytes = reader_or_iterable.read(size)
+        else:
+            new_bytes = b''
+            while len(new_bytes) < size:
+                try:
+                    new_bytes += next(reader_or_iterable)
+                except StopIteration:
+                    break
+
+        self._bytes += new_bytes
+        return len(new_bytes)

--- a/smart_open/bytebuffer.py
+++ b/smart_open/bytebuffer.py
@@ -17,7 +17,35 @@ class ByteBuffer(object):
 
     The bytes are stored in a bytestring, and previously-read bytes are freed
     when the buffer is next filled (by slicing the bytestring into a smaller
-    copy)."""
+    copy).
+
+    Example
+    -------
+
+    Note that while this example works in both Python 2 and 3, the doctest only
+    passes in Python 3 due to the bytestring literals in the expected values.
+
+    >>> buf = ByteBuffer(chunk_size = 8)
+    >>> message_bytes = iter([b'Hello, W', b'orld!'])
+    >>> buf.fill(message_bytes)
+    8
+    >>> len(buf) # only chunk_size bytes are filled
+    8
+    >>> buf.peek()
+    b'Hello, W'
+    >>> len(buf) # peek() does not change read position
+    8
+    >>> buf.read(6)
+    b'Hello,'
+    >>> len(buf) # read() does change read position
+    2
+    >>> buf.fill(message_bytes)
+    5
+    >>> buf.read()
+    b' World!'
+    >>> len(buf)
+    0
+    """
 
     def __init__(self, chunk_size=io.DEFAULT_BUFFER_SIZE):
         """Create a ByteBuffer instance that reads chunk_size bytes when filled.

--- a/smart_open/bytebuffer.py
+++ b/smart_open/bytebuffer.py
@@ -1,42 +1,73 @@
 # -*- coding: utf-8 -*-
-"""Implements a byte buffer that allows callers to read data with minimal
-copying, and has a fast __len__ method. The buffer is parametrized by its
-chunk_size, which is the number of bytes that it will read in from the supplied
-reader or iterable when the buffer is being filled. As primary use case for this
-buffer is to amortize the overhead costs of transferring data over the network
-(rather than capping memory consumption), it leads to more predictable
-performance to always read the same amount of bytes each time the buffer is
-filled, hence the chunk_size parameter instead of some fixed capacity.
-
-The bytes are stored in a bytestring, and previously-read bytes are freed when
-the buffer is next filled (by slicing the bytestring into a smaller copy)."""
+"""Implements ByteBuffer class for amortizing network transfer overhead."""
 
 import io
 
 
 class ByteBuffer(object):
+    """Implements a byte buffer that allows callers to read data with minimal
+    copying, and has a fast __len__ method. The buffer is parametrized by its
+    chunk_size, which is the number of bytes that it will read in from the
+    supplied reader or iterable when the buffer is being filled. As primary use
+    case for this buffer is to amortize the overhead costs of transferring data
+    over the network (rather than capping memory consumption), it leads to more
+    predictable performance to always read the same amount of bytes each time
+    the buffer is filled, hence the chunk_size parameter instead of some fixed
+    capacity.
+
+    The bytes are stored in a bytestring, and previously-read bytes are freed
+    when the buffer is next filled (by slicing the bytestring into a smaller
+    copy)."""
+
     def __init__(self, chunk_size=io.DEFAULT_BUFFER_SIZE):
-        """The chunk_size indicates the number of bytes that will be read from
-        the supplied reader when filling the buffer. The buffer has no maximum
-        size."""
+        """Create a ByteBuffer instance that reads chunk_size bytes when filled.
+        Note that the buffer has no maximum size.
+
+        Parameters
+        -----------
+        chunk_size: int, optional
+            The the number of bytes that will be read from the supplied reader
+            or iterable when filling the buffer.
+        """
         self._chunk_size = chunk_size
         self.empty()
 
     def __len__(self):
-        """Return the number of unread bytes in the buffer"""
+        """Return the number of unread bytes in the buffer as an int"""
         return len(self._bytes) - self._pos
 
     def read(self, size = -1):
-        """Read up to size bytes from the buffer while advancing the read
-        position, and then return the bytes. If size is negative, return all
-        unread bytes."""
+        """Read bytes from the buffer and advance the read position. Returns
+        the bytes in a bytestring.
+
+        Parameters
+        ----------
+        size: int, optional
+            Maximum number of bytes to read. If negative or not supplied, read
+            all unread bytes in the buffer.
+
+        Returns
+        -------
+        bytes
+        """
         part = self.peek(size)
         self._pos += len(part)
         return part
 
     def peek(self, size = -1):
-        """Return up to the next size bytes from the buffer, without advancing
-        the read position. If size is negative, return all unread bytes."""
+        """Get bytes from the buffer without advancing the read position.
+        Returns the bytes in a bytestring.
+
+        Parameters
+        ----------
+        size: int, optional
+            Maximum number of bytes to return. If negative or not supplied,
+            return all unread bytes in the buffer.
+
+        Returns
+        -------
+        bytes
+        """
         if size < 0 or size > len(self):
             size = len(self)
 
@@ -49,13 +80,32 @@ class ByteBuffer(object):
         self._pos = 0
 
     def fill(self, reader_or_iterable, size = -1):
-        """Fill the buffer with bytes from `reader_or_iterable` until one of
-        these conditions is met:
+        """Fill the buffer with bytes from reader_or_iterable until one of these
+        conditions is met:
             * size bytes have been read from reader_or_iterable (if size >= 0);
             * chunk_size bytes have been read from reader_or_iterable;
             * no more bytes can be read from reader_or_iterable;
-        Return number of bytes added to the buffer.
-        Note: all previously-read bytes in the buffer are removed."""
+        Returns the number of new bytes added to the buffer.
+        Note: all previously-read bytes in the buffer are removed.
+
+        Parameters
+        ----------
+        reader_or_iterable: a file-like object, or iterable that contains bytes
+            The source of bytes to fill the buffer with. If this argument has
+            the `read` attribute, it's assumed to be a file-like object and
+            `read` is called to get the bytes; otherwise it's assumed to be an
+            iterable that contains bytes, and `next` is used to get them.
+        size: int, optional
+            The number of bytes to try to read from reader_or_iterable. If not
+            supplied, negative, or larger than the buffer's chunk_size, then
+            chunk_size bytes are read. Note that if reader_or_iterable is an
+            iterable, then it's possible that more bytes will be read if the
+            iterable produces more than one byte on each `next` call.
+
+        Returns
+        -------
+        int, the number of new bytes added to the buffer.
+        """
         size = size if size >= 0 else self._chunk_size
         size = min(size, self._chunk_size)
 

--- a/smart_open/bytebuffer.py
+++ b/smart_open/bytebuffer.py
@@ -11,8 +11,11 @@ filled, hence the chunk_size parameter instead of some fixed capacity.
 The bytes are stored in a bytestring, and previously-read bytes are freed when
 the buffer is next filled (by slicing the bytestring into a smaller copy)."""
 
+import io
+
+
 class ByteBuffer(object):
-    def __init__(self, chunk_size):
+    def __init__(self, chunk_size=io.DEFAULT_BUFFER_SIZE):
         """The chunk_size indicates the number of bytes that will be read from
         the supplied reader when filling the buffer. The buffer has no maximum
         size."""

--- a/smart_open/bytebuffer.py
+++ b/smart_open/bytebuffer.py
@@ -36,7 +36,7 @@ class ByteBuffer(object):
         """Return the number of unread bytes in the buffer as an int"""
         return len(self._bytes) - self._pos
 
-    def read(self, size = -1):
+    def read(self, size=-1):
         """Read bytes from the buffer and advance the read position. Returns
         the bytes in a bytestring.
 
@@ -54,7 +54,7 @@ class ByteBuffer(object):
         self._pos += len(part)
         return part
 
-    def peek(self, size = -1):
+    def peek(self, size=-1):
         """Get bytes from the buffer without advancing the read position.
         Returns the bytes in a bytestring.
 
@@ -71,7 +71,7 @@ class ByteBuffer(object):
         if size < 0 or size > len(self):
             size = len(self)
 
-        part = self._bytes[self._pos : self._pos + size]
+        part = self._bytes[self._pos:self._pos+size]
         return part
 
     def empty(self):
@@ -79,7 +79,7 @@ class ByteBuffer(object):
         self._bytes = b''
         self._pos = 0
 
-    def fill(self, source, size = -1):
+    def fill(self, source, size=-1):
         """Fill the buffer with bytes from source until one of these
         conditions is met:
             * size bytes have been read from source (if size >= 0);

--- a/smart_open/http.py
+++ b/smart_open/http.py
@@ -6,7 +6,7 @@ import logging
 
 import requests
 
-from smart_open import s3
+from smart_open import bytebuffer, s3
 
 DEFAULT_BUFFER_SIZE = 128 * 1024
 
@@ -70,7 +70,7 @@ class BufferedInputBase(io.BufferedIOBase):
             self.response.raise_for_status()
 
         self._read_iter = self.response.iter_content(self.buffer_size)
-        self._read_buffer = b''
+        self._read_buffer = bytebuffer.ByteBuffer(buffer_size)
         self._current_pos = 0
 
         #
@@ -111,28 +111,24 @@ class BufferedInputBase(io.BufferedIOBase):
 
         if size == 0:
             return b''
-        elif size < 0 and not self._read_buffer:
+        elif size < 0 and len(self._read_buffer) == 0:
             retval = self.response.raw.read()
         elif size < 0:
-            retval = self._read_buffer + self.response.raw.read()
-            self._read_buffer = b''
+            retval = self._read_buffer.read() + self.response.raw.read()
         else:
             while len(self._read_buffer) < size:
                 logger.debug("http reading more content at current_pos: %d with size: %d", self._current_pos, size)
-                try:
-                    self._read_buffer += next(self._read_iter)
-                except StopIteration:
+                bytes_read = self._read_buffer.fill(self._read_iter)
+                if bytes_read == 0:
                     # Oops, ran out of data early.
-                    retval = self._read_buffer
+                    retval = self._read_buffer.read()
                     self._current_pos += len(retval)
-                    self._read_buffer = b''
 
                     return retval
 
             # If we got here, it means we have enough data in the buffer
             # to return to the caller.
-            retval = self._read_buffer[:size]
-            self._read_buffer = self._read_buffer[size:]
+            retval = self._read_buffer.read(size)
 
         self._current_pos += len(retval)
         return retval
@@ -193,7 +189,7 @@ class SeekableBufferedInputBase(BufferedInputBase):
             self._seekable = False
 
         self._read_iter = self.response.iter_content(self.buffer_size)
-        self._read_buffer = b''
+        self._read_buffer = bytebuffer.ByteBuffer(buffer_size)
         self._current_pos = 0
 
         #
@@ -234,13 +230,13 @@ class SeekableBufferedInputBase(BufferedInputBase):
         if new_pos == self.content_length:
             self.response = None
             self._read_iter = None
-            self._read_buffer = b''
+            self._read_buffer.empty()
         else:
             response = self._partial_request(new_pos)
             if response.ok:
                 self.response = response
                 self._read_iter = self.response.iter_content(self.buffer_size)
-                self._read_buffer = b''
+                self._read_buffer.empty()
             else:
                 self.response = None
 

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -296,14 +296,14 @@ class BufferedInputBase(io.BufferedIOBase):
     def _read_from_buffer(self, size = -1):
         """Remove at most size bytes from our buffer and return them."""
         # logger.debug('reading %r bytes from %r byte-long buffer', size, len(self._buffer))
-        size = size if size > 0 else len(self._buffer)
+        size = size if size >= 0 else len(self._buffer)
         part = self._buffer.read(size)
         self._current_pos += len(part)
         # logger.debug('part: %r', part)
         return part
 
     def _fill_buffer(self, size = -1):
-        size = size if size > 0 else self._buffer._chunk_size
+        size = size if size >= 0 else self._buffer._chunk_size
         while len(self._buffer) < size and not self._eof:
             bytes_read = self._buffer.fill(self._raw_reader)
             if bytes_read == 0:

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -271,7 +271,7 @@ class BufferedInputBase(io.BufferedIOBase):
         while not (self._eof and len(self._buffer) == 0):
             #
             # In the worst case, we're reading the unread part of self._buffer
-            # twice here, once in the if condition, and once when calling index.
+            # twice here, once in the if condition and once when calling index.
             #
             # This is sub-optimal, but better than the alternative: wrapping
             # .index in a try..except, because that is slower.
@@ -293,7 +293,7 @@ class BufferedInputBase(io.BufferedIOBase):
     #
     # Internal methods.
     #
-    def _read_from_buffer(self, size = -1):
+    def _read_from_buffer(self, size=-1):
         """Remove at most size bytes from our buffer and return them."""
         # logger.debug('reading %r bytes from %r byte-long buffer', size, len(self._buffer))
         size = size if size >= 0 else len(self._buffer)
@@ -302,13 +302,14 @@ class BufferedInputBase(io.BufferedIOBase):
         # logger.debug('part: %r', part)
         return part
 
-    def _fill_buffer(self, size = -1):
+    def _fill_buffer(self, size=-1):
         size = size if size >= 0 else self._buffer._chunk_size
         while len(self._buffer) < size and not self._eof:
             bytes_read = self._buffer.fill(self._raw_reader)
             if bytes_read == 0:
                 logger.debug('reached EOF while filling buffer')
                 self._eof = True
+
 
 class SeekableBufferedInputBase(BufferedInputBase):
     """Reads bytes from S3.

--- a/smart_open/tests/test_bytebuffer.py
+++ b/smart_open/tests/test_bytebuffer.py
@@ -57,6 +57,16 @@ class ByteBufferTest(unittest.TestCase):
         self.assertEqual(len(buf), CHUNK_SIZE)
         self.assertEqual(buf._bytes, contents)
 
+    def test_fill_from_list(self):
+        buf = smart_open.bytebuffer.ByteBuffer(CHUNK_SIZE)
+        contents = random_byte_string(CHUNK_SIZE)
+        contents_list = [contents[i:i+7] for i in range(0, CHUNK_SIZE, 7)]
+
+        bytes_filled = buf.fill(contents_list)
+        self.assertEqual(bytes_filled, CHUNK_SIZE)
+        self.assertEqual(len(buf), CHUNK_SIZE)
+        self.assertEqual(buf._bytes, contents)
+
     def test_fill_multiple(self):
         buf = smart_open.bytebuffer.ByteBuffer(CHUNK_SIZE)
         long_contents = random_byte_string(CHUNK_SIZE * 4)

--- a/smart_open/tests/test_bytebuffer.py
+++ b/smart_open/tests/test_bytebuffer.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+import random
+import unittest
+
+import six
+
+import smart_open.bytebuffer
+
+
+CHUNK_SIZE = 1024
+
+
+def random_byte_string(length = CHUNK_SIZE):
+    rand_bytes = [six.int2byte(random.randint(0, 255)) for _ in range(length)]
+    return b''.join(rand_bytes)
+
+
+def bytebuffer_and_random_contents():
+    buf = smart_open.bytebuffer.ByteBuffer(CHUNK_SIZE)
+    contents = random_byte_string(CHUNK_SIZE)
+    content_reader = six.BytesIO(contents)
+    buf.fill(content_reader)
+
+    return [buf, contents]
+
+
+class ByteBufferTest(unittest.TestCase):
+    def test_len(self):
+        buf = smart_open.bytebuffer.ByteBuffer(CHUNK_SIZE)
+        self.assertEqual(len(buf), 0)
+
+        contents = b'foo bar baz'
+        buf._bytes = contents
+        self.assertEqual(len(buf), len(contents))
+
+        pos = 4
+        buf._pos = pos
+        self.assertEqual(len(buf), len(contents) - pos)
+
+    def test_fill_from_reader(self):
+        buf = smart_open.bytebuffer.ByteBuffer(CHUNK_SIZE)
+        contents = random_byte_string(CHUNK_SIZE)
+        content_reader = six.BytesIO(contents)
+
+        bytes_filled = buf.fill(content_reader)
+        self.assertEqual(bytes_filled, CHUNK_SIZE)
+        self.assertEqual(len(buf), CHUNK_SIZE)
+        self.assertEqual(buf._bytes, contents)
+
+    def test_fill_from_iterable(self):
+        buf = smart_open.bytebuffer.ByteBuffer(CHUNK_SIZE)
+        contents = random_byte_string(CHUNK_SIZE)
+        contents_iter = (contents[i:i+8] for i in range(0, CHUNK_SIZE, 8))
+
+        bytes_filled = buf.fill(contents_iter)
+        self.assertEqual(bytes_filled, CHUNK_SIZE)
+        self.assertEqual(len(buf), CHUNK_SIZE)
+        self.assertEqual(buf._bytes, contents)
+
+    def test_fill_multiple(self):
+        buf = smart_open.bytebuffer.ByteBuffer(CHUNK_SIZE)
+        long_contents = random_byte_string(CHUNK_SIZE * 4)
+        long_content_reader = six.BytesIO(long_contents)
+
+        first_bytes_filled = buf.fill(long_content_reader)
+        self.assertEqual(first_bytes_filled, CHUNK_SIZE)
+
+        second_bytes_filled = buf.fill(long_content_reader)
+        self.assertEqual(second_bytes_filled, CHUNK_SIZE)
+        self.assertEqual(len(buf), 2 * CHUNK_SIZE)
+
+    def test_fill_size(self):
+        buf = smart_open.bytebuffer.ByteBuffer(CHUNK_SIZE)
+        contents = random_byte_string(CHUNK_SIZE * 2)
+        content_reader = six.BytesIO(contents)
+        fill_size = int(CHUNK_SIZE / 2)
+
+        bytes_filled = buf.fill(content_reader, size = fill_size)
+
+        self.assertEqual(bytes_filled, fill_size)
+        self.assertEqual(len(buf), fill_size)
+
+        second_bytes_filled = buf.fill(content_reader, size = CHUNK_SIZE + 1)
+        self.assertEqual(second_bytes_filled, CHUNK_SIZE)
+        self.assertEqual(len(buf), fill_size + CHUNK_SIZE)
+
+    def test_fill_reader_exhaustion(self):
+        buf = smart_open.bytebuffer.ByteBuffer(CHUNK_SIZE)
+        short_content_size = int(CHUNK_SIZE / 4)
+        short_contents = random_byte_string(short_content_size)
+        short_content_reader = six.BytesIO(short_contents)
+
+        bytes_filled = buf.fill(short_content_reader)
+        self.assertEqual(bytes_filled, short_content_size)
+        self.assertEqual(len(buf), short_content_size)
+
+    def test_fill_iterable_exhaustion(self):
+        buf = smart_open.bytebuffer.ByteBuffer(CHUNK_SIZE)
+        short_content_size = int(CHUNK_SIZE / 4)
+        short_contents = random_byte_string(short_content_size)
+        short_contents_iter = (short_contents[i:i+8]
+                               for i in range(0, short_content_size, 8))
+
+        bytes_filled = buf.fill(short_contents_iter)
+        self.assertEqual(bytes_filled, short_content_size)
+        self.assertEqual(len(buf), short_content_size)
+
+    def test_empty(self):
+        buf, _ = bytebuffer_and_random_contents()
+
+        self.assertEqual(len(buf), CHUNK_SIZE)
+        buf.empty()
+        self.assertEqual(len(buf), 0)
+
+    def test_peek(self):
+        buf, contents = bytebuffer_and_random_contents()
+
+        self.assertEqual(buf.peek(), contents)
+        self.assertEqual(len(buf), CHUNK_SIZE)
+        self.assertEqual(buf.peek(64), contents[0:64])
+        self.assertEqual(buf.peek(CHUNK_SIZE * 10), contents)
+
+    def test_read(self):
+        buf, contents = bytebuffer_and_random_contents()
+
+        self.assertEqual(buf.read(), contents)
+        self.assertEqual(len(buf), 0)
+        self.assertEqual(buf.read(), b'')
+
+    def test_read_size(self):
+        buf, contents = bytebuffer_and_random_contents()
+        read_size = 128
+
+        self.assertEqual(buf.read(read_size), contents[:read_size])
+        self.assertEqual(len(buf), CHUNK_SIZE - read_size)
+
+        self.assertEqual(buf.read(CHUNK_SIZE*2), contents[read_size:])
+        self.assertEqual(len(buf), 0)

--- a/smart_open/tests/test_bytebuffer.py
+++ b/smart_open/tests/test_bytebuffer.py
@@ -10,7 +10,7 @@ import smart_open.bytebuffer
 CHUNK_SIZE = 1024
 
 
-def random_byte_string(length = CHUNK_SIZE):
+def random_byte_string(length=CHUNK_SIZE):
     rand_bytes = [six.int2byte(random.randint(0, 255)) for _ in range(length)]
     return b''.join(rand_bytes)
 
@@ -85,12 +85,12 @@ class ByteBufferTest(unittest.TestCase):
         content_reader = six.BytesIO(contents)
         fill_size = int(CHUNK_SIZE / 2)
 
-        bytes_filled = buf.fill(content_reader, size = fill_size)
+        bytes_filled = buf.fill(content_reader, size=fill_size)
 
         self.assertEqual(bytes_filled, fill_size)
         self.assertEqual(len(buf), fill_size)
 
-        second_bytes_filled = buf.fill(content_reader, size = CHUNK_SIZE + 1)
+        second_bytes_filled = buf.fill(content_reader, size=CHUNK_SIZE+1)
         self.assertEqual(second_bytes_filled, CHUNK_SIZE)
         self.assertEqual(len(buf), fill_size + CHUNK_SIZE)
 


### PR DESCRIPTION
## Add ByteBuffer Class

This class encapsulates the buffer functionality implemented in
smart_open.s3.BufferedInputBase and in
smart_open.http.BufferedInputBase as a standalone class. It uses the
read implementation introduced to the S3 BufferedInputBase in the
previous commit, to minimize copying of the buffer.

Because the use case for these ByteBuffers is to amortize the network
transfer overhead costs of reading data from S3 or via HTTP, it's better
to read a consistent number of bytes when filling up the buffer to
consistently amortize that overhead cost, rather than filling the buffer
up to some a priori capacity. To that end, the ByteBuffer constructor
takes a `chunk_size` that sets the number of bytes to read when filling
the buffer, rather than a fixed buffer capacity (which could easily
lead to reading a different number of bytes from the reader if the
caller ever filled the buffer when it was not empty). However, the
caller can still ask for fewer than `chunk_size` bytes to be read during
filling using the fill method's `size` argument.

Change the BufferedInputBase class (and descendents) in both
smart_open.s3 and smart_open.http to use instances of ByteBuffer for
their read buffers, instead of bytestrings. This simplifies their
implementation, while still avoiding copying on reads to maintain the
94% performance improvement for many small reads on an S3 file
introduced in the first version of this PR.

### Initial, Now Discarded Implementation

Previously, the buffer of an S3 file opened in 'rb' mode was split into
two copies whenever its `read()` method was called: one copy was
returned to the caller, and the other copy became the new buffer. This
lead to bad performance when performing many small reads with the buffer
set to a large enough size to amortize the cost of transferring data
from S3.

In our use case, we set the buffer to 4 MiB when reading a 16.5 MiB file
containing 694k serialized protobuf messages, each prefixed by their
byte length. This required calling the S3 file's `read()` method nearly
1.4 million times, which in turn meant that the up-to-4MiB buffer needed
to be copied and garbage collected the same number of times. All of that
copying and garbage collecting alone took 152 seconds, for a total of
179 seconds to download and parse the file.

Eliminate the copying on each `read()` by adding an instance attribute
`_buffer_pos` to smart_open.s3's BufferedInputBase and its descendents,
in order to track the current position within the buffer. Change
`read()` to use `_buffer_pos` to create the slice of the buffer to
return to the caller, and then move `_buffer_pos` by the size of that
slice.

Add two new internal instance methods to BufferedInputBase to accomodate
the fact that the buffer now contains already-read data. The first,
`_len_remaining_buffer()`, calculates how many unread bytes remain in
the buffer (previously this was simply the length of the buffer); this
is now used everywhere that `len(self._buffer)` was previously used in
BufferedInputBase. The second method, `_remaining_buffer()`, returns
a copy of the unread portion of the buffer; this is used in
BufferedInputBase's `readline()` method to find the next unread newline.

With these changes, that same 16.5 MiB protobuf file with 694k messages
can be downloaded and parsed in 10 seconds, a 94% improvement in
performance!