### PR TITLE
Add pathlib monkeypatch with replacement of `pathlib.Path.open`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -395,13 +395,13 @@ Now you can natively use ``smart_open.open`` with your ``Path`` objects
   >> patch_pathlib()  # replace `Path.open` with `smart_open.open`
   >>
   >> path = Path("smart_open/tests/test_data/crime-and-punishment.txt.gz")
-  >>>
+  >>
   >> with path.open("r") as infile:
   ..     # not possible with standard `Path.open` (because gzipped),
   ..     # but works perfectly with "patched" version by `smart_open`
   ..     for line in infile:
   ..         print(line)
-
+  ..         break
 
 Comments, bug reports
 =====================

--- a/README.rst
+++ b/README.rst
@@ -392,7 +392,7 @@ Now you can natively use ``smart_open.open`` with your ``Path`` objects
   >>> from pathlib import Path
   >>> from smart_open.smart_open_lib import patch_pathlib
   >>>
-  >>> patch_pathlib()  # replace `Path.open` with `smart_open.open`
+  >>> _ = patch_pathlib()  # replace `Path.open` with `smart_open.open`
   >>>
   >>> path = Path("smart_open/tests/test_data/crime-and-punishment.txt.gz")
   >>>
@@ -400,8 +400,9 @@ Now you can natively use ``smart_open.open`` with your ``Path`` objects
   ...     # not possible with standard `Path.open` (because gzipped),
   ...     # but works perfectly with "patched" version by `smart_open`
   ...     for line in infile:
-  ...         print(line)
+  ...         print(repr(line))
   ...         break
+  'В начале июля, в чрезвычайно жаркое время, под вечер, один молодой человек вышел из своей каморки, которую нанимал от жильцов в С -- м переулке, на улицу и медленно, как бы в нерешимости, отправился к К -- ну мосту.\n'
 
 Comments, bug reports
 =====================

--- a/README.rst
+++ b/README.rst
@@ -389,19 +389,19 @@ Now you can natively use ``smart_open.open`` with your ``Path`` objects
 
 .. code-block:: python
 
-  >> from pathlib import Path
-  >> from smart_open.smart_open_lib import patch_pathlib
-  >>
-  >> patch_pathlib()  # replace `Path.open` with `smart_open.open`
-  >>
-  >> path = Path("smart_open/tests/test_data/crime-and-punishment.txt.gz")
-  >>
-  >> with path.open("r") as infile:
-  ..     # not possible with standard `Path.open` (because gzipped),
-  ..     # but works perfectly with "patched" version by `smart_open`
-  ..     for line in infile:
-  ..         print(line)
-  ..         break
+  >>> from pathlib import Path
+  >>> from smart_open.smart_open_lib import patch_pathlib
+  >>>
+  >>> patch_pathlib()  # replace `Path.open` with `smart_open.open`
+  >>>
+  >>> path = Path("smart_open/tests/test_data/crime-and-punishment.txt.gz")
+  >>>
+  >>> with path.open("r") as infile:
+  ...     # not possible with standard `Path.open` (because gzipped),
+  ...     # but works perfectly with "patched" version by `smart_open`
+  ...     for line in infile:
+  ...         print(line)
+  ...         break
 
 Comments, bug reports
 =====================

--- a/README.rst
+++ b/README.rst
@@ -382,6 +382,26 @@ If your file object doesn't have one, set the ``.name`` attribute to an appropri
 Furthermore, that value has to end with a **known** file extension (see the ``register_compressor`` function).
 Otherwise, the transparent decompression will not occur.
 
+Drop-in replacement of ``pathlib.Path.open``
+--------------------------------------------
+
+Now you can natively use ``smart_open.open`` with your ``Path`` objects
+
+.. code-block:: python
+
+  >> from pathlib import Path
+  >> from smart_open.smart_open_lib import patch_pathlib
+  >>
+  >> patch_pathlib()  # replace `Path.open` with `smart_open.open`
+  >>
+  >> path = Path("/path/to/my/fize.gz")
+  >> with path.open("r") as infile:
+  ..     # not possible with standard `Path.open` (because gzipped),
+  ..     # but works perfectly with "patching"
+  ..     for line in infile:
+  ..         print(line)
+
+
 Comments, bug reports
 =====================
 

--- a/README.rst
+++ b/README.rst
@@ -385,7 +385,8 @@ Otherwise, the transparent decompression will not occur.
 Drop-in replacement of ``pathlib.Path.open``
 --------------------------------------------
 
-Now you can natively use ``smart_open.open`` with your ``Path`` objects
+Now you can natively use ``smart_open.open`` with your ``Path`` objects.
+You can't transparently read text from compressed file with original ``Path.open``, but can after ``patch_pathlib``.
 
 .. code-block:: python
 
@@ -397,8 +398,6 @@ Now you can natively use ``smart_open.open`` with your ``Path`` objects
   >>> path = Path("smart_open/tests/test_data/crime-and-punishment.txt.gz")
   >>>
   >>> with path.open("r") as infile:
-  ...     # not possible with standard `Path.open` (because gzipped),
-  ...     # but works perfectly with "patched" version by `smart_open`
   ...     for line in infile:
   ...         print(repr(line))
   ...         break

--- a/README.rst
+++ b/README.rst
@@ -394,10 +394,11 @@ Now you can natively use ``smart_open.open`` with your ``Path`` objects
   >>
   >> patch_pathlib()  # replace `Path.open` with `smart_open.open`
   >>
-  >> path = Path("/path/to/my/fize.gz")
+  >> path = Path("smart_open/tests/test_data/crime-and-punishment.txt.gz")
+  >>>
   >> with path.open("r") as infile:
   ..     # not possible with standard `Path.open` (because gzipped),
-  ..     # but works perfectly with "patching"
+  ..     # but works perfectly with "patched" version by `smart_open`
   ..     for line in infile:
   ..         print(line)
 

--- a/README.rst
+++ b/README.rst
@@ -398,10 +398,8 @@ You can't transparently read text from compressed file with original ``Path.open
   >>> path = Path("smart_open/tests/test_data/crime-and-punishment.txt.gz")
   >>>
   >>> with path.open("r") as infile:
-  ...     for line in infile:
-  ...         print(repr(line))
-  ...         break
-  'В начале июля, в чрезвычайно жаркое время, под вечер, один молодой человек вышел из своей каморки, которую нанимал от жильцов в С -- м переулке, на улицу и медленно, как бы в нерешимости, отправился к К -- ну мосту.\n'
+  ...     print(infile.readline()[:41])
+  В начале июля, в чрезвычайно жаркое время
 
 Comments, bug reports
 =====================

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -928,3 +928,13 @@ def _encoding_wrapper(fileobj, mode, encoding=None, errors=None):
     if mode[0] in ('w', 'a') or mode.endswith('+'):
         fileobj = codecs.getwriter(encoding)(fileobj, **kw)
     return fileobj
+
+
+def patch_pathlib():
+    """Replace `Path.open` with `smart_open.open`"""
+    pathlib = sys.modules.get("pathlib", None)
+
+    if pathlib:
+        pathlib.Path.open = open
+    else:
+        warnings.warn("Can't patch 'pathlib.Path.open', you should import 'pathlib' first")

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -947,9 +947,9 @@ def _patch_pathlib(func):
     """Replace `Path.open` with `func`"""
     pathlib = sys.modules.get("pathlib", None)
 
-    if pathlib:
-        old_impl = pathlib.Path.open
-        pathlib.Path.open = func
-        return old_impl
-    else:
+    if not pathlib:
         raise RuntimeError("Can't patch 'pathlib.Path.open', you should import 'pathlib' first")
+
+    old_impl = pathlib.Path.open
+    pathlib.Path.open = func
+    return old_impl

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -13,6 +13,7 @@ import logging
 import tempfile
 import os
 import hashlib
+import pathlib
 
 import boto3
 import mock
@@ -24,6 +25,7 @@ import six
 import smart_open
 from smart_open import smart_open_lib
 from smart_open import webhdfs
+from smart_open.smart_open_lib import patch_pathlib
 
 logger = logging.getLogger(__name__)
 
@@ -286,6 +288,12 @@ class ParseUriTest(unittest.TestCase):
         self.assertEqual(parsed_uri.scheme, "gs")
         self.assertEqual(parsed_uri.bucket_id, "mybucket")
         self.assertEqual(parsed_uri.blob_id, "mydir/myblob")
+
+    def test_pathlib_monkeypath(self):
+        assert pathlib.Path.open != smart_open.open
+        patch_pathlib()
+        assert pathlib.Path.open == smart_open.open
+
 
 
 class SmartOpenHttpTest(unittest.TestCase):


### PR DESCRIPTION
## Problem

If you use `pathlib.Path` instead of `str` in your code, you should use the internal `open` method like

```python
with mypath.open("r") as infile:
    ...
```
of course, you can pass them to `smart_open` like this

```python
with smart_open.open(mypath, 'r') as infile:
    ...
```
but this doesn't looks "good enough"

## Solution

I implement "mokeypatch" function that replaces `pathlib.Path.open` to `smart_open.open`

## Example

```python
from pathlib import Path
from smart_open.smart_open_lib import patch_pathlib

patch_pathlib()

pth = Path("/dev/random")

with pth.open("rb") as infile:
    print(pth.read(4))
```



