### PR TITLE
Fixes "the connection was closed by the remote peer" error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ script:
       unset SO_S3_RESULT_URL;
     fi
   - flake8 --max-line-length=110
+  - sh -c "moto_server -p5000 1> /dev/null 2> /dev/null" &
   - python setup.py test
   - export SO_S3_URL=$SO_S3_URL/$(python -c 'from uuid import uuid4;print(uuid4())')
   - pip install pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
 
 install:
   - pip install --upgrade setuptools
+  - pip install flask
   - pip install .[test]
   - pip install flake8
   - pip freeze
@@ -46,7 +47,7 @@ script:
       unset SO_S3_RESULT_URL;
     fi
   - flake8 --max-line-length=110
-  - sh -c "moto_server -p5000 1> /dev/null 2> /dev/null" &
+  - sh -c "moto_server -p5000 2> /dev/null &"
   - python setup.py test
   - export SO_S3_URL=$SO_S3_URL/$(python -c 'from uuid import uuid4;print(uuid4())')
   - pip install pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - python: '2.7'
       env:
         - SO_DISABLE_MOCKS: "1"
+        - SO_DISABLE_MOTO_SERVER: "1"
         - SO_S3_URL: "s3://smart-open-py27-benchmark"
         - SO_S3_RESULT_URL: "s3://smart-open-py27-benchmark-results"
 
@@ -19,12 +20,14 @@ matrix:
     - python: '3.6'
       env:
         - SO_DISABLE_MOCKS: "1"
+        - SO_DISABLE_MOTO_SERVER: "1"
         - SO_S3_URL: "s3://smart-open-py36-benchmark"
         - SO_S3_RESULT_URL: "s3://smart-open-py36-benchmark-results"
 
     - python: '3.7'
       env:
         - SO_DISABLE_MOCKS: "1"
+        - SO_DISABLE_MOTO_SERVER: "1"
         - SO_S3_URL: "s3://smart-open-py37-benchmark"
         - SO_S3_RESULT_URL: "s3://smart-open-py37-benchmark-results"
         - BOTO_CONFIG: "/dev/null"
@@ -46,8 +49,10 @@ script:
       unset SO_S3_URL;
       unset SO_S3_RESULT_URL;
     fi
+  - if [[ ${SO_DISABLE_MOTO_SERVER} -ne 1 ]]; then
+      sh -c "moto_server -p5000 2> /dev/null &";
+    fi
   - flake8 --max-line-length=110
-  - sh -c "moto_server -p5000 2> /dev/null &"
   - python setup.py test
   - export SO_S3_URL=$SO_S3_URL/$(python -c 'from uuid import uuid4;print(uuid4())')
   - pip install pytest

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -182,7 +182,7 @@ class SeekableRawReader(object):
         """
         #
         # Close old body explicitly.
-        # When first seek(), self._body is not exist. Catch the exception and do nothing.
+        # When first seek() after __init__(), self._body is not exist.
         #
         if self._body is not None:
             self._body.close()
@@ -190,6 +190,8 @@ class SeekableRawReader(object):
         self._position = position
 
     def _load_body(self):
+        """Build a continuous connection with the remote peer starts from the current postion.
+        """
         range_string = make_range_string(self._position)
         logger.debug('content_length: %r range_string: %r', self._content_length, range_string)
 
@@ -210,9 +212,11 @@ class SeekableRawReader(object):
         return binary
 
     def read(self, size=-1):
+        """Read from the continuous connection with the remote peer."""
         if self._position >= self._content_length:
             return b''
         if self._body is None:
+            # When the first read() after __init__() or seek(), self._body is not exist.
             self._load_body()
 
         try:

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -107,13 +107,13 @@ def ignore_resource_warnings():
 class SeekableRawReaderTest(unittest.TestCase):
 
     def setUp(self):
-        self._moto_pipe = os.popen('moto_server --port 5000', 'r')
         self._local_resoruce = boto3.resource('s3', endpoint_url='http://localhost:5000')
         self._local_resoruce.Bucket(BUCKET_NAME).create()
         self._local_resoruce.Object(BUCKET_NAME, KEY_NAME).put(Body=b'123456')
 
     def tearDown(self):
-        self._moto_pipe.close()
+        self._local_resoruce.Object(BUCKET_NAME, KEY_NAME).delete()
+        self._local_resoruce.Bucket(BUCKET_NAME).delete()
 
     def test_read_from_a_closed_body(self):
         obj = self._local_resoruce.Object(BUCKET_NAME, KEY_NAME)

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -103,6 +103,7 @@ def ignore_resource_warnings():
         return
     warnings.filterwarnings("ignore", category=ResourceWarning, message="unclosed.*<ssl.SSLSocket.*>")  # noqa
 
+
 @maybe_mock_s3
 class SeekableRawReaderTest(unittest.TestCase):
 
@@ -121,6 +122,7 @@ class SeekableRawReaderTest(unittest.TestCase):
         self.assertEqual(reader.read(1), b'1')
         reader._body.close()
         self.assertEqual(reader.read(2), b'23')
+
 
 @maybe_mock_s3
 class SeekableBufferedInputBaseTest(unittest.TestCase):


### PR DESCRIPTION
#### SeekableRawReader reopens a connection after getting a IncompleteReadError

#### Motivation
- Fixes #362 

The current SeekableRawReader sends HTTP request in the [`seek()`](https://github.com/RaRe-Technologies/smart_open/blob/21d98e6a7144191c24ceca862e32910ff740c933/smart_open/s3.py#L200) method, and keeps an continuous connection with the remote peer. But if the SeekableRawReader does not read from the connection immediately after `seek()`, the remote peer may close the connection due to a timeout. Then, the SeekableRawReader attempts to read on a StreamingBody whose underlying connection had been closed, and gets a [botocore.exceptions.IncompleteReadError](), the following example shows the case:

```python
from boto3 import resource

endpoints = [
    'http://xxxxxxxxxxxxx', # real s3
    'http://localhost:8000' # moto s3 server
]

real_s3_resource = resource('s3', endpoint_url=endpoints[0])
moto_s3_resource = resource('s3', endpoint_url=endpoints[1])

# Test read from a closed streaming body.

# For real s3.
obj = real_s3_resource.Object('gyp', 'images.msg')
body = obj.get()['Body']
print(type(body)) # <class 'botocore.response.StreamingBody'>
print(body.read(1)) # b'\xdd'
body.close() # Close the body.
try:
    body.read(1)
except Exception as e:
    print(type(e)) # <class 'botocore.exceptions.IncompleteReadError'>


# For moto s3 server.
moto_s3_resource.Bucket('gyp').create()
moto_s3_resource.Object('gyp', 'test-key').put(Body=b'123456')
obj = moto_s3_resource.Object('gyp', 'test-key')
body = obj.get()['Body']
print(type(body)) # <class 'botocore.response.StreamingBody'>
print(body.read(1)) # b'1'
body.close() # Close the body.
try:
    body.read(1)
except Exception as e:
    print(type(e)) # <class 'botocore.exceptions.IncompleteReadError'>
```

In the above code, the `body` is closed by client actively to stimulate connection closed by the remote peer.

In the [PR](https://github.com/RaRe-Technologies/smart_open/pull/379), I intended to delay the action of sending HTTP request until read, the solution solved the problem of closed connection between a pair of `seek() - read()`, but introduced a similar problem between continuous `read()`, namely, the connection may also be closed by the remote peer after a read, if the second read occurs a long time later.

In this PR, I try to catch the IncompleteReadError in the `read()` directly, if connection is close, and IncompleteReadError is raised,
1. Catch the exception and dereference the current StreamingBody, 
2. Call the `seek()` from the current offset to build a new connection with remote peer. 
3. Finally, read from the new connection as required.
