### PR TITLE
Optimize reading from S3

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -147,12 +147,9 @@ class RawReader(object):
 class SeekableRawReader(object):
     """Read an S3 object."""
 
-    def __init__(self, s3_object):
+    def __init__(self, s3_object, content_length):
         self._object = s3_object
-        try:
-            self._content_length = self._object.content_length
-        except botocore.client.ClientError:
-            raise ValueError('the s3 key %r does not exist, or is forbidden for access' % s3_object.key)
+        self._content_length = content_length
         self.seek(0)
 
     def seek(self, position):
@@ -339,8 +336,8 @@ class SeekableBufferedInputBase(BufferedInputBase):
             resource_kwargs = {}
         s3 = session.resource('s3', **resource_kwargs)
         self._object = s3.Object(bucket, key)
-        self._raw_reader = SeekableRawReader(self._object)
         self._content_length = self._object.content_length
+        self._raw_reader = SeekableRawReader(self._object, self._content_length)
         self._current_pos = 0
         self._buffer = smart_open.bytebuffer.ByteBuffer(buffer_size)
         self._eof = False

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -386,6 +386,8 @@ class BufferedOutputBaseTest(unittest.TestCase):
                 fout.write(expected)
 
     def test_read_nonexisting_key(self):
+        create_bucket_and_key()
+
         with self.assertRaises(ValueError):
             with smart_open.s3.open(BUCKET_NAME, 'my_nonexisting_key', 'rb') as fin:
                 fin.read()


### PR DESCRIPTION
Fixes #317. Looks like content_length wasn't being cached in boto3.

With the updated code:

```python
import sys

import boto3
import smart_open


def old_code(bucket, key, connection_params):
    s3 = boto3.resource('s3', **connection_params)
    obj = s3.Object(bucket, key)
    return obj.get(Range='bytes=0-')['Body'].read(100)


def new_code(bucket, key, connection_params):
    f = smart_open.open(
        f's3://{bucket}/{key}',
        mode='rb',
        transport_params={'session': boto3.Session(**connection_params)},
    )
    return f.read(100)


def main():
    function_name, bucket, key = sys.argv[1:4]
    function = globals()[function_name]

    connection_params = {}
    data = function(bucket, key, connection_params)
    print(len(data))


if __name__ == '__main__':
    main()
```

```
(smart_open) misha@cabron:~/git/smart_open$ time python bug.py old_code bucket key
100

real    0m1.050s
user    0m0.274s
sys     0m0.041s
(smart_open) misha@cabron:~/git/smart_open$ time python bug.py new_code bucket key
100

real    0m1.275s
user    0m0.354s
sys     0m0.029s
```

We're now around 1.3 times slower than using boto3. I suspect that this is a start-up cost only, so as we read larger files, it will amortize.