### PR TITLE
Fix error when calling str() or repr() on GCS SeekableBufferedInputBase

### DIFF
--- a/smart_open/gcs.py
+++ b/smart_open/gcs.py
@@ -213,7 +213,8 @@ class SeekableBufferedInputBase(io.BufferedIOBase):
         self._blob = client.get_bucket(bucket).get_blob(key)  # type: google.cloud.storage.Blob
 
         if self._blob is None:
-            raise google.cloud.exceptions.NotFound('blob {} not found in {}'.format(key, bucket))
+            raise google.cloud.exceptions.NotFound('blob %s not found in %s' % (key, bucket))
+
         self._size = self._blob.size if self._blob.size is not None else 0
 
         self._raw_reader = _SeekableRawReader(self._blob, self._size)

--- a/smart_open/gcs.py
+++ b/smart_open/gcs.py
@@ -209,11 +209,11 @@ class SeekableBufferedInputBase(io.BufferedIOBase):
     ):
         if client is None:
             client = google.cloud.storage.Client()
-        bucket = client.get_bucket(bucket)  # type: google.cloud.storage.Bucket
+        self._bucket = client.get_bucket(bucket)  # type: google.cloud.storage.Bucket
 
-        self._blob = bucket.get_blob(key)
+        self._blob = self._bucket.get_blob(key)
         if self._blob is None:
-            raise google.cloud.exceptions.NotFound('blob {} not found in {}'.format(key, bucket))
+            raise google.cloud.exceptions.NotFound('blob {} not found in {}'.format(key, self._bucket.name))
         self._size = self._blob.size if self._blob.size is not None else 0
 
         self._raw_reader = _SeekableRawReader(self._blob, self._size)

--- a/smart_open/gcs.py
+++ b/smart_open/gcs.py
@@ -210,12 +210,10 @@ class SeekableBufferedInputBase(io.BufferedIOBase):
         if client is None:
             client = google.cloud.storage.Client()
 
-        self._bucket_name = bucket
-        bucket = client.get_bucket(bucket)  # type: google.cloud.storage.Bucket
+        self._blob = client.get_bucket(bucket).get_blob(key)  # type: google.cloud.storage.Blob
 
-        self._blob = bucket.get_blob(key)
         if self._blob is None:
-            raise google.cloud.exceptions.NotFound('blob {} not found in {}'.format(key, self._bucket_name))
+            raise google.cloud.exceptions.NotFound('blob {} not found in {}'.format(key, bucket))
         self._size = self._blob.size if self._blob.size is not None else 0
 
         self._raw_reader = _SeekableRawReader(self._blob, self._size)
@@ -374,11 +372,11 @@ class SeekableBufferedInputBase(io.BufferedIOBase):
                 self._eof = True
 
     def __str__(self):
-        return "(%s, %r, %r)" % (self.__class__.__name__, self._bucket_name, self._blob.name)
+        return "(%s, %r, %r)" % (self.__class__.__name__, self._blob.bucket.name, self._blob.name)
 
     def __repr__(self):
         return "%s(bucket=%r, blob=%r, buffer_size=%r)" % (
-            self.__class__.__name__, self._bucket_name, self._blob.name, self._current_part_size,
+            self.__class__.__name__, self._blob.bucket.name, self._blob.name, self._current_part_size,
         )
 
 
@@ -398,9 +396,7 @@ class BufferedOutputBase(io.BufferedIOBase):
             client = google.cloud.storage.Client()
         self._client = client
         self._credentials = self._client._credentials  # noqa
-        self._bucket_name = bucket
-        bucket = self._client.bucket(bucket)  # type: google.cloud.storage.Bucket
-        self._blob = bucket.blob(blob)  # type: google.cloud.storage.Blob
+        self._blob = self._client.bucket(bucket).blob(blob)  # type: google.cloud.storage.Blob
         assert min_part_size % _REQUIRED_CHUNK_MULTIPLE == 0, 'min part size must be a multiple of 256KB'
         assert min_part_size >= _MIN_MIN_PART_SIZE, 'min part size must be greater than 256KB'
         self._min_part_size = min_part_size
@@ -599,9 +595,9 @@ class BufferedOutputBase(io.BufferedIOBase):
             self.close()
 
     def __str__(self):
-        return "(%s, %r, %r)" % (self.__class__.__name__, self._bucket_name, self._blob.name)
+        return "(%s, %r, %r)" % (self.__class__.__name__, self._blob.bucket.name, self._blob.name)
 
     def __repr__(self):
         return "%s(bucket=%r, blob=%r, min_part_size=%r)" % (
-            self.__class__.__name__, self._bucket_name, self._blob.name, self._min_part_size,
+            self.__class__.__name__, self._blob.bucket.name, self._blob.name, self._min_part_size,
         )


### PR DESCRIPTION
Fix `__repr__` and `__str__` on `gcs.SeekableBufferedInputBase` by storing the bucket as `_bucket` instead of `bucket`.

This is now consistent with [`gcs.BufferedOutputBase`](https://github.com/RaRe-Technologies/smart_open/blob/master/smart_open/gcs.py#L399) and [`s3. _SeekableRawReader`](https://github.com/RaRe-Technologies/smart_open/blob/master/smart_open/s3.py#L197) (which stores its S3 client as `_object`)

#### Motivation

We were seeing logging errors originating from smart_open:

```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/logging/__init__.py", line 1081, in emit msg = self.format(record)
  File "/usr/local/lib/python3.8/logging/__init__.py", line 925, in format return fmt.format(record)
  File "/usr/local/lib/python3.8/logging/__init__.py", line 664, in format record.message = record.getMessage()
  File "/usr/local/lib/python3.8/logging/__init__.py", line 369, in getMessage msg = msg % self.args
  File "/usr/local/lib/python3.8/gzip.py", line 220, in __repr__ s = repr(self.fileobj)
  File "/usr/local/lib/python3.8/site-packages/smart_open/gcs.py", line 379, in __repr__ self.__class__.__name__, self._bucket.name, self._blob.name, self._current_part_size, AttributeError: 'SeekableBufferedInputBase' object has no attribute '_bucket'
```