### PR TITLE
allow use of S3 single part uploads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
   # The creds won't be available unless this is a branch belonging to the
   # RaRe-Technologies organization.
   #
-  - if [[ ${TRAVIS_SECURE_ENV_VARS} && ${RUN_BENCHMARKS} ]]; then
+  - if [[ "${TRAVIS_SECURE_ENV_VARS}" = "true" && "${RUN_BENCHMARKS}" = "true" ]]; then
       export SO_S3_URL=$SO_S3_URL/$(python -c 'from uuid import uuid4;print(uuid4())');
       pip install pytest_benchmark awscli;
       set -e;
@@ -68,7 +68,7 @@ script:
   #
   # These integration tests require AWS creds and an initialized S3 bucket
   #
-  - if [[ ${TRAVIS_SECURE_ENV_VARS} ]]; then
+  - if [[ "${TRAVIS_SECURE_ENV_VARS}" = "true" ]]; then
       pytest integration-tests/test_s3_ported.py;
     fi
 

--- a/help.txt
+++ b/help.txt
@@ -101,6 +101,16 @@ FUNCTIONS
         multipart_upload_kwargs: dict, optional
             Additional parameters to pass to boto3's initiate_multipart_upload function.
             For writing only.
+        singlepart_upload_kwargs: dict, optional
+            Additional parameters to pass to boto3's S3.Object.put function when using single
+            part upload.
+            For writing only.
+        multipart_upload: bool, optional
+            Default: `True`
+            If set to `True`, will use multipart upload for writing to S3. If set
+            to `False`, S3 upload will use the S3 Single-Part Upload API, which
+            is more ideal for small file sizes.
+            For writing only.
         version_id: str, optional
             Version of the object, used when reading object. If None, will fetch the most recent version.
         

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -515,8 +515,12 @@ multipart upload may fail")
             self._object = s3.Object(bucket, key)
             self._min_part_size = min_part_size
             self._mp = self._object.initiate_multipart_upload(**self._upload_kwargs)
-        except botocore.client.ClientError:
-            raise ValueError('the bucket %r does not exist, or is forbidden for access' % bucket)
+        except botocore.client.ClientError as error:
+            raise ValueError(
+                'the bucket %r does not exist, or is forbidden for access (%r)' % (
+                    bucket, error
+                )
+            )
 
         self._buf = io.BytesIO()
         self._total_bytes = 0

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -495,8 +495,6 @@ class MultipartWriter(io.BufferedIOBase):
             resource_kwargs=None,
             upload_kwargs=None,
             ):
-
-
         if min_part_size < MIN_MIN_PART_SIZE:
             logger.warning("S3 requires minimum part size >= 5MB; \
 multipart upload may fail")

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -427,7 +427,7 @@ class MultipartWriterTest(unittest.TestCase):
         self.assertEqual(contents, boto3_body)
 
 
-@maybe_mock_s3
+@moto.mock_s3
 class SinglepartWriterTest(unittest.TestCase):
     """
     Test writing into s3 files using single part upload.

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -302,7 +302,7 @@ class SeekableBufferedInputBaseTest(unittest.TestCase):
 
 
 @maybe_mock_s3
-class BufferedOutputBaseTest(unittest.TestCase):
+class BufferedMultiPartOutputBaseTest(unittest.TestCase):
     """
     Test writing into s3 files.
 
@@ -318,7 +318,7 @@ class BufferedOutputBaseTest(unittest.TestCase):
         test_string = u"žluťoučký koníček".encode('utf8')
 
         # write into key
-        with smart_open.s3.BufferedOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fout:
+        with smart_open.s3.BufferedMultiPartOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fout:
             fout.write(test_string)
 
         # read key and test content
@@ -329,7 +329,7 @@ class BufferedOutputBaseTest(unittest.TestCase):
     def test_write_01a(self):
         """Does s3 write fail on incorrect input?"""
         try:
-            with smart_open.s3.BufferedOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fin:
+            with smart_open.s3.BufferedMultiPartOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fin:
                 fin.write(None)
         except TypeError:
             pass
@@ -338,7 +338,7 @@ class BufferedOutputBaseTest(unittest.TestCase):
 
     def test_write_02(self):
         """Does s3 write unicode-utf8 conversion work?"""
-        smart_open_write = smart_open.s3.BufferedOutputBase(BUCKET_NAME, WRITE_KEY_NAME)
+        smart_open_write = smart_open.s3.BufferedMultiPartOutputBase(BUCKET_NAME, WRITE_KEY_NAME)
         smart_open_write.tell()
         logger.info("smart_open_write: %r", smart_open_write)
         with smart_open_write as fout:
@@ -348,7 +348,7 @@ class BufferedOutputBaseTest(unittest.TestCase):
     def test_write_03(self):
         """Does s3 multipart chunking work correctly?"""
         # write
-        smart_open_write = smart_open.s3.BufferedOutputBase(
+        smart_open_write = smart_open.s3.BufferedMultiPartOutputBase(
             BUCKET_NAME, WRITE_KEY_NAME, min_part_size=10
         )
         with smart_open_write as fout:
@@ -369,7 +369,7 @@ class BufferedOutputBaseTest(unittest.TestCase):
 
     def test_write_04(self):
         """Does writing no data cause key with an empty value to be created?"""
-        smart_open_write = smart_open.s3.BufferedOutputBase(BUCKET_NAME, WRITE_KEY_NAME)
+        smart_open_write = smart_open.s3.BufferedMultiPartOutputBase(BUCKET_NAME, WRITE_KEY_NAME)
         with smart_open_write as fout:  # noqa
             pass
 
@@ -380,7 +380,7 @@ class BufferedOutputBaseTest(unittest.TestCase):
 
     def test_gzip(self):
         expected = u'а не спеть ли мне песню... о любви'.encode('utf-8')
-        with smart_open.s3.BufferedOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fout:
+        with smart_open.s3.BufferedMultiPartOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fout:
             with gzip.GzipFile(fileobj=fout, mode='w') as zipfile:
                 zipfile.write(expected)
 
@@ -397,7 +397,7 @@ class BufferedOutputBaseTest(unittest.TestCase):
         """
         expected = u'не думай о секундах свысока'
 
-        with smart_open.s3.BufferedOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fout:
+        with smart_open.s3.BufferedMultiPartOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fout:
             with io.BufferedWriter(fout) as sub_out:
                 sub_out.write(expected.encode('utf-8'))
 
@@ -448,6 +448,101 @@ class BufferedOutputBaseTest(unittest.TestCase):
 
         boto3_body = returned_obj.get()['Body'].read()
         self.assertEqual(contents, boto3_body)
+
+
+@maybe_mock_s3
+class BufferedSinglePartOutputBaseTest(unittest.TestCase):
+    """
+    Test writing into s3 files using single part upload.
+
+    """
+    def setUp(self):
+        ignore_resource_warnings()
+
+    def tearDown(self):
+        cleanup_bucket()
+
+    def test_write_01(self):
+        """Does writing into s3 work correctly?"""
+        test_string = u"žluťoučký koníček".encode('utf8')
+
+        # write into key
+        with smart_open.s3.BufferedSinglePartOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fout:
+            fout.write(test_string)
+
+        # read key and test content
+        output = list(smart_open.smart_open("s3://{}/{}".format(BUCKET_NAME, WRITE_KEY_NAME), "rb"))
+
+        self.assertEqual(output, [test_string])
+
+    def test_write_01a(self):
+        """Does s3 write fail on incorrect input?"""
+        try:
+            with smart_open.s3.BufferedSinglePartOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fin:
+                fin.write(None)
+        except TypeError:
+            pass
+        else:
+            self.fail()
+
+    def test_write_02(self):
+        """Does s3 write unicode-utf8 conversion work?"""
+        test_string = u"testžížáč".encode("utf-8")
+
+        smart_open_write = smart_open.s3.BufferedSinglePartOutputBase(BUCKET_NAME, WRITE_KEY_NAME)
+        smart_open_write.tell()
+        logger.info("smart_open_write: %r", smart_open_write)
+        with smart_open_write as fout:
+            fout.write(test_string)
+            self.assertEqual(fout.tell(), 14)
+
+    def test_write_04(self):
+        """Does writing no data cause key with an empty value to be created?"""
+        smart_open_write = smart_open.s3.BufferedSinglePartOutputBase(BUCKET_NAME, WRITE_KEY_NAME)
+        with smart_open_write as fout:  # noqa
+            pass
+
+        # read back the same key and check its content
+        output = list(smart_open.smart_open("s3://{}/{}".format(BUCKET_NAME, WRITE_KEY_NAME)))
+
+        self.assertEqual(output, [])
+
+    def test_buffered_writer_wrapper_works(self):
+        """
+        Ensure that we can wrap a smart_open s3 stream in a BufferedWriter, which
+        passes a memoryview object to the underlying stream in python >= 2.7
+        """
+        expected = u'не думай о секундах свысока'
+
+        with smart_open.s3.BufferedSinglePartOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fout:
+            with io.BufferedWriter(fout) as sub_out:
+                sub_out.write(expected.encode('utf-8'))
+
+        with smart_open.smart_open("s3://{}/{}".format(BUCKET_NAME, WRITE_KEY_NAME)) as fin:
+            with io.TextIOWrapper(fin, encoding='utf-8') as text:
+                actual = text.read()
+
+        self.assertEqual(expected, actual)
+
+    def test_nonexisting_bucket(self):
+        expected = u"выйду ночью в поле с конём".encode('utf-8')
+        with self.assertRaises(ValueError):
+            with smart_open.s3.open('thisbucketdoesntexist', 'mykey', 'wb', multipart_upload=False) as fout:
+                fout.write(expected)
+
+    def test_double_close(self):
+        text = u'там за туманами, вечными, пьяными'.encode('utf-8')
+        fout = smart_open.s3.open(BUCKET_NAME, 'key', 'wb', multipart_upload=False)
+        fout.write(text)
+        fout.close()
+        fout.close()
+
+    def test_flush_close(self):
+        text = u'там за туманами, вечными, пьяными'.encode('utf-8')
+        fout = smart_open.s3.open(BUCKET_NAME, 'key', 'wb', multipart_upload=False)
+        fout.write(text)
+        fout.flush()
+        fout.close()
 
 
 class ClampTest(unittest.TestCase):

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -302,7 +302,7 @@ class SeekableBufferedInputBaseTest(unittest.TestCase):
 
 
 @maybe_mock_s3
-class BufferedMultiPartOutputBaseTest(unittest.TestCase):
+class MultipartWriterTest(unittest.TestCase):
     """
     Test writing into s3 files.
 
@@ -318,7 +318,7 @@ class BufferedMultiPartOutputBaseTest(unittest.TestCase):
         test_string = u"žluťoučký koníček".encode('utf8')
 
         # write into key
-        with smart_open.s3.BufferedMultiPartOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fout:
+        with smart_open.s3.MultipartWriter(BUCKET_NAME, WRITE_KEY_NAME) as fout:
             fout.write(test_string)
 
         # read key and test content
@@ -329,7 +329,7 @@ class BufferedMultiPartOutputBaseTest(unittest.TestCase):
     def test_write_01a(self):
         """Does s3 write fail on incorrect input?"""
         try:
-            with smart_open.s3.BufferedMultiPartOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fin:
+            with smart_open.s3.MultipartWriter(BUCKET_NAME, WRITE_KEY_NAME) as fin:
                 fin.write(None)
         except TypeError:
             pass
@@ -338,7 +338,7 @@ class BufferedMultiPartOutputBaseTest(unittest.TestCase):
 
     def test_write_02(self):
         """Does s3 write unicode-utf8 conversion work?"""
-        smart_open_write = smart_open.s3.BufferedMultiPartOutputBase(BUCKET_NAME, WRITE_KEY_NAME)
+        smart_open_write = smart_open.s3.MultipartWriter(BUCKET_NAME, WRITE_KEY_NAME)
         smart_open_write.tell()
         logger.info("smart_open_write: %r", smart_open_write)
         with smart_open_write as fout:
@@ -348,7 +348,7 @@ class BufferedMultiPartOutputBaseTest(unittest.TestCase):
     def test_write_03(self):
         """Does s3 multipart chunking work correctly?"""
         # write
-        smart_open_write = smart_open.s3.BufferedMultiPartOutputBase(
+        smart_open_write = smart_open.s3.MultipartWriter(
             BUCKET_NAME, WRITE_KEY_NAME, min_part_size=10
         )
         with smart_open_write as fout:
@@ -369,7 +369,7 @@ class BufferedMultiPartOutputBaseTest(unittest.TestCase):
 
     def test_write_04(self):
         """Does writing no data cause key with an empty value to be created?"""
-        smart_open_write = smart_open.s3.BufferedMultiPartOutputBase(BUCKET_NAME, WRITE_KEY_NAME)
+        smart_open_write = smart_open.s3.MultipartWriter(BUCKET_NAME, WRITE_KEY_NAME)
         with smart_open_write as fout:  # noqa
             pass
 
@@ -380,7 +380,7 @@ class BufferedMultiPartOutputBaseTest(unittest.TestCase):
 
     def test_gzip(self):
         expected = u'а не спеть ли мне песню... о любви'.encode('utf-8')
-        with smart_open.s3.BufferedMultiPartOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fout:
+        with smart_open.s3.MultipartWriter(BUCKET_NAME, WRITE_KEY_NAME) as fout:
             with gzip.GzipFile(fileobj=fout, mode='w') as zipfile:
                 zipfile.write(expected)
 
@@ -397,7 +397,7 @@ class BufferedMultiPartOutputBaseTest(unittest.TestCase):
         """
         expected = u'не думай о секундах свысока'
 
-        with smart_open.s3.BufferedMultiPartOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fout:
+        with smart_open.s3.MultipartWriter(BUCKET_NAME, WRITE_KEY_NAME) as fout:
             with io.BufferedWriter(fout) as sub_out:
                 sub_out.write(expected.encode('utf-8'))
 
@@ -451,7 +451,7 @@ class BufferedMultiPartOutputBaseTest(unittest.TestCase):
 
 
 @maybe_mock_s3
-class BufferedSinglePartOutputBaseTest(unittest.TestCase):
+class SinglepartWriterTest(unittest.TestCase):
     """
     Test writing into s3 files using single part upload.
 
@@ -467,7 +467,7 @@ class BufferedSinglePartOutputBaseTest(unittest.TestCase):
         test_string = u"žluťoučký koníček".encode('utf8')
 
         # write into key
-        with smart_open.s3.BufferedSinglePartOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fout:
+        with smart_open.s3.SinglepartWriter(BUCKET_NAME, WRITE_KEY_NAME) as fout:
             fout.write(test_string)
 
         # read key and test content
@@ -478,7 +478,7 @@ class BufferedSinglePartOutputBaseTest(unittest.TestCase):
     def test_write_01a(self):
         """Does s3 write fail on incorrect input?"""
         try:
-            with smart_open.s3.BufferedSinglePartOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fin:
+            with smart_open.s3.SinglepartWriter(BUCKET_NAME, WRITE_KEY_NAME) as fin:
                 fin.write(None)
         except TypeError:
             pass
@@ -489,7 +489,7 @@ class BufferedSinglePartOutputBaseTest(unittest.TestCase):
         """Does s3 write unicode-utf8 conversion work?"""
         test_string = u"testžížáč".encode("utf-8")
 
-        smart_open_write = smart_open.s3.BufferedSinglePartOutputBase(BUCKET_NAME, WRITE_KEY_NAME)
+        smart_open_write = smart_open.s3.SinglepartWriter(BUCKET_NAME, WRITE_KEY_NAME)
         smart_open_write.tell()
         logger.info("smart_open_write: %r", smart_open_write)
         with smart_open_write as fout:
@@ -498,7 +498,7 @@ class BufferedSinglePartOutputBaseTest(unittest.TestCase):
 
     def test_write_04(self):
         """Does writing no data cause key with an empty value to be created?"""
-        smart_open_write = smart_open.s3.BufferedSinglePartOutputBase(BUCKET_NAME, WRITE_KEY_NAME)
+        smart_open_write = smart_open.s3.SinglepartWriter(BUCKET_NAME, WRITE_KEY_NAME)
         with smart_open_write as fout:  # noqa
             pass
 
@@ -514,7 +514,7 @@ class BufferedSinglePartOutputBaseTest(unittest.TestCase):
         """
         expected = u'не думай о секундах свысока'
 
-        with smart_open.s3.BufferedSinglePartOutputBase(BUCKET_NAME, WRITE_KEY_NAME) as fout:
+        with smart_open.s3.SinglepartWriter(BUCKET_NAME, WRITE_KEY_NAME) as fout:
             with io.BufferedWriter(fout) as sub_out:
                 sub_out.write(expected.encode('utf-8'))
 


### PR DESCRIPTION
I had encountered a use case, where I needed to upload many different files into S3 and wanted to use smart_open. The files were a large set of small and some sporadic large files.

Writing all the files to my S3 bucket proved slow, since smart_open is meant for large file and does thus use multipart upload. This resulted in significant overhead.

I am a huge fan of the smart_open interface and ease of use, and though about how such a use case could be supported in smart_open. 

I fixed my issue, by introducing an optional parameter hinting at the size of the input stream (often this is known) and then added the possibility for the S3 writer to use direct upload if better suited.

This PR is far from done (no handling of what happens if the input stream proves larger than claimed) and I just wanted to propose and start a discussion on such a feature. Further, there are many different ways on how smart_open could be guided to use direct upload. Maybe this is not even wanted...

Therefore, thanks for having a look at this and let's start a discussion and I am happy to adjust my implementation :)
