### PR TITLE
accept bytearray and memoryview as input to write in s3 submodule

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -473,8 +473,14 @@ multipart upload may fail")
 
         There's buffering happening under the covers, so this may not actually
         do any HTTP transfer right away."""
-        if not isinstance(b, six.binary_type):
-            raise TypeError("input must be a binary string, got: %r", b)
+        import sys
+        if sys.version_info < (2, 7):
+            binary_types = (six.binary_type, bytearray)
+        else:
+            binary_types = (six.binary_type, bytearray, memoryview)
+
+        if not isinstance(b, binary_types):
+            raise TypeError("input must be a buffer, got: %r", type(b))
 
         self._buf.write(b)
         self._total_bytes += len(b)

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -480,7 +480,7 @@ multipart upload may fail")
             binary_types = (six.binary_type, bytearray, memoryview)
 
         if not isinstance(b, binary_types):
-            raise TypeError("input must be a buffer, got: %r", type(b))
+            raise TypeError("input must be one of %r, got: %r" % (binary_types, type(b))
 
         self._buf.write(b)
         self._total_bytes += len(b)

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -10,6 +10,7 @@ import warnings
 import boto3
 import botocore.client
 import six
+import sys
 
 import smart_open.bytebuffer
 
@@ -34,6 +35,11 @@ READ_BINARY = 'rb'
 WRITE_BINARY = 'wb'
 MODES = (READ_BINARY, WRITE_BINARY)
 """Allowed I/O modes for working with S3."""
+
+_BINARY_TYPES = (six.binary_type, bytearray)
+"""Allowed binary buffer types for writing to the underlying S3 stream"""
+if sys.version_info >= (2, 7):
+    _BINARY_TYPES = (six.binary_type, bytearray, memoryview)
 
 BINARY_NEWLINE = b'\n'
 
@@ -473,14 +479,10 @@ multipart upload may fail")
 
         There's buffering happening under the covers, so this may not actually
         do any HTTP transfer right away."""
-        import sys
-        if sys.version_info < (2, 7):
-            binary_types = (six.binary_type, bytearray)
-        else:
-            binary_types = (six.binary_type, bytearray, memoryview)
 
-        if not isinstance(b, binary_types):
-            raise TypeError("input must be one of %r, got: %r" % (binary_types, type(b))
+        if not isinstance(b, _BINARY_TYPES):
+            raise TypeError(
+                "input must be one of %r, got: %r" % (_BINARY_TYPES, type(b)))
 
         self._buf.write(b)
         self._total_bytes += len(b)

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -64,7 +64,7 @@ class SeekableBufferedInputBaseTest(unittest.TestCase):
     def setUp(self):
         # lower the multipart upload size, to speed up these tests
         self.old_min_part_size = smart_open.s3.DEFAULT_MIN_PART_SIZE
-        smart_open.s3.DEFAULT_MIN_PART_SIZE = 5 * 1024 ** 2
+        smart_open.s3.DEFAULT_MIN_PART_SIZE = 5 * 1024**2
 
     def tearDown(self):
         smart_open.s3.DEFAULT_MIN_PART_SIZE = self.old_min_part_size
@@ -193,7 +193,7 @@ class SeekableBufferedInputBaseTest(unittest.TestCase):
 
         with smart_open.s3.SeekableBufferedInputBase(BUCKET_NAME, KEY_NAME) as fin:
             fin.readline()
-            self.assertEqual(fin.tell(), content.index(b'\n') + 1)
+            self.assertEqual(fin.tell(), content.index(b'\n')+1)
 
             fin.seek(0)
             actual = list(fin)

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -5,7 +5,6 @@ import logging
 import os
 import unittest
 import uuid
-from io import TextIOWrapper
 
 import boto.s3.bucket
 import boto3
@@ -323,23 +322,19 @@ class BufferedOutputBaseTest(unittest.TestCase):
 
     def test_buffered_writer_wrapper_works(self):
         """
-        Ensure that we can wrap a smart_open s3 stream in a subclass of
-        BufferedWriter. BufferedWriter passes a memoryview object to the
-        underlying stream in python >= 2.7
+        Ensure that we can wrap a smart_open s3 stream in a BufferedWriter, which
+        passes a memoryview object to the underlying stream in python >= 2.7
         """
-
-        class BufferedWriterSubclass(io.BufferedWriter):
-            pass
 
         create_bucket_and_key()
         expected = u'не думай о секундах свысока'
 
         with smart_open.s3.BufferedOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fout:
-            with BufferedWriterSubclass(fout) as sub_out:
+            with io.BufferedWriter(fout) as sub_out:
                 sub_out.write(expected.encode('utf-8'))
 
         with smart_open.smart_open("s3://{}/{}".format(BUCKET_NAME, WRITE_KEY_NAME)) as fin:
-            with TextIOWrapper(fin, encoding='utf-8') as text:
+            with io.TextIOWrapper(fin, encoding='utf-8') as text:
                 actual = text.read()
 
         self.assertEqual(expected, actual)


### PR DESCRIPTION
Hello, I'd like to add ability to handle memoryview objects.
https://docs.python.org/2/c-api/buffer.html
 
I encountered this when attempting to wrap a s3 stream in a io.BufferedWriter like this

```
class MD5BufferedWriter(io.BufferedWriter):
    def __init__(self, output_stream):
        super().__init__(output_stream)
        self.md5 = hashlib.md5()

    def digest(self):
        return self.md5.hexdigest()

    def write(self, b):
        self.md5.update(b)
        return super().write(b)

with MD5BufferedWriter(smart_open.open('s3://bucket/name', 'wb')) as bt:
       bt.write('a'.encode('utf-8'))
```