### PR TITLE
Dont list buckets in s3 tests

### DIFF
--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -34,29 +34,30 @@ def maybe_mock_s3(func):
         return moto.mock_s3(func)
 
 
-def cleanup_bucket(s3, delete_bucket=False):
-    bucket = s3.Bucket(BUCKET_NAME)
+@maybe_mock_s3
+def setUpModule():
+    global s3
+    s3 = boto3.resource('s3')
+    s3.create_bucket(Bucket=BUCKET_NAME)
+
+
+@maybe_mock_s3
+def tearDownModule():
     try:
-        for key in bucket.objects.all():
-            key.delete()
-
-        if delete_bucket:
-            bucket.delete()
-            return False
+        cleanup_bucket()
+        s3.Bucket(BUCKET_NAME).delete()
     except s3.meta.client.exceptions.NoSuchBucket:
-        return False
-
-    return True
+        pass
 
 
-def create_bucket_and_key(
-        bucket_name=BUCKET_NAME, key_name=KEY_NAME, contents=None,
-        num_attempts=12, sleep_time=5):
+def cleanup_bucket():
+    for key in s3.Bucket(BUCKET_NAME).objects.all():
+        key.delete()
+
+
+def put_to_bucket(contents, num_attempts=12, sleep_time=5):
     # fake (or not) connection, bucket and key
     logger.debug('%r', locals())
-    s3 = boto3.resource('s3')
-    mybucket = s3.create_bucket(Bucket=bucket_name)
-    cleanup_bucket(s3)
 
     #
     # In real life, it can take a few seconds for the bucket to become ready.
@@ -65,16 +66,23 @@ def create_bucket_and_key(
     #
     for attempt in range(num_attempts):
         try:
-            mybucket = s3.Bucket(bucket_name)
-            mykey = s3.Object(bucket_name, key_name)
-            if contents is not None:
-                mykey.put(Body=contents)
-            return mybucket, mykey
+            s3.Object(BUCKET_NAME, KEY_NAME).put(Body=contents)
+            return
         except botocore.exceptions.ClientError as err:
             logger.error('caught %r, retrying', err)
             time.sleep(sleep_time)
 
-    assert False, 'failed to create bucket %s after %d attempts' % (bucket_name, num_attempts)
+    assert False, 'failed to create bucket %s after %d attempts' % (BUCKET_NAME, num_attempts)
+
+
+def clean_and_populate_bucket(num_keys=10):
+    # fake (or not) connection, bucket and key
+    logger.debug('%r', locals())
+    cleanup_bucket()
+
+    for key_number in range(num_keys):
+        key_name = 'key_%d' % key_number
+        s3.Object(BUCKET_NAME, key_name).put(Body=str(key_number))
 
 
 def ignore_resource_warnings():
@@ -98,14 +106,12 @@ class SeekableBufferedInputBaseTest(unittest.TestCase):
 
     def tearDown(self):
         smart_open.s3.DEFAULT_MIN_PART_SIZE = self.old_min_part_size
-        s3 = boto3.resource('s3')
-        cleanup_bucket(s3, delete_bucket=True)
 
     def test_iter(self):
         """Are S3 files iterated over correctly?"""
         # a list of strings to test with
         expected = u"hello wořld\nhow are you?".encode('utf8')
-        create_bucket_and_key(contents=expected)
+        put_to_bucket(contents=expected)
 
         # connect to fake s3 and read from the fake key we filled above
         fin = smart_open.s3.SeekableBufferedInputBase(BUCKET_NAME, KEY_NAME)
@@ -115,7 +121,7 @@ class SeekableBufferedInputBaseTest(unittest.TestCase):
     def test_iter_context_manager(self):
         # same thing but using a context manager
         expected = u"hello wořld\nhow are you?".encode('utf8')
-        create_bucket_and_key(contents=expected)
+        put_to_bucket(contents=expected)
         with smart_open.s3.SeekableBufferedInputBase(BUCKET_NAME, KEY_NAME) as fin:
             output = [line.rstrip(b'\n') for line in fin]
             self.assertEqual(output, expected.split(b'\n'))
@@ -123,7 +129,7 @@ class SeekableBufferedInputBaseTest(unittest.TestCase):
     def test_read(self):
         """Are S3 files read correctly?"""
         content = u"hello wořld\nhow are you?".encode('utf8')
-        create_bucket_and_key(contents=content)
+        put_to_bucket(contents=content)
         logger.debug('content: %r len: %r', content, len(content))
 
         fin = smart_open.s3.SeekableBufferedInputBase(BUCKET_NAME, KEY_NAME)
@@ -134,7 +140,7 @@ class SeekableBufferedInputBaseTest(unittest.TestCase):
     def test_seek_beginning(self):
         """Does seeking to the beginning of S3 files work correctly?"""
         content = u"hello wořld\nhow are you?".encode('utf8')
-        create_bucket_and_key(contents=content)
+        put_to_bucket(contents=content)
 
         fin = smart_open.s3.SeekableBufferedInputBase(BUCKET_NAME, KEY_NAME)
         self.assertEqual(content[:6], fin.read(6))
@@ -149,7 +155,7 @@ class SeekableBufferedInputBaseTest(unittest.TestCase):
     def test_seek_start(self):
         """Does seeking from the start of S3 files work correctly?"""
         content = u"hello wořld\nhow are you?".encode('utf8')
-        create_bucket_and_key(contents=content)
+        put_to_bucket(contents=content)
 
         fin = smart_open.s3.SeekableBufferedInputBase(BUCKET_NAME, KEY_NAME)
         seek = fin.seek(6)
@@ -160,7 +166,7 @@ class SeekableBufferedInputBaseTest(unittest.TestCase):
     def test_seek_current(self):
         """Does seeking from the middle of S3 files work correctly?"""
         content = u"hello wořld\nhow are you?".encode('utf8')
-        create_bucket_and_key(contents=content)
+        put_to_bucket(contents=content)
 
         fin = smart_open.s3.SeekableBufferedInputBase(BUCKET_NAME, KEY_NAME)
         self.assertEqual(fin.read(5), b'hello')
@@ -171,7 +177,7 @@ class SeekableBufferedInputBaseTest(unittest.TestCase):
     def test_seek_end(self):
         """Does seeking from the end of S3 files work correctly?"""
         content = u"hello wořld\nhow are you?".encode('utf8')
-        create_bucket_and_key(contents=content)
+        put_to_bucket(contents=content)
 
         fin = smart_open.s3.SeekableBufferedInputBase(BUCKET_NAME, KEY_NAME)
         seek = fin.seek(-4, whence=smart_open.s3.END)
@@ -180,7 +186,7 @@ class SeekableBufferedInputBaseTest(unittest.TestCase):
 
     def test_detect_eof(self):
         content = u"hello wořld\nhow are you?".encode('utf8')
-        create_bucket_and_key(contents=content)
+        put_to_bucket(contents=content)
 
         fin = smart_open.s3.SeekableBufferedInputBase(BUCKET_NAME, KEY_NAME)
         fin.read()
@@ -195,7 +201,7 @@ class SeekableBufferedInputBaseTest(unittest.TestCase):
         buf.close = lambda: None  # keep buffer open so that we can .getvalue()
         with gzip.GzipFile(fileobj=buf, mode='w') as zipfile:
             zipfile.write(expected)
-        create_bucket_and_key(contents=buf.getvalue())
+        put_to_bucket(contents=buf.getvalue())
 
         #
         # Make sure we're reading things correctly.
@@ -219,7 +225,7 @@ class SeekableBufferedInputBaseTest(unittest.TestCase):
 
     def test_readline(self):
         content = b'englishman\nin\nnew\nyork\n'
-        create_bucket_and_key(contents=content)
+        put_to_bucket(contents=content)
 
         with smart_open.s3.SeekableBufferedInputBase(BUCKET_NAME, KEY_NAME) as fin:
             fin.readline()
@@ -234,7 +240,7 @@ class SeekableBufferedInputBaseTest(unittest.TestCase):
 
     def test_readline_tiny_buffer(self):
         content = b'englishman\nin\nnew\nyork\n'
-        create_bucket_and_key(contents=content)
+        put_to_bucket(contents=content)
 
         with smart_open.s3.BufferedInputBase(BUCKET_NAME, KEY_NAME, buffer_size=8) as fin:
             actual = list(fin)
@@ -244,7 +250,7 @@ class SeekableBufferedInputBaseTest(unittest.TestCase):
 
     def test_read0_does_not_return_data(self):
         content = b'englishman\nin\nnew\nyork\n'
-        create_bucket_and_key(contents=content)
+        put_to_bucket(contents=content)
 
         with smart_open.s3.BufferedInputBase(BUCKET_NAME, KEY_NAME) as fin:
             data = fin.read(0)
@@ -261,13 +267,8 @@ class BufferedOutputBaseTest(unittest.TestCase):
     def setUp(self):
         ignore_resource_warnings()
 
-    def tearDown(self):
-        s3 = boto3.resource('s3')
-        cleanup_bucket(s3, delete_bucket=True)
-
     def test_write_01(self):
         """Does writing into s3 work correctly?"""
-        create_bucket_and_key()
         test_string = u"žluťoučký koníček".encode('utf8')
 
         # write into key
@@ -281,8 +282,6 @@ class BufferedOutputBaseTest(unittest.TestCase):
 
     def test_write_01a(self):
         """Does s3 write fail on incorrect input?"""
-        create_bucket_and_key()
-
         try:
             with smart_open.s3.BufferedOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fin:
                 fin.write(None)
@@ -293,8 +292,6 @@ class BufferedOutputBaseTest(unittest.TestCase):
 
     def test_write_02(self):
         """Does s3 write unicode-utf8 conversion work?"""
-        create_bucket_and_key()
-
         smart_open_write = smart_open.s3.BufferedOutputBase(BUCKET_NAME, WRITE_KEY_NAME)
         smart_open_write.tell()
         logger.info("smart_open_write: %r", smart_open_write)
@@ -304,8 +301,6 @@ class BufferedOutputBaseTest(unittest.TestCase):
 
     def test_write_03(self):
         """Does s3 multipart chunking work correctly?"""
-        create_bucket_and_key()
-
         # write
         smart_open_write = smart_open.s3.BufferedOutputBase(
             BUCKET_NAME, WRITE_KEY_NAME, min_part_size=10
@@ -328,8 +323,6 @@ class BufferedOutputBaseTest(unittest.TestCase):
 
     def test_write_04(self):
         """Does writing no data cause key with an empty value to be created?"""
-        _ = create_bucket_and_key()
-
         smart_open_write = smart_open.s3.BufferedOutputBase(BUCKET_NAME, WRITE_KEY_NAME)
         with smart_open_write as fout:  # noqa
             pass
@@ -340,8 +333,6 @@ class BufferedOutputBaseTest(unittest.TestCase):
         self.assertEqual(output, [])
 
     def test_gzip(self):
-        create_bucket_and_key()
-
         expected = u'а не спеть ли мне песню... о любви'.encode('utf-8')
         with smart_open.s3.BufferedOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fout:
             with gzip.GzipFile(fileobj=fout, mode='w') as zipfile:
@@ -358,8 +349,6 @@ class BufferedOutputBaseTest(unittest.TestCase):
         Ensure that we can wrap a smart_open s3 stream in a BufferedWriter, which
         passes a memoryview object to the underlying stream in python >= 2.7
         """
-
-        create_bucket_and_key()
         expected = u'не думай о секундах свысока'
 
         with smart_open.s3.BufferedOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fout:
@@ -374,7 +363,7 @@ class BufferedOutputBaseTest(unittest.TestCase):
 
     def test_binary_iterator(self):
         expected = u"выйду ночью в поле с конём".encode('utf-8').split(b' ')
-        create_bucket_and_key(contents=b"\n".join(expected))
+        put_to_bucket(contents=b"\n".join(expected))
         with smart_open.s3.open(BUCKET_NAME, KEY_NAME, 'rb') as fin:
             actual = [line.rstrip() for line in fin]
         self.assertEqual(expected, actual)
@@ -391,8 +380,6 @@ class BufferedOutputBaseTest(unittest.TestCase):
                 fin.read()
 
     def test_double_close(self):
-        create_bucket_and_key()
-
         text = u'там за туманами, вечными, пьяными'.encode('utf-8')
         fout = smart_open.s3.open(BUCKET_NAME, 'key', 'wb')
         fout.write(text)
@@ -400,8 +387,6 @@ class BufferedOutputBaseTest(unittest.TestCase):
         fout.close()
 
     def test_flush_close(self):
-        create_bucket_and_key()
-
         text = u'там за туманами, вечными, пьяными'.encode('utf-8')
         fout = smart_open.s3.open(BUCKET_NAME, 'key', 'wb')
         fout.write(text)
@@ -425,26 +410,25 @@ class IterBucketTest(unittest.TestCase):
         ignore_resource_warnings()
 
     def test_iter_bucket(self):
-        populate_bucket()
+        clean_and_populate_bucket()
         results = list(smart_open.s3.iter_bucket(BUCKET_NAME))
         self.assertEqual(len(results), 10)
 
     def test_accepts_boto3_bucket(self):
-        populate_bucket()
-        s3 = boto3.resource('s3')
+        clean_and_populate_bucket()
         bucket = s3.Bucket(BUCKET_NAME)
         results = list(smart_open.s3.iter_bucket(bucket))
         self.assertEqual(len(results), 10)
 
     def test_accepts_boto_bucket(self):
-        populate_bucket()
+        clean_and_populate_bucket()
         bucket = boto.s3.bucket.Bucket(name=BUCKET_NAME)
         results = list(smart_open.s3.iter_bucket(bucket))
         self.assertEqual(len(results), 10)
 
     def test_list_bucket(self):
         num_keys = 10
-        populate_bucket()
+        clean_and_populate_bucket()
         keys = list(smart_open.s3._list_bucket(BUCKET_NAME))
         self.assertEqual(len(keys), num_keys)
 
@@ -453,7 +437,7 @@ class IterBucketTest(unittest.TestCase):
 
     def test_list_bucket_long(self):
         num_keys = 1010
-        populate_bucket(num_keys=num_keys)
+        clean_and_populate_bucket(num_keys=num_keys)
         keys = list(smart_open.s3._list_bucket(BUCKET_NAME))
         self.assertEqual(len(keys), num_keys)
 
@@ -462,7 +446,7 @@ class IterBucketTest(unittest.TestCase):
 
     def test_old(self):
         """Does s3_iter_bucket work correctly?"""
-        create_bucket_and_key()
+        cleanup_bucket()
 
         #
         # Use an old-school boto Bucket class for historical reasons.
@@ -514,7 +498,7 @@ class IterBucketSingleProcessTest(unittest.TestCase):
 
     def test(self):
         num_keys = 101
-        populate_bucket(num_keys=num_keys)
+        clean_and_populate_bucket(num_keys=num_keys)
         keys = list(smart_open.s3.iter_bucket(BUCKET_NAME))
         self.assertEqual(len(keys), num_keys)
 
@@ -529,14 +513,14 @@ class DownloadKeyTest(unittest.TestCase):
 
     def test_happy(self):
         contents = b'hello'
-        create_bucket_and_key(contents=contents)
+        put_to_bucket(contents=contents)
         expected = (KEY_NAME, contents)
         actual = smart_open.s3._download_key(KEY_NAME, bucket_name=BUCKET_NAME)
         self.assertEqual(expected, actual)
 
     def test_intermittent_error(self):
         contents = b'hello'
-        create_bucket_and_key(contents=contents)
+        put_to_bucket(contents=contents)
         expected = (KEY_NAME, contents)
         side_effect = [ARBITRARY_CLIENT_ERROR, ARBITRARY_CLIENT_ERROR, contents]
         with mock.patch('smart_open.s3._download_fileobj', side_effect=side_effect):
@@ -545,7 +529,7 @@ class DownloadKeyTest(unittest.TestCase):
 
     def test_persistent_error(self):
         contents = b'hello'
-        create_bucket_and_key(contents=contents)
+        put_to_bucket(contents=contents)
         side_effect = [ARBITRARY_CLIENT_ERROR, ARBITRARY_CLIENT_ERROR,
                        ARBITRARY_CLIENT_ERROR, ARBITRARY_CLIENT_ERROR]
         with mock.patch('smart_open.s3._download_fileobj', side_effect=side_effect):
@@ -554,7 +538,7 @@ class DownloadKeyTest(unittest.TestCase):
 
     def test_intermittent_error_retries(self):
         contents = b'hello'
-        create_bucket_and_key(contents=contents)
+        put_to_bucket(contents=contents)
         expected = (KEY_NAME, contents)
         side_effect = [ARBITRARY_CLIENT_ERROR, ARBITRARY_CLIENT_ERROR,
                        ARBITRARY_CLIENT_ERROR, ARBITRARY_CLIENT_ERROR, contents]
@@ -564,7 +548,7 @@ class DownloadKeyTest(unittest.TestCase):
 
     def test_propagates_other_exception(self):
         contents = b'hello'
-        create_bucket_and_key(contents=contents)
+        put_to_bucket(contents=contents)
         with mock.patch('smart_open.s3._download_fileobj', side_effect=ValueError):
             self.assertRaises(ValueError, smart_open.s3._download_key,
                               KEY_NAME, bucket_name=BUCKET_NAME)
@@ -577,7 +561,6 @@ class OpenTest(unittest.TestCase):
 
     def test_read_never_returns_none(self):
         """read should never return None."""
-        s3 = boto3.resource('s3')
         s3.create_bucket(Bucket=BUCKET_NAME)
 
         test_string = u"ветер по морю гуляет..."
@@ -588,22 +571,6 @@ class OpenTest(unittest.TestCase):
         self.assertEqual(r.read(), test_string.encode("utf-8"))
         self.assertEqual(r.read(), b"")
         self.assertEqual(r.read(), b"")
-
-
-def populate_bucket(bucket_name=BUCKET_NAME, num_keys=10):
-    # fake (or not) connection, bucket and key
-    logger.debug('%r', locals())
-    s3 = boto3.resource('s3')
-    bucket_exist = cleanup_bucket(s3)
-
-    if not bucket_exist:
-        mybucket = s3.create_bucket(Bucket=bucket_name)
-
-    mybucket = s3.Bucket(bucket_name)
-
-    for key_number in range(num_keys):
-        key_name = 'key_%d' % key_number
-        s3.Object(bucket_name, key_name).put(Body=str(key_number))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
While working on a previous PR I stubbed my toe on AWS permissions.  The tests needed to be able to list all of the bucket names in my account but I'm not comfortable giving those permissions to Travis so I modified the cleanup_bucket() method to directly delete the bucket instead of listing each bucket to decide whether to delete it or not.

After I made that change I noticed that I was getting more test failures due to race conditions - tests expecting the test bucket to be there when it wasn't or vice versa. To make this happen less often I changed the suite so it creates the test bucket before the tests run and deletes it afterward instead of create/delete per test. This is more stable and saves 20-30s in the s3 tests when running without mocks.
