### PR TITLE
Fix Travis Build

### DIFF
--- a/smart_open/tests/test_gcs.py
+++ b/smart_open/tests/test_gcs.py
@@ -29,7 +29,7 @@ import smart_open
 BUCKET_NAME = 'test-smartopen-{}'.format(uuid.uuid4().hex)
 BLOB_NAME = 'test-blob'
 WRITE_BLOB_NAME = 'test-write-blob'
-DISABLE_MOCKS = os.environ.get('SO_DISABLE_MOCKS') == "1"
+DISABLE_MOCKS = os.environ.get('SO_DISABLE_GCS_MOCKS') == "1"
 
 RESUMABLE_SESSION_URI_TEMPLATE = (
     'https://www.googleapis.com/upload/storage/v1/b/'


### PR DESCRIPTION
#### Fix Travis Build

#### Motivation

https://github.com/RaRe-Technologies/smart_open/pull/404 made Travis fail due to GCS mocks being enabled when they shouldn't have. We can fix this by changing GCS mocks to toggle from  an environment variable specific to GCS instead of the same one as S3.

Odd this didn't fail on the gcs branch, it doesn't look like the Travis build is different for branches and master?

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [ ] Linked to any existing issues that your PR will be solving
- [ ] Included tests for any new functionality
- [X] Checked that all unit tests pass
