### PR TITLE
smart_open/s3: Initial implementations of str and repr

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -412,6 +412,14 @@ class SeekableBufferedInputBase(BufferedInputBase):
         """Unsupported."""
         raise io.UnsupportedOperation
 
+    def __str__(self):
+        return "s3.SeekableBufferedInputBase(bucket_name='{}', key='{}')".format(
+            self._object.bucket_name, self._object.key)
+
+    def __repr__(self):
+        return "s3.SeekableBufferedInputBase(bucket_name='{}', key='{}')".format(
+            self._object.bucket_name, self._object.key)
+
 
 class BufferedOutputBase(io.BufferedIOBase):
     """Writes bytes to S3.
@@ -553,6 +561,13 @@ multipart upload may fail")
         else:
             self.close()
 
+    def __str__(self):
+        return "s3.BufferedOutputBase(bucket_name='{}', key='{}')".format(
+            self._object.bucket_name, self._object.key)
+
+    def __repr__(self):
+        return "s3.BufferedOutputBase(bucket_name='{}', key='{}')".format(
+            self._object.bucket_name, self._object.key)
 
 def iter_bucket(bucket_name, prefix='', accept_key=None,
                 key_limit=None, workers=16, retries=3):

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -424,7 +424,7 @@ class SeekableBufferedInputBase(BufferedInputBase):
             "bucket_name=%r, "
             "key=%r, "
             "version_id=%r, "
-            "line_terminator=%r, "
+            "line_terminator=%r)"
         ) % (
             self._object.bucket_name,
             self._object.key,

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -352,6 +352,11 @@ class SeekableBufferedInputBase(BufferedInputBase):
 
     def __init__(self, bucket, key, version_id=None, buffer_size=DEFAULT_BUFFER_SIZE,
                  line_terminator=BINARY_NEWLINE, session=None, resource_kwargs=None):
+
+        self._buffer_size = buffer_size
+        self._session = session
+        self._resource_kwargs = resource_kwargs
+
         if session is None:
             session = boto3.Session()
         if resource_kwargs is None:
@@ -413,23 +418,26 @@ class SeekableBufferedInputBase(BufferedInputBase):
         raise io.UnsupportedOperation
 
     def __str__(self):
-        return "smart_open.s3.SeekableBufferedInputBase(%r, %r)" % (
-            self._object.bucket_name,
-            self._object.key
-        )
+        return "smart_open.s3.SeekableBufferedInputBase(%r, %r)" % (self._object.bucket_name, self._object.key)
 
     def __repr__(self):
         return (
             "smart_open.s3.SeekableBufferedInputBase("
-            "bucket_name=%r, "
+            "bucket=%r, "
             "key=%r, "
             "version_id=%r, "
-            "line_terminator=%r)"
+            "buffer_size=%r, "
+            "line_terminator=%r, "
+            "session=%r, "
+            "resource_kwargs=%r)"
         ) % (
             self._object.bucket_name,
             self._object.key,
             self._version_id,
+            self._buffer_size,
             self._line_terminator,
+            self._session,
+            self._resource_kwargs
         )
 
 
@@ -447,6 +455,11 @@ class BufferedOutputBase(io.BufferedIOBase):
             resource_kwargs=None,
             multipart_upload_kwargs=None,
             ):
+
+        self._session = session
+        self._resource_kwargs = resource_kwargs
+        self._multipart_upload_kwargs = multipart_upload_kwargs
+
         if min_part_size < MIN_MIN_PART_SIZE:
             logger.warning("S3 requires minimum part size >= 5MB; \
 multipart upload may fail")
@@ -470,6 +483,7 @@ multipart upload may fail")
         self._total_bytes = 0
         self._total_parts = 0
         self._parts = []
+
 
         #
         # This member is part of the io.BufferedIOBase interface.
@@ -574,21 +588,24 @@ multipart upload may fail")
             self.close()
 
     def __str__(self):
-        return "smart_open.s3.BufferedOutputBase(%r, %r)" % (
-            self._object.bucket_name,
-            self._object.key
-        )
+        return "smart_open.s3.BufferedOutputBase(%r, %r)" % (self._object.bucket_name, self._object.key)
 
     def __repr__(self):
         return (
             "smart_open.s3.BufferedOutputBase("
-            "bucket_name=%r, "
+            "bucket=%r, "
             "key=%r, "
-            "min_part_size=%r)"
+            "min_part_size=%r, "
+            "session=%r, "
+            "resource_kwargs=%r, "
+            "multipart_upload_kwargs=%r)"
         ) % (
             self._object.bucket_name,
             self._object.key,
             self._min_part_size,
+            self._session,
+            self._resource_kwargs,
+            self._multipart_upload_kwargs
         )
 
 

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -437,7 +437,7 @@ class SeekableBufferedInputBase(BufferedInputBase):
             self._buffer_size,
             self._line_terminator,
             self._session,
-            self._resource_kwargs
+            self._resource_kwargs,
         )
 
 
@@ -605,7 +605,7 @@ multipart upload may fail")
             self._min_part_size,
             self._session,
             self._resource_kwargs,
-            self._multipart_upload_kwargs
+            self._multipart_upload_kwargs,
         )
 
 

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -413,12 +413,24 @@ class SeekableBufferedInputBase(BufferedInputBase):
         raise io.UnsupportedOperation
 
     def __str__(self):
-        return "s3.SeekableBufferedInputBase(bucket_name='{}', key='{}')".format(
-            self._object.bucket_name, self._object.key)
+        return ("smart_open.s3.SeekableBufferedInputBase(%r, %r)") % (
+            self._object.bucket_name,
+            self._object.key
+        )
 
     def __repr__(self):
-        return "s3.SeekableBufferedInputBase(bucket_name='{}', key='{}')".format(
-            self._object.bucket_name, self._object.key)
+        return (
+            "smart_open.s3.SeekableBufferedInputBase("
+            "bucket_name=%r, "
+            "key=%r, "
+            "version_id=%r, "
+            "line_terminator=%r, "
+        ) % (
+            self._object.bucket_name,
+            self._object.key,
+            self._version_id,
+            self._line_terminator,
+        )
 
 
 class BufferedOutputBase(io.BufferedIOBase):
@@ -562,12 +574,23 @@ multipart upload may fail")
             self.close()
 
     def __str__(self):
-        return "s3.BufferedOutputBase(bucket_name='{}', key='{}')".format(
-            self._object.bucket_name, self._object.key)
+        return "smart_open.s3.BufferedOutputBase(%r, %r)" % (
+            self._object.bucket_name,
+            self._object.key
+        )
 
     def __repr__(self):
-        return "s3.BufferedOutputBase(bucket_name='{}', key='{}')".format(
-            self._object.bucket_name, self._object.key)
+        return (
+            "smart_open.s3.BufferedOutputBase("
+            "bucket_name=%r, "
+            "key=%r, "
+            "min_part_size=%r)"
+        ) % (
+            self._object.bucket_name,
+            self._object.key,
+            self._min_part_size,
+        )
+
 
 def iter_bucket(bucket_name, prefix='', accept_key=None,
                 key_limit=None, workers=16, retries=3):


### PR DESCRIPTION
Initial implementations of str and repr for SeekableBufferedInputBase and BufferedOutputBase.

This wasn't too difficult to implement, so I've gone and made the first version before getting the answers to the [questions at the issue thread](https://github.com/RaRe-Technologies/smart_open/issues/316#issuecomment-537198615). Please let me know if you'd like these outputs to look differently, if I should add other parameters to them or if I should add these to any other objects.