### PR TITLE
WIP support ACL's x-amz-acl via resource_kwargs (apply on s3's BufferedOutputBase close)

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -492,6 +492,9 @@ multipart upload may fail")
         if multipart_upload_kwargs is None:
             multipart_upload_kwargs = {}
 
+        if 'x-amz-acl' in resource_kwargs:
+            self._x_amz_acl = resource_kwargs.pop('x-amz-acl')
+
         s3 = session.resource('s3', **resource_kwargs)
         try:
             self._object = s3.Object(bucket, key)
@@ -537,6 +540,10 @@ multipart upload may fail")
             self._mp.abort()
 
             self._object.put(Body=b'')
+
+        if self._x_amz_acl:
+            self._object.Acl().put(ACL=self._x_amz_acl)
+
         self._mp = None
         logger.debug("successfully closed")
 


### PR DESCRIPTION
#### support ACL's x-amz-acl via resource_kwargs (apply on s3's BufferedOutputBase close)

#### Motivation

We often need to support uploading files to S3 buckets from different accounts. 

In order for the S3 object to be visible from the account that owns the bucket the ACL needs to be set. A quick way is to use the built in: x-amz-acl

In this PR I overload the resource_kwargs used within s3.py so that we can pass x-amz-acl which is then applied during the close for BufferedOutputBase objects.

#### Tests

Let me know what tests you would like me to write for it. Keep in mind that the upload doesn't fail unless the owner of the bucket refuses the object creation (may point to whether or not the close is the right place). So a test would require 2 accounts an upload afterwards download from a separate account.

#### Work in progress

Flagged as WIP pending comments on testing.

#### Checklist

Before you create the PR, please make sure you have:

- [X] Picked a concise, informative and complete title
- [X] Clearly explained the motivation behind the PR
- [ ] Linked to any existing issues that your PR will be solving
- [ ] Included tests for any new functionality
- [ ] Checked that all unit tests pass
