### PR TITLE
Updated iter_bucket to use concurrent futures.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,14 +41,10 @@ def read(fname):
 
 tests_require = [
     'mock',
-    'moto[server]==1.3.4',
+    'moto[server]',
     'pathlib2',
     'responses',
-    # Temporary pin boto3 & botocore, because moto doesn't work with new version
-    # See https://github.com/spulec/moto/issues/1793 and
-    # https://github.com/RaRe-Technologies/smart_open/issues/227
-    'boto3 < 1.8.0',
-    # 'botocore < 1.11.0'
+    'boto3',
     # Not used directly but allows boto GCE plugins to load.
     # https://github.com/GoogleCloudPlatform/compute-image-packages/issues/262
     'google-compute-engine==2.8.12'

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def read(fname):
 
 tests_require = [
     'mock',
-    'moto==1.3.4',
+    'moto[server]==1.3.4',
     'pathlib2',
     'responses',
     # Temporary pin boto3 & botocore, because moto doesn't work with new version

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -783,7 +783,8 @@ class ConcurrentFuturesPool(object):
 
     def imap_unordered(self, function, items):
         futures = [self.executor.submit(function, item) for item in items]
-        return (future.result() for future in concurrent.futures.as_completed(futures))
+        for future in concurrent.futures.as_completed(futures):
+            yield future.result()
 
     def terminate(self):
         self.executor.shutdown(wait=True)

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -791,12 +791,12 @@ class ConcurrentFuturesPool(object):
 
 @contextlib.contextmanager
 def _create_process_pool(processes=1):
-    if _CONCURRENT_FUTURES and processes:
-        logger.info("creating concurrent futures pool with %i workers", processes)
-        pool = ConcurrentFuturesPool(max_workers=processes)
-    elif _MULTIPROCESSING and processes:
+    if _MULTIPROCESSING and processes:
         logger.info("creating multiprocessing pool with %i workers", processes)
         pool = multiprocessing.pool.Pool(processes=processes)
+    elif _CONCURRENT_FUTURES and processes:
+        logger.info("creating concurrent futures pool with %i workers", processes)
+        pool = ConcurrentFuturesPool(max_workers=processes)
     else:
         logger.info("creating dummy pool")
         pool = DummyPool()

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -783,7 +783,7 @@ class ConcurrentFuturesPool(object):
 
     def imap_unordered(self, function, items):
         futures = [self.executor.submit(function, item) for item in items]
-        return map(lambda future: future.result(), concurrent.futures.as_completed(futures))
+        return (future.result() for future in concurrent.futures.as_completed(futures))
 
     def terminate(self):
         self.executor.shutdown(wait=True)

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -21,6 +21,16 @@ import smart_open.bytebuffer
 
 logger = logging.getLogger(__name__)
 
+# AWS Lambda environments do not support multiprocessing.Queue or multiprocessing.Pool.
+# However they do support Threads and therefore concurrent.futures's ThreadPoolExecutor.
+# We use this flag to allow python 2 backward compatibility, where concurrent.futures doesn't exist.
+_CONCURRENT_FUTURES = False
+try:
+    import concurrent.futures
+    _CONCURRENT_FUTURES = True
+except ImportError:
+    warnings.warn("concurrent.futures could not be imported and won't be used")
+
 # Multiprocessing is unavailable in App Engine (and possibly other sandboxes).
 # The only method currently relying on it is iter_bucket, which is instructed
 # whether to use it by the MULTIPROCESSING flag.
@@ -766,10 +776,26 @@ class DummyPool(object):
         pass
 
 
+class ConcurrentFuturesPool(object):
+    """A class that mimics multiprocessing.pool.Pool but uses concurrent futures instead of processes."""
+    def __init__(self, max_workers):
+        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers)
+
+    def imap_unordered(self, function, items):
+        futures = [self.executor.submit(function, item) for item in items]
+        return map(lambda future: future.result(), concurrent.futures.as_completed(futures))
+
+    def terminate(self):
+        self.executor.shutdown(wait=True)
+
+
 @contextlib.contextmanager
 def _create_process_pool(processes=1):
-    if _MULTIPROCESSING and processes:
-        logger.info("creating pool with %i workers", processes)
+    if _CONCURRENT_FUTURES and processes:
+        logger.info("creating concurrent futures pool with %i workers", processes)
+        pool = ConcurrentFuturesPool(max_workers=processes)
+    elif _MULTIPROCESSING and processes:
+        logger.info("creating multiprocessing pool with %i workers", processes)
         pool = multiprocessing.pool.Pool(processes=processes)
     else:
         logger.info("creating dummy pool")

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -460,7 +460,6 @@ class IterBucketTest(unittest.TestCase):
         expected = ['key_%d' % x for x in range(num_keys)]
         self.assertEqual(sorted(keys), sorted(expected))
 
-    @unittest.skipIf(DISABLE_MOCKS, 'this test mysteriously fails when mocks are disabled')
     def test_old(self):
         """Does s3_iter_bucket work correctly?"""
         #

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -460,6 +460,7 @@ class IterBucketTest(unittest.TestCase):
         expected = ['key_%d' % x for x in range(num_keys)]
         self.assertEqual(sorted(keys), sorted(expected))
 
+    @unittest.skipIf(DISABLE_MOCKS, 'this test mysteriously fails when mocks are disabled')
     def test_old(self):
         """Does s3_iter_bucket work correctly?"""
         #

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -469,7 +469,7 @@ class IterBucketTest(unittest.TestCase):
 
         # first, create some keys in the bucket
         expected = {}
-        for key_no in range(200):
+        for key_no in range(42):
             key_name = "mykey%s" % key_no
             with smart_open.smart_open("s3://%s/%s" % (BUCKET_NAME, key_name), 'wb') as fout:
                 content = '\n'.join("line%i%i" % (key_no, line_no) for line_no in range(10)).encode('utf8')
@@ -500,15 +500,66 @@ class IterBucketTest(unittest.TestCase):
 
 
 @maybe_mock_s3
-class IterBucketSingleProcessTest(unittest.TestCase):
+class IterBucketConcurrentFuturesTest(unittest.TestCase):
     def setUp(self):
-        self.old_flag = smart_open.s3._MULTIPROCESSING
+        self.old_flag_multi = smart_open.s3._MULTIPROCESSING
         smart_open.s3._MULTIPROCESSING = False
+        if not smart_open.s3._CONCURRENT_FUTURES:
+            self.fail('Unable to test iter bucket concurrent futures since it is disabled on this machine.')
 
         ignore_resource_warnings()
 
     def tearDown(self):
-        smart_open.s3._MULTIPROCESSING = self.old_flag
+        smart_open.s3._MULTIPROCESSING = self.old_flag_multi
+        cleanup_bucket()
+
+    def test(self):
+        num_keys = 101
+        populate_bucket(num_keys=num_keys)
+        keys = list(smart_open.s3.iter_bucket(BUCKET_NAME))
+        self.assertEqual(len(keys), num_keys)
+
+        expected = [('key_%d' % x, b'%d' % x) for x in range(num_keys)]
+        self.assertEqual(sorted(keys), sorted(expected))
+
+
+@maybe_mock_s3
+class IterBucketMultiprocessingTest(unittest.TestCase):
+    def setUp(self):
+        self.old_flag_concurrent = smart_open.s3._CONCURRENT_FUTURES
+        smart_open.s3._CONCURRENT_FUTURES = False
+        if not smart_open.s3._MULTIPROCESSING:
+            self.fail('Unable to test iter bucket multiprocessing since it is disabled on this machine.')
+
+        ignore_resource_warnings()
+
+    def tearDown(self):
+        smart_open.s3._CONCURRENT_FUTURES = self.old_flag_concurrent
+        cleanup_bucket()
+
+    def test(self):
+        num_keys = 101
+        populate_bucket(num_keys=num_keys)
+        keys = list(smart_open.s3.iter_bucket(BUCKET_NAME))
+        self.assertEqual(len(keys), num_keys)
+
+        expected = [('key_%d' % x, b'%d' % x) for x in range(num_keys)]
+        self.assertEqual(sorted(keys), sorted(expected))
+
+
+@maybe_mock_s3
+class IterBucketSingleProcessTest(unittest.TestCase):
+    def setUp(self):
+        self.old_flag_multi = smart_open.s3._MULTIPROCESSING
+        self.old_flag_concurrent = smart_open.s3._CONCURRENT_FUTURES
+        smart_open.s3._MULTIPROCESSING = False
+        smart_open.s3._CONCURRENT_FUTURES = False
+
+        ignore_resource_warnings()
+
+    def tearDown(self):
+        smart_open.s3._MULTIPROCESSING = self.old_flag_multi
+        smart_open.s3._CONCURRENT_FUTURES = self.old_flag_concurrent
         cleanup_bucket()
 
     def test(self):

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -501,13 +501,11 @@ class IterBucketTest(unittest.TestCase):
 
 
 @maybe_mock_s3
+@unittest.skipIf(not smart_open.s3._CONCURRENT_FUTURES, 'concurrent.futures unavailable')
 class IterBucketConcurrentFuturesTest(unittest.TestCase):
     def setUp(self):
         self.old_flag_multi = smart_open.s3._MULTIPROCESSING
         smart_open.s3._MULTIPROCESSING = False
-        if not smart_open.s3._CONCURRENT_FUTURES:
-            self.fail('Unable to test iter bucket concurrent futures since it is disabled on this machine.')
-
         ignore_resource_warnings()
 
     def tearDown(self):
@@ -525,13 +523,11 @@ class IterBucketConcurrentFuturesTest(unittest.TestCase):
 
 
 @maybe_mock_s3
+@unittest.skipIf(not smart_open.s3._MULTIPROCESSING, 'multiprocessing unavailable')
 class IterBucketMultiprocessingTest(unittest.TestCase):
     def setUp(self):
         self.old_flag_concurrent = smart_open.s3._CONCURRENT_FUTURES
         smart_open.s3._CONCURRENT_FUTURES = False
-        if not smart_open.s3._MULTIPROCESSING:
-            self.fail('Unable to test iter bucket multiprocessing since it is disabled on this machine.')
-
         ignore_resource_warnings()
 
     def tearDown(self):


### PR DESCRIPTION
This PR addresses issue #340.
AWS Lambda environments do not support multiprocessing.Queue or
multiprocessing.Pool, which are used by iter_bucket to optimize the
pulling of files from s3.

Solution: Switch to using concurrent.futures.ThreadPoolExecutor instead.
This still optimizes the pulling of files from s3 without using new
processes.