### PR TITLE
enable smart_open to operate without docstrings

### DIFF
--- a/smart_open/doctools.py
+++ b/smart_open/doctools.py
@@ -63,6 +63,9 @@ def extract_kwargs(docstring):
     ('bar', 'str, optional', ['This parameter is the bar.'])
 
     """
+    if not docstring:
+        return []
+
     lines = inspect.cleandoc(docstring).split('\n')
     retval = []
 

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -363,7 +363,10 @@ def open(
     return decoded
 
 
-open.__doc__ = open.__doc__ % {
+#
+# The docstring can be None if -OO was passed to the interpreter.
+#
+open.__doc__ = None if open.__doc__ is None else open.__doc__ % {
     's3': doctools.to_docstring(
         doctools.extract_kwargs(smart_open_s3.open.__doc__),
         lpad=u'    ',


### PR DESCRIPTION
#### Motivation

Fix #396 

The below command was causing a crash:

```
$ python -OO -c 'import smart_open'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/misha/git/smart_open/smart_open/__init__.py", line 27, in <module>
    from .smart_open_lib import open, smart_open, register_compressor
  File "/home/misha/git/smart_open/smart_open/smart_open_lib.py", line 368, in <module>
    doctools.extract_kwargs(smart_open_s3.open.__doc__),
  File "/home/misha/git/smart_open/smart_open/doctools.py", line 66, in extract_kwargs
    lines = inspect.cleandoc(docstring).split('\n')
  File "/usr/lib/python3.6/inspect.py", line 620, in cleandoc
    lines = doc.expandtabs().split('\n')
AttributeError: 'NoneType' object has no attribute 'expandtabs'
```

The present PR fixes the underlying issue.

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [ ] Linked to any existing issues that your PR will be solving
- [ ] Included tests for any new functionality
- [ ] Checked that all unit tests pass
