### PR TITLE
implemented efficient readline for ByteBuffer

### DIFF
--- a/integration-tests/test_s3_readline.py
+++ b/integration-tests/test_s3_readline.py
@@ -1,0 +1,26 @@
+import sys
+from smart_open import open
+
+
+def read_lines(url, limit):
+    lines = []
+    with open(url, 'r', errors='ignore') as fin:
+        for i, l in enumerate(fin):
+            if i == limit:
+                break
+            lines.append(l)
+
+    return lines
+
+
+def test(benchmark):
+    #
+    # This file is around 850MB.
+    #
+    url = (
+        's3://commoncrawl/crawl-data/CC-MAIN-2019-51/segments/1575541319511.97'
+        '/warc/CC-MAIN-20191216093448-20191216121448-00559.warc.gz'
+    )
+    limit = 1000000
+    lines = benchmark(read_lines, url, limit)
+    assert len(lines) == limit

--- a/integration-tests/test_s3_readline.py
+++ b/integration-tests/test_s3_readline.py
@@ -1,4 +1,3 @@
-import sys
 from smart_open import open
 
 

--- a/smart_open/bytebuffer.py
+++ b/smart_open/bytebuffer.py
@@ -159,3 +159,22 @@ class ByteBuffer(object):
 
         self._bytes += new_bytes
         return len(new_bytes)
+
+    def readline(self, terminator):
+        """Efficiently reads a line from this buffer.
+
+        A line is a contiguous sequence of bytes that ends with either:
+
+        1. The ``terminator`` character
+        2. The end of the buffer itself
+
+        :param byte terminator: The line terminator character.
+        :rtype: bytes
+
+        """
+        index = self._bytes.find(terminator, self._pos)
+        if index == -1:
+            size = len(self)
+        else:
+            size = index - self._pos + 1
+        return self.read(size)

--- a/smart_open/bytebuffer.py
+++ b/smart_open/bytebuffer.py
@@ -161,7 +161,7 @@ class ByteBuffer(object):
         return len(new_bytes)
 
     def readline(self, terminator):
-        """Efficiently reads a line from this buffer.
+        """Read a line from this buffer efficiently.
 
         A line is a contiguous sequence of bytes that ends with either:
 

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -338,24 +338,22 @@ class Reader(io.BufferedIOBase):
         """Read up to and including the next newline.  Returns the bytes read."""
         if limit != -1:
             raise NotImplementedError('limits other than -1 not implemented yet')
-        the_line = io.BytesIO()
+
+        #
+        # A single line may span multiple buffers.
+        #
+        line = io.BytesIO()
         while not (self._eof and len(self._buffer) == 0):
-            #
-            # In the worst case, we're reading the unread part of self._buffer
-            # twice here, once in the if condition and once when calling index.
-            #
-            # This is sub-optimal, but better than the alternative: wrapping
-            # .index in a try..except, because that is slower.
-            #
-            remaining_buffer = self._buffer.peek()
-            if self._line_terminator in remaining_buffer:
-                next_newline = remaining_buffer.index(self._line_terminator)
-                the_line.write(self._read_from_buffer(next_newline + 1))
+            line_part = self._buffer.readline(self._line_terminator)
+            line.write(line_part)
+            self._current_pos += len(line_part)
+
+            if line_part.endswith(self._line_terminator):
                 break
             else:
-                the_line.write(self._read_from_buffer())
                 self._fill_buffer()
-        return the_line.getvalue()
+
+        return line.getvalue()
 
     def seekable(self):
         """If False, seek(), tell() and truncate() will raise IOError.

--- a/smart_open/tests/test_bytebuffer.py
+++ b/smart_open/tests/test_bytebuffer.py
@@ -5,6 +5,7 @@
 # This code is distributed under the terms and conditions
 # from the MIT License (MIT).
 #
+import io
 import random
 import unittest
 
@@ -152,3 +153,37 @@ class ByteBufferTest(unittest.TestCase):
 
         self.assertEqual(buf.read(CHUNK_SIZE*2), contents[read_size:])
         self.assertEqual(len(buf), 0)
+
+    def test_readline(self):
+        """Does the readline function work as expected in the simple case?"""
+        expected = (b'this is the very first line\n', b'and this the second')
+        buf = smart_open.bytebuffer.ByteBuffer()
+        buf.fill(io.BytesIO(b''.join(expected)))
+
+        first_line = buf.readline(b'\n')
+        self.assertEqual(expected[0], first_line)
+
+        second_line = buf.readline(b'\n')
+        self.assertEqual(expected[1], second_line)
+
+    def test_readline_middle(self):
+        """Does the readline function work when we're in the middle of the buffer?"""
+        expected = (b'this is the very first line\n', b'and this the second')
+        buf = smart_open.bytebuffer.ByteBuffer()
+        buf.fill(io.BytesIO(b''.join(expected)))
+
+        buf.read(5)
+        first_line = buf.readline(b'\n')
+        self.assertEqual(expected[0][5:], first_line)
+
+        buf.read(5)
+        second_line = buf.readline(b'\n')
+        self.assertEqual(expected[1][5:], second_line)
+
+    def test_readline_terminator(self):
+        """Does the readline function respect the terminator parameter?"""
+        buf = smart_open.bytebuffer.ByteBuffer()
+        buf.fill(io.BytesIO(b'one!two.three,'))
+        expected = [b'one!', b'two.', b'three,']
+        actual = [buf.readline(b'!'), buf.readline(b'.'), buf.readline(b',')]
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
#### Motivation

The previous implementation searched for the terminator in the buffer twice. This was unnecessary.

The new implementaiton performs the search only once.

- Fixes #371 

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass