### PR TITLE
improve buffering efficiency

### DIFF
--- a/integration-tests/test_s3_buffering.py
+++ b/integration-tests/test_s3_buffering.py
@@ -1,4 +1,3 @@
-import sys
 from smart_open import open
 
 

--- a/integration-tests/test_s3_buffering.py
+++ b/integration-tests/test_s3_buffering.py
@@ -1,0 +1,24 @@
+import sys
+from smart_open import open
+
+
+def read_bytes(url, limit):
+    bytes_ = []
+    with open(url, 'rb') as fin:
+        for i in range(limit):
+            bytes_.append(fin.read(1))
+
+    return bytes_
+
+
+def test(benchmark):
+    #
+    # This file is around 850MB.
+    #
+    url = (
+        's3://commoncrawl/crawl-data/CC-MAIN-2019-51/segments/1575541319511.97'
+        '/warc/CC-MAIN-20191216093448-20191216121448-00559.warc.gz'
+    )
+    limit = 1000000
+    bytes_ = benchmark(read_bytes, url, limit)
+    assert len(bytes_) == limit

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -314,10 +314,6 @@ class Reader(io.BufferedIOBase):
         if self._eof:
             return self._read_from_buffer()
 
-        #
-        # Fill our buffer to the required size.
-        #
-        # logger.debug('filling %r byte-long buffer up to %r bytes', len(self._buffer), size)
         self._fill_buffer(size)
         return self._read_from_buffer(size)
 
@@ -430,7 +426,7 @@ class Reader(io.BufferedIOBase):
         return part
 
     def _fill_buffer(self, size=-1):
-        size = size if size >= 0 else self._buffer._chunk_size
+        size = max(size, self._buffer._chunk_size)
         while len(self._buffer) < size and not self._eof:
             bytes_read = self._buffer.fill(self._raw_reader)
             if bytes_read == 0:


### PR DESCRIPTION
#### Motivation

This fixes an edge case where the user performs multiple sequential reads of a small number of bytes, e.g. one byte at a time. The previous implementation would fill the buffer one byte a time, which negates the benefit of using a buffer.

The new implementation fixes the above problem by always reading in chunks that are larger than a sensible threshold (currently equal to io.DEFAULT_BUFFER_SIZE).

- Fixes #348

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass