### PR TITLE
Fix merge artifact

### DIFF
--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -382,8 +382,6 @@ class BufferedOutputBaseTest(unittest.TestCase):
                 fout.write(expected)
 
     def test_read_nonexisting_key(self):
-        create_bucket_and_key()
-
         with self.assertRaises(ValueError):
             with smart_open.s3.open(BUCKET_NAME, 'my_nonexisting_key', 'rb') as fin:
                 fin.read()


### PR DESCRIPTION
Two separate PRs were touching the same code. [1] modified the bucket
handling to perform it at module load time. In the meanwhile, [2] fixed
a broken test by relying on functionality that wasn't around after [1]
got merged.

[1] https://github.com/RaRe-Technologies/smart_open/pull/318
[2] https://github.com/RaRe-Technologies/smart_open/pull/322