### PR TITLE
adding password option to ssh, scp and sftp: continued

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,7 @@ Other examples of URLs that ``smart_open`` accepts::
     file:///home/user/file.bz2
     [ssh|scp|sftp]://username@host//path/file
     [ssh|scp|sftp]://username@host/path/file
+    [ssh|scp|sftp]://username:password@host/path/file
 
 .. _doctools_after_examples:
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ tests_require = [
     # 'botocore < 1.11.0'
     # Not used directly but allows boto GCE plugins to load.
     # https://github.com/GoogleCloudPlatform/compute-image-packages/issues/262
-    'google-compute-engine==2.8.12'
+    'google-compute-engine==2.8.12',
+    'paramiko==2.6.0',
 ]
 
 install_requires = [

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ tests_require = [
     # Not used directly but allows boto GCE plugins to load.
     # https://github.com/GoogleCloudPlatform/compute-image-packages/issues/262
     'google-compute-engine==2.8.12',
-    'paramiko==2.6.0',
+    'paramiko',
 ]
 
 install_requires = [

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -129,6 +129,7 @@ Uri = collections.namedtuple(
         'access_id',
         'access_secret',
         'user',
+        'password',
     )
 )
 """Represents all the options that we parse from user input.
@@ -554,6 +555,7 @@ def _open_binary_stream(uri, mode, transport_params):
                 host=parsed_uri.host,
                 user=parsed_uri.user,
                 port=parsed_uri.port,
+                password=parsed_uri.password,
             )
             return fobj, filename
         elif parsed_uri.scheme in smart_open_s3.SUPPORTED_SCHEMES:
@@ -826,23 +828,30 @@ def _parse_uri_file(input_path):
 def _parse_uri_ssh(unt):
     """Parse a Uri from a urllib namedtuple."""
     if '@' in unt.netloc:
-        user, host_port = unt.netloc.split('@', 1)
+        user_pass, host_port = unt.netloc.rsplit('@', 1)
     else:
-        user, host_port = None, unt.netloc
+        user_pass, host_port = None, unt.netloc
 
     if ':' in host_port:
         host, port = host_port.split(':', 1)
     else:
         host, port = host_port, None
 
-    if not user:
+    if not user_pass:
         user = None
+        password = None
+    elif ':' in user_pass:
+        user, password = user_pass.split(':', 1)
+    else:
+        user = user_pass
+        password = None
+
     if not port:
         port = smart_open_ssh.DEFAULT_PORT
     else:
         port = int(port)
 
-    return Uri(scheme=unt.scheme, uri_path=unt.path, user=user, host=host, port=port)
+    return Uri(scheme=unt.scheme, uri_path=unt.path, user=user, host=host, port=port, password=password)
 
 
 def _need_to_buffer(file_obj, mode, ext):

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -556,6 +556,7 @@ def _open_binary_stream(uri, mode, transport_params):
                 user=parsed_uri.user,
                 port=parsed_uri.port,
                 password=parsed_uri.password,
+                transport_params=transport_params
             )
             return fobj, filename
         elif parsed_uri.scheme in smart_open_s3.SUPPORTED_SCHEMES:
@@ -845,6 +846,11 @@ def _parse_uri_ssh(unt):
     else:
         user = user_pass
         password = None
+
+    if user:
+        user = urlparse.unquote(user)
+    if password:
+        password = urlparse.unquote(password)
 
     if not port:
         port = smart_open_ssh.DEFAULT_PORT

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -555,7 +555,7 @@ def _open_binary_stream(uri, mode, transport_params):
                 user=parsed_uri.user,
                 port=parsed_uri.port,
                 password=parsed_uri.password,
-                transport_params=transport_params
+                transport_params=transport_params,
             )
             return fobj, filename
         elif parsed_uri.scheme in smart_open_s3.SUPPORTED_SCHEMES:

--- a/smart_open/ssh.py
+++ b/smart_open/ssh.py
@@ -94,8 +94,8 @@ def open(path, mode='r', host=None, user=None, password=None, port=DEFAULT_PORT,
     If you specify a previously unseen host, then its host key will be added to
     the local ~/.ssh/known_hosts *automatically*.
 
-    If `username` or `password` are specified in _both_ the uri and `transport_params`,
-    `transport_params` will take precedence
+    If ``username`` or ``password`` are specified in *both* the uri and
+    ``transport_params``, ``transport_params`` will take precedence
     """
     if not host:
         raise ValueError('you must specify the host to connect to')

--- a/smart_open/ssh.py
+++ b/smart_open/ssh.py
@@ -39,7 +39,7 @@ SCHEMES = ("ssh", "scp", "sftp")
 DEFAULT_PORT = 22
 
 
-def _connect(hostname, username, port, password):
+def _connect(hostname, username, port, password, transport_params):
     try:
         import paramiko
     except ImportError:
@@ -55,11 +55,14 @@ def _connect(hostname, username, port, password):
         ssh = _SSH[key] = paramiko.client.SSHClient()
         ssh.load_system_host_keys()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        ssh.connect(hostname, port, username, password)
+        kwargs = transport_params.get('connect_kwargs', {}).copy()
+        kwargs.setdefault('password', password)
+        kwargs.setdefault('username', username)
+        ssh.connect(hostname, port, **kwargs)
     return ssh
 
 
-def open(path, mode='r', host=None, user=None, password=None, port=DEFAULT_PORT):
+def open(path, mode='r', host=None, user=None, password=None, port=DEFAULT_PORT, transport_params=None):
     """Open a file on a remote machine over SSH.
 
     Expects authentication to be already set up via existing keys on the local machine.
@@ -79,6 +82,8 @@ def open(path, mode='r', host=None, user=None, password=None, port=DEFAULT_PORT)
         The password to use to login to the remote machine.
     port: int, optional
         The port to connect to.
+    transport_params: dict, optional
+        Any additional settings to be passed to paramiko.SSHClient.connect
 
     Returns
     -------
@@ -89,11 +94,16 @@ def open(path, mode='r', host=None, user=None, password=None, port=DEFAULT_PORT)
     If you specify a previously unseen host, then its host key will be added to
     the local ~/.ssh/known_hosts *automatically*.
 
+    If `username` or `password` are specified in _both_ the uri and `transport_params`, `transport_params` will take
+    precedence
     """
     if not host:
         raise ValueError('you must specify the host to connect to')
     if not user:
         user = getpass.getuser()
-    conn = _connect(host, user, port, password)
+    if not transport_params:
+        transport_params = {}
+
+    conn = _connect(host, user, port, password, transport_params)
     sftp_client = conn.get_transport().open_sftp_client()
     return sftp_client.open(path, mode)

--- a/smart_open/ssh.py
+++ b/smart_open/ssh.py
@@ -39,7 +39,7 @@ SCHEMES = ("ssh", "scp", "sftp")
 DEFAULT_PORT = 22
 
 
-def _connect(hostname, username, port):
+def _connect(hostname, username, port, password):
     try:
         import paramiko
     except ImportError:
@@ -55,11 +55,11 @@ def _connect(hostname, username, port):
         ssh = _SSH[key] = paramiko.client.SSHClient()
         ssh.load_system_host_keys()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        ssh.connect(hostname, port, username)
+        ssh.connect(hostname, port, username, password)
     return ssh
 
 
-def open(path, mode='r', host=None, user=None, port=DEFAULT_PORT):
+def open(path, mode='r', host=None, user=None, password=None, port=DEFAULT_PORT):
     """Open a file on a remote machine over SSH.
 
     Expects authentication to be already set up via existing keys on the local machine.
@@ -75,6 +75,8 @@ def open(path, mode='r', host=None, user=None, port=DEFAULT_PORT):
     user: str, optional
         The username to use to login to the remote machine.
         If None, defaults to the name of the current user.
+    password: str, optional
+        The password to use to login to the remote machine.
     port: int, optional
         The port to connect to.
 
@@ -92,6 +94,6 @@ def open(path, mode='r', host=None, user=None, port=DEFAULT_PORT):
         raise ValueError('you must specify the host to connect to')
     if not user:
         user = getpass.getuser()
-    conn = _connect(host, user, port)
+    conn = _connect(host, user, port, password)
     sftp_client = conn.get_transport().open_sftp_client()
     return sftp_client.open(path, mode)

--- a/smart_open/ssh.py
+++ b/smart_open/ssh.py
@@ -94,8 +94,8 @@ def open(path, mode='r', host=None, user=None, password=None, port=DEFAULT_PORT,
     If you specify a previously unseen host, then its host key will be added to
     the local ~/.ssh/known_hosts *automatically*.
 
-    If `username` or `password` are specified in _both_ the uri and `transport_params`, `transport_params` will take
-    precedence
+    If `username` or `password` are specified in _both_ the uri and `transport_params`,
+    `transport_params` will take precedence
     """
     if not host:
         raise ValueError('you must specify the host to connect to')

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -196,22 +196,24 @@ class ParseUriTest(unittest.TestCase):
         self.assertEqual(uri.uri_path, '//' + path)
 
     def test_ssh(self):
-        as_string = 'ssh://user@host:1234/path/to/file'
+        as_string = 'ssh://user:pass@host:1234/path/to/file'
         uri = smart_open_lib._parse_uri(as_string)
         self.assertEqual(uri.scheme, 'ssh')
         self.assertEqual(uri.uri_path, '/path/to/file')
         self.assertEqual(uri.user, 'user')
         self.assertEqual(uri.host, 'host')
         self.assertEqual(uri.port, 1234)
+        self.assertEqual(uri.password, 'pass')
 
     def test_scp(self):
-        as_string = 'scp://user@host:/path/to/file'
+        as_string = 'scp://user:pass@host:/path/to/file'
         uri = smart_open_lib._parse_uri(as_string)
         self.assertEqual(uri.scheme, 'scp')
         self.assertEqual(uri.uri_path, '/path/to/file')
         self.assertEqual(uri.user, 'user')
         self.assertEqual(uri.host, 'host')
         self.assertEqual(uri.port, 22)
+        self.assertEqual(uri.password, 'pass')
 
     def test_sftp(self):
         as_string = 'sftp://host/path/to/file'
@@ -221,6 +223,22 @@ class ParseUriTest(unittest.TestCase):
         self.assertEqual(uri.user, None)
         self.assertEqual(uri.host, 'host')
         self.assertEqual(uri.port, 22)
+        self.assertEqual(uri.password, None)
+
+    def test_sftp_with_user_and_pass(self):
+        as_string = 'sftp://user:pass@host:2222/path/to/file'
+        uri = smart_open_lib._parse_uri(as_string)
+        self.assertEqual(uri.scheme, 'sftp')
+        self.assertEqual(uri.uri_path, '/path/to/file')
+        self.assertEqual(uri.user, 'user')
+        self.assertEqual(uri.host, 'host')
+        self.assertEqual(uri.port, 2222)
+        self.assertEqual(uri.password, 'pass')
+
+    def test_ssh_complex_password_with_colon(self):
+        as_string = 'sftp://user:some:complex@password$$@host:2222/path/to/file'
+        uri = smart_open_lib._parse_uri(as_string)
+        self.assertEqual(uri.password, 'some:complex@password$$')
 
 
 class SmartOpenHttpTest(unittest.TestCase):
@@ -231,13 +249,14 @@ class SmartOpenHttpTest(unittest.TestCase):
     @mock.patch('smart_open.ssh.open')
     def test_read_ssh(self, mock_open):
         """Is SSH line iterator called correctly?"""
-        obj = smart_open.smart_open("ssh://ubuntu@ip_address:1022/some/path/lines.txt")
+        obj = smart_open.smart_open("ssh://ubuntu:pass@ip_address:1022/some/path/lines.txt")
         obj.__iter__()
         mock_open.assert_called_with(
             '/some/path/lines.txt',
             'rb',
             host='ip_address',
             user='ubuntu',
+            password='pass',
             port=1022
         )
 

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -249,7 +249,8 @@ class SmartOpenHttpTest(unittest.TestCase):
     @mock.patch('smart_open.ssh.open')
     def test_read_ssh(self, mock_open):
         """Is SSH line iterator called correctly?"""
-        obj = smart_open.smart_open("ssh://ubuntu:pass@ip_address:1022/some/path/lines.txt")
+        obj = smart_open.smart_open("ssh://ubuntu:pass@ip_address:1022/some/path/lines.txt",
+                                    hello='world')
         obj.__iter__()
         mock_open.assert_called_with(
             '/some/path/lines.txt',
@@ -257,7 +258,8 @@ class SmartOpenHttpTest(unittest.TestCase):
             host='ip_address',
             user='ubuntu',
             password='pass',
-            port=1022
+            port=1022,
+            transport_params={'hello': 'world'}
         )
 
     @responses.activate

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -196,6 +196,16 @@ class ParseUriTest(unittest.TestCase):
         self.assertEqual(uri.uri_path, '//' + path)
 
     def test_ssh(self):
+        as_string = 'ssh://user@host:1234/path/to/file'
+        uri = smart_open_lib._parse_uri(as_string)
+        self.assertEqual(uri.scheme, 'ssh')
+        self.assertEqual(uri.uri_path, '/path/to/file')
+        self.assertEqual(uri.user, 'user')
+        self.assertEqual(uri.host, 'host')
+        self.assertEqual(uri.port, 1234)
+        self.assertEqual(uri.password, None)
+
+    def test_ssh_with_pass(self):
         as_string = 'ssh://user:pass@host:1234/path/to/file'
         uri = smart_open_lib._parse_uri(as_string)
         self.assertEqual(uri.scheme, 'ssh')
@@ -206,6 +216,16 @@ class ParseUriTest(unittest.TestCase):
         self.assertEqual(uri.password, 'pass')
 
     def test_scp(self):
+        as_string = 'scp://user@host:/path/to/file'
+        uri = smart_open_lib._parse_uri(as_string)
+        self.assertEqual(uri.scheme, 'scp')
+        self.assertEqual(uri.uri_path, '/path/to/file')
+        self.assertEqual(uri.user, 'user')
+        self.assertEqual(uri.host, 'host')
+        self.assertEqual(uri.port, 22)
+        self.assertEqual(uri.password, None)
+
+    def test_scp_with_pass(self):
         as_string = 'scp://user:pass@host:/path/to/file'
         uri = smart_open_lib._parse_uri(as_string)
         self.assertEqual(uri.scheme, 'scp')
@@ -249,8 +269,10 @@ class SmartOpenHttpTest(unittest.TestCase):
     @mock.patch('smart_open.ssh.open')
     def test_read_ssh(self, mock_open):
         """Is SSH line iterator called correctly?"""
-        obj = smart_open.smart_open("ssh://ubuntu:pass@ip_address:1022/some/path/lines.txt",
-                                    hello='world')
+        obj = smart_open.smart_open(
+            "ssh://ubuntu:pass@ip_address:1022/some/path/lines.txt",
+            hello='world',
+        )
         obj.__iter__()
         mock_open.assert_called_with(
             '/some/path/lines.txt',
@@ -259,7 +281,7 @@ class SmartOpenHttpTest(unittest.TestCase):
             user='ubuntu',
             password='pass',
             port=1022,
-            transport_params={'hello': 'world'}
+            transport_params={'hello': 'world'},
         )
 
     @responses.activate

--- a/smart_open/tests/test_ssh.py
+++ b/smart_open/tests/test_ssh.py
@@ -11,6 +11,7 @@ def mock_ssh(func):
     def wrapper(*args, **kwargs):
         smart_open.ssh._SSH.clear()
         return func(*args, **kwargs)
+
     return mock.patch("paramiko.client.SSHClient.get_transport")(
         mock.patch("paramiko.client.SSHClient.connect")(wrapper)
     )
@@ -34,15 +35,13 @@ class SSHOpen(unittest.TestCase):
 
     @mock_ssh
     def test_open_with_transport_params(self, mock_connect, get_transp_mock):
-        smart_open.open("ssh://user:pass@some-host/", transport_params={
-            "connect_kwargs": {
-                "username": "ubuntu",
-                "password": "pwd",
-            }
-        })
-        mock_connect.assert_called_with("some-host", 22, username='ubuntu', password="pwd")
+        smart_open.open(
+            "ssh://user:pass@some-host/",
+            transport_params={"connect_kwargs": {"username": "ubuntu", "password": "pwd"}},
+        )
+        mock_connect.assert_called_with("some-host", 22, username="ubuntu", password="pwd")
 
 
-if __name__ == '__main__':
-    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)
+if __name__ == "__main__":
+    logging.basicConfig(format="%(asctime)s : %(levelname)s : %(message)s", level=logging.DEBUG)
     unittest.main()

--- a/smart_open/tests/test_ssh.py
+++ b/smart_open/tests/test_ssh.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import mock
+import unittest
+
+import smart_open.ssh
+
+def mock_ssh(func):
+    def wrapper(*args, **kwargs):
+        smart_open.ssh._SSH.clear()
+        return func(*args, **kwargs)
+    return mock.patch("paramiko.client.SSHClient.get_transport")(
+        mock.patch("paramiko.client.SSHClient.connect")(wrapper)
+    )
+
+class SSHOpen(unittest.TestCase):
+    @mock_ssh
+    def test_open(self, mock_connect, get_transp_mock):
+        smart_open.open("ssh://user:pass@some-host/")
+        mock_connect.assert_called_with("some-host", 22, username="user", password="pass")
+
+    @mock_ssh
+    def test_percent_encoding(self, mock_connect, get_transp_mock):
+        smart_open.open("ssh://user%3a:pass%40@some-host/")
+        mock_connect.assert_called_with("some-host", 22, username="user:", password="pass@")
+
+    @mock_ssh
+    def test_open_without_password(self, mock_connect, get_transp_mock):
+        smart_open.open("ssh://user@some-host/")
+        mock_connect.assert_called_with("some-host", 22, username="user", password=None)
+
+    @mock_ssh
+    def test_open_with_transport_params(self, mock_connect, get_transp_mock):
+        smart_open.open("ssh://user:pass@some-host/", transport_params={
+            "connect_kwargs": {
+                "username": "ubuntu",
+                "password": "pwd",
+            }
+        })
+        mock_connect.assert_called_with("some-host", 22, username='ubuntu', password="pwd")
+
+if __name__ == '__main__':
+    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)
+    unittest.main()

--- a/smart_open/tests/test_ssh.py
+++ b/smart_open/tests/test_ssh.py
@@ -6,6 +6,7 @@ import unittest
 
 import smart_open.ssh
 
+
 def mock_ssh(func):
     def wrapper(*args, **kwargs):
         smart_open.ssh._SSH.clear()
@@ -13,6 +14,7 @@ def mock_ssh(func):
     return mock.patch("paramiko.client.SSHClient.get_transport")(
         mock.patch("paramiko.client.SSHClient.connect")(wrapper)
     )
+
 
 class SSHOpen(unittest.TestCase):
     @mock_ssh
@@ -39,6 +41,7 @@ class SSHOpen(unittest.TestCase):
             }
         })
         mock_connect.assert_called_with("some-host", 22, username='ubuntu', password="pwd")
+
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)


### PR DESCRIPTION
It seems that author abandoned original #292 PR, so I'll continue it here. I've addressed comments, @mpenkov please take a look.

Additionally I'm calling urlparse.unquote on username and password, allowing percent encoding of username / password.