### PR TITLE
response.content changed to response.text in error string

### DIFF
--- a/smart_open/webhdfs.py
+++ b/smart_open/webhdfs.py
@@ -128,11 +128,11 @@ class BufferedOutputBase(io.BufferedIOBase):
         init_response = requests.put("http://" + self.uri_path,
                                      params=payload, allow_redirects=False)
         if not init_response.status_code == httplib.TEMPORARY_REDIRECT:
-            raise WebHdfsException(str(init_response.status_code) + "\n" + init_response.content)
+            raise WebHdfsException(str(init_response.status_code) + "\n" + init_response.text)
         uri = init_response.headers['location']
         response = requests.put(uri, data="", headers={'content-type': 'application/octet-stream'})
         if not response.status_code == httplib.CREATED:
-            raise WebHdfsException(str(response.status_code) + "\n" + response.content)
+            raise WebHdfsException(str(response.status_code) + "\n" + response.text)
         self.lines = []
         self.parts = 0
         self.chunk_bytes = 0
@@ -161,12 +161,12 @@ class BufferedOutputBase(io.BufferedIOBase):
         init_response = requests.post("http://" + self.uri_path,
                                       params=payload, allow_redirects=False)
         if not init_response.status_code == httplib.TEMPORARY_REDIRECT:
-            raise WebHdfsException(str(init_response.status_code) + "\n" + init_response.content)
+            raise WebHdfsException(str(init_response.status_code) + "\n" + init_response.text)
         uri = init_response.headers['location']
         response = requests.post(uri, data=data,
                                  headers={'content-type': 'application/octet-stream'})
         if not response.status_code == httplib.OK:
-            raise WebHdfsException(str(response.status_code) + "\n" + repr(response.content))
+            raise WebHdfsException(str(response.status_code) + "\n" + repr(response.text))
 
     def write(self, b):
         """


### PR DESCRIPTION
#### Webhdfs Error response fix
Fix for Issue #338 
webhdfs.py is returning a byte string instead of a string which is causing a "must be str not bytes" error.
Fix makes the error return response.text instead of response.content

#### Motivation

webhdfs.py is returning a byte string instead of a string which is causing a "must be str not bytes" error.

- Fixes #338
