### PR TITLE
feat: adding password option to ssh, scp and sftp

### DIFF
--- a/smart_open/helpers.py
+++ b/smart_open/helpers.py
@@ -1,0 +1,52 @@
+import inspect
+
+
+def inspect_kwargs(kallable):
+    #
+    # inspect.getargspec got deprecated in Py3.4, and calling it spews
+    # deprecation warnings that we'd prefer to avoid.  Unfortunately, older
+    # versions of Python (<3.3) did not have inspect.signature, so we need to
+    # handle them the old-fashioned getargspec way.
+    #
+    try:
+        signature = inspect.signature(kallable)
+    except AttributeError:
+        args, varargs, keywords, defaults = inspect.getargspec(kallable)
+        if not defaults:
+            return {}
+        supported_keywords = args[-len(defaults):]
+        return dict(zip(supported_keywords, defaults))
+    else:
+        return {
+            name: param.default
+            for name, param in signature.parameters.items()
+            if param.default != inspect.Parameter.empty
+        }
+
+
+def check_kwargs(kallable, kwargs, logger):
+    """Check which keyword arguments the callable supports.
+
+    Parameters
+    ----------
+    kallable: callable
+        A function or method to test
+    kwargs: dict
+        The keyword arguments to check.  If the callable doesn't support any
+        of these, a warning message will get printed.
+    logger: Logger
+        The logger to which warnings will be printed
+
+    Returns
+    -------
+    dict
+        A dictionary of argument names and values supported by the callable.
+    """
+    supported_keywords = sorted(inspect_kwargs(kallable))
+    unsupported_keywords = [k for k in sorted(kwargs) if k not in supported_keywords]
+    supported_kwargs = {k: v for (k, v) in kwargs.items() if k in supported_keywords}
+
+    if unsupported_keywords:
+        logger.warn('ignoring unsupported keyword arguments: %r', unsupported_keywords)
+
+    return supported_kwargs

--- a/smart_open/ssh.py
+++ b/smart_open/ssh.py
@@ -25,6 +25,8 @@ Similarly, from a command line::
 import getpass
 import logging
 
+from smart_open.helpers import check_kwargs
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -43,18 +45,26 @@ SCHEMES = ("ssh", "scp", "sftp")
 DEFAULT_PORT = 22
 
 
-def _connect(hostname, username, port, password):
+def _connect(hostname, username, port, password, transport_params):
     key = (hostname, username)
     ssh = _SSH.get(key)
     if ssh is None:
         ssh = _SSH[key] = paramiko.client.SSHClient()
         ssh.load_system_host_keys()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        ssh.connect(hostname, port, username, password)
+        kwargs = check_kwargs(ssh.connect, transport_params, logger)
+
+        if 'password' not in kwargs:
+            kwargs['password'] = password
+
+        if 'username' not in kwargs:
+            kwargs['username'] = username
+
+        ssh.connect(hostname, port, **kwargs)
     return ssh
 
 
-def open(path, mode='r', host=None, user=None, password=None, port=DEFAULT_PORT):
+def open(path, mode='r', host=None, user=None, password=None, port=DEFAULT_PORT, transport_params=None):
     """Open a file on a remote machine over SSH.
 
     Expects authentication to be already set up via existing keys on the local machine.
@@ -74,6 +84,8 @@ def open(path, mode='r', host=None, user=None, password=None, port=DEFAULT_PORT)
         The password to use to login to the remote machine.
     port: int, optional
         The port to connect to.
+    transport_params: dict, optional
+        Any additional settings to be passed to paramiko.SSHClient.connect
 
     Returns
     -------
@@ -84,11 +96,16 @@ def open(path, mode='r', host=None, user=None, password=None, port=DEFAULT_PORT)
     If you specify a previously unseen host, then its host key will be added to
     the local ~/.ssh/known_hosts *automatically*.
 
+    If `username` or `password` are specified in _both_ the uri and `transport_params`, `transport_params` will take
+    precedence
     """
     if not host:
         raise ValueError('you must specify the host to connect to')
     if not user:
         user = getpass.getuser()
-    conn = _connect(host, user, port, password)
+    if not transport_params:
+        transport_params = {}
+
+    conn = _connect(host, user, port, password, transport_params)
     sftp_client = conn.get_transport().open_sftp_client()
     return sftp_client.open(path, mode)

--- a/smart_open/ssh.py
+++ b/smart_open/ssh.py
@@ -43,18 +43,18 @@ SCHEMES = ("ssh", "scp", "sftp")
 DEFAULT_PORT = 22
 
 
-def _connect(hostname, username, port):
+def _connect(hostname, username, port, password):
     key = (hostname, username)
     ssh = _SSH.get(key)
     if ssh is None:
         ssh = _SSH[key] = paramiko.client.SSHClient()
         ssh.load_system_host_keys()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        ssh.connect(hostname, port, username)
+        ssh.connect(hostname, port, username, password)
     return ssh
 
 
-def open(path, mode='r', host=None, user=None, port=DEFAULT_PORT):
+def open(path, mode='r', host=None, user=None, password=None, port=DEFAULT_PORT):
     """Open a file on a remote machine over SSH.
 
     Expects authentication to be already set up via existing keys on the local machine.
@@ -70,6 +70,8 @@ def open(path, mode='r', host=None, user=None, port=DEFAULT_PORT):
     user: str, optional
         The username to use to login to the remote machine.
         If None, defaults to the name of the current user.
+    password: str, optional
+        The password to use to login to the remote machine.
     port: int, optional
         The port to connect to.
 
@@ -87,6 +89,6 @@ def open(path, mode='r', host=None, user=None, port=DEFAULT_PORT):
         raise ValueError('you must specify the host to connect to')
     if not user:
         user = getpass.getuser()
-    conn = _connect(host, user, port)
+    conn = _connect(host, user, port, password)
     sftp_client = conn.get_transport().open_sftp_client()
     return sftp_client.open(path, mode)

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -222,7 +222,8 @@ class SmartOpenHttpTest(unittest.TestCase):
     @mock.patch('smart_open.ssh.open')
     def test_read_ssh(self, mock_open):
         """Is SSH line iterator called correctly?"""
-        obj = smart_open.smart_open("ssh://ubuntu:pass@ip_address:1022/some/path/lines.txt")
+        obj = smart_open.smart_open("ssh://ubuntu:pass@ip_address:1022/some/path/lines.txt",
+                                    hello='world')
         obj.__iter__()
         mock_open.assert_called_with(
             '/some/path/lines.txt',
@@ -230,7 +231,8 @@ class SmartOpenHttpTest(unittest.TestCase):
             host='ip_address',
             user='ubuntu',
             password='pass',
-            port=1022
+            port=1022,
+            transport_params={'hello': 'world'}
         )
 
     @responses.activate
@@ -1188,7 +1190,7 @@ class S3OpenTest(unittest.TestCase):
             self.assertEqual(fin.read().decode("utf-8"), text)
 
     @mock_s3
-    @mock.patch('smart_open.smart_open_lib._inspect_kwargs', mock.Mock(return_value={}))
+    @mock.patch('smart_open.helpers.inspect_kwargs', mock.Mock(return_value={}))
     def test_gzip_write_mode(self):
         """Should always open in binary mode when writing through a codec."""
         s3 = boto3.resource('s3')
@@ -1200,7 +1202,7 @@ class S3OpenTest(unittest.TestCase):
             mock_open.assert_called_with('bucket', 'key.gz', 'wb')
 
     @mock_s3
-    @mock.patch('smart_open.smart_open_lib._inspect_kwargs', mock.Mock(return_value={}))
+    @mock.patch('smart_open.helpers.inspect_kwargs', mock.Mock(return_value={}))
     def test_gzip_read_mode(self):
         """Should always open in binary mode when reading through a codec."""
         s3 = boto3.resource('s3')


### PR DESCRIPTION
*Motivation*: I want to be able to access files on an sftp server that uses username / password for authentication.

This adds the ability to parse a url like `sftp://username:pwd@host:port/path`.