### PR TITLE
Add "downloads" badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,12 +2,14 @@
 smart_open — utils for streaming large files in Python
 ======================================================
 
-|License|_ |Travis|_
+|License|_ |Travis|_ |Downloads|_
 
 .. |License| image:: https://img.shields.io/pypi/l/smart_open.svg
 .. |Travis| image:: https://travis-ci.org/RaRe-Technologies/smart_open.svg?branch=master
-.. _Travis: https://travis-ci.org/RaRe-Technologies/smart_open
+.. |Downloads| image:: https://pepy.tech/badge/smart-open/month
 .. _License: https://github.com/RaRe-Technologies/smart_open/blob/master/LICENSE
+.. _Travis: https://travis-ci.org/RaRe-Technologies/smart_open
+.. _Downloads: https://pypi.org/project/smart-open/
 
 What?
 =====


### PR DESCRIPTION
Trying the idea from #440.

#### Motivation

In general, seeing how much others use a package improves confidence in its robustness and maintenance. A kind of social proof.

I see no downsides, except if the service that provides this badge (https://pepy.tech/) proves unstable or unreliable.

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass