### PR TITLE
Allow accept_key function to use content metadata.

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -955,7 +955,8 @@ def iter_bucket(
     prefix: str, optional
         Limits the iteration to keys starting wit the prefix.
     accept_key: callable, optional
-        This is a function that accepts a key name (unicode string) and
+        This is a function that accepts a key name (unicode string), and optionally as a 
+        second argument, a dictionary of content metadata provided by S3, and 
         returns True/False, signalling whether the given key should be downloaded.
         The default behavior is to accept all keys.
     key_limit: int, optional
@@ -1061,7 +1062,14 @@ def _list_bucket(
         else:
             for c in content:
                 key = c['Key']
-                if accept_key(key):
+                # Enable accept_key() to optionally take `content` as a second argument.
+                try:
+                    is_included = accept_key(key)
+                except TypeError:
+                    # Python raises TypeError when the number or arguments doesn't match the required number.
+                    is_included = accept_key(key, content)
+           
+                if is_included:
                     yield key
         ctoken = response.get('NextContinuationToken', None)
         if not ctoken:

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -538,6 +538,16 @@ class IterBucketTest(unittest.TestCase):
         results = list(smart_open.s3.iter_bucket(BUCKET_NAME))
         self.assertEqual(len(results), 10)
 
+    def test_iter_bucket_accept_key(self):
+        """ Ensure accept_key function can have 1 or 2 arguments."""
+        populate_bucket()
+        results = list(smart_open.s3.iter_bucket(BUCKET_NAME,
+            accept_key=lambda key: False))
+        self.assertEqual(len(results), 0)
+        results = list(smart_open.s3.iter_bucket(BUCKET_NAME,
+            accept_key=lambda key, content: False))
+        self.assertEqual(len(results), 0)
+
     def test_accepts_boto3_bucket(self):
         populate_bucket()
         bucket = boto3.resource('s3').Bucket(BUCKET_NAME)


### PR DESCRIPTION
#### Title

Allow accept_key function to use content metadata.

#### Motivation

The goal here is to allow users to provide a more intelligent filtering function to iter_bucket that can consider the content metadata, and not just the key. For example, one could implement a function to include all files under a certain size, or updated since some date.

This is an alternative implementation to PR#324, which is likely more compatible (it should pass your test suite!) and may be better all-around; it's certainly more pythonic, IMO.

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [n/a] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass

