### PR TITLE
Correctly handle GCS paths that contain '?' char 

### DIFF
--- a/smart_open/gcs.py
+++ b/smart_open/gcs.py
@@ -10,7 +10,6 @@
 
 import io
 import logging
-import urllib.parse
 
 import google.cloud.exceptions
 import google.cloud.storage
@@ -90,7 +89,7 @@ def _fail(response, part_num, content_length, total_size, headers):
 
 
 def parse_uri(uri_as_string):
-    sr = urllib.parse.urlsplit(uri_as_string)
+    sr = smart_open.utils.safe_urlsplit(uri_as_string)
     assert sr.scheme == SCHEME
     bucket_id = sr.netloc
     blob_id = sr.path.lstrip('/')

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -11,7 +11,6 @@ import io
 import functools
 import logging
 import time
-import urllib.parse
 
 import boto
 import boto3
@@ -47,28 +46,6 @@ _UPLOAD_ATTEMPTS = 6
 _SLEEP_SECONDS = 10
 
 
-def _safe_urlsplit(url):
-    """This is a hack to prevent the regular urlsplit from splitting around question marks.
-
-    A question mark (?) in a URL typically indicates the start of a
-    querystring, and the standard library's urlparse function handles the
-    querystring separately.  Unfortunately, question marks can also appear
-    _inside_ the actual URL for some schemas like S3.
-
-    Replaces question marks with newlines prior to splitting.  This is safe because:
-
-    1. The standard library's urlsplit completely ignores newlines
-    2. Raw newlines will never occur in innocuous URLs.  They are always URL-encoded.
-
-    See Also
-    --------
-    https://github.com/python/cpython/blob/3.7/Lib/urllib/parse.py
-    https://github.com/RaRe-Technologies/smart_open/issues/285
-    """
-    sr = urllib.parse.urlsplit(url.replace('?', '\n'), allow_fragments=False)
-    return urllib.parse.SplitResult(sr.scheme, sr.netloc, sr.path.replace('\n', '?'), '', '')
-
-
 def parse_uri(uri_as_string):
     #
     # Restrictions on bucket names and labels:
@@ -82,7 +59,7 @@ def parse_uri(uri_as_string):
     # We use the above as a guide only, and do not perform any validation.  We
     # let boto3 take care of that for us.
     #
-    split_uri = _safe_urlsplit(uri_as_string)
+    split_uri = smart_open.utils.safe_urlsplit(uri_as_string)
     assert split_uri.scheme in SCHEMES
 
     port = DEFAULT_PORT

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -179,6 +179,12 @@ class ParseUriTest(unittest.TestCase):
         self.assertEqual(parsed_uri.access_id, None)
         self.assertEqual(parsed_uri.access_secret, None)
 
+    def test_s3_uri_contains_question_mark(self):
+        parsed_uri = smart_open_lib._parse_uri("s3://mybucket/mydir/mykey?param")
+        self.assertEqual(parsed_uri.scheme, "s3")
+        self.assertEqual(parsed_uri.bucket_id, "mybucket")
+        self.assertEqual(parsed_uri.key_id, "mydir/mykey?param")
+
     def test_host_and_port(self):
         as_string = 's3u://user:secret@host:1234@mybucket/mykey.txt'
         uri = smart_open_lib._parse_uri(as_string)
@@ -286,6 +292,12 @@ class ParseUriTest(unittest.TestCase):
         self.assertEqual(parsed_uri.scheme, "gs")
         self.assertEqual(parsed_uri.bucket_id, "mybucket")
         self.assertEqual(parsed_uri.blob_id, "mydir/myblob")
+
+    def test_gs_uri_contains_question_mark(self):
+        parsed_uri = smart_open_lib._parse_uri("gs://mybucket/mydir/myblob?param")
+        self.assertEqual(parsed_uri.scheme, "gs")
+        self.assertEqual(parsed_uri.bucket_id, "mybucket")
+        self.assertEqual(parsed_uri.blob_id, "mydir/myblob?param")
 
     def test_pathlib_monkeypatch(self):
         from smart_open.smart_open_lib import pathlib

--- a/smart_open/utils.py
+++ b/smart_open/utils.py
@@ -10,6 +10,7 @@
 
 import inspect
 import logging
+import urllib.parse
 
 logger = logging.getLogger(__name__)
 
@@ -116,3 +117,26 @@ def make_range_string(start, stop=None):
     if stop is None:
         return 'bytes=%d-' % start
     return 'bytes=%d-%d' % (start, stop)
+
+
+def safe_urlsplit(url):
+    """This is a hack to prevent the regular urlsplit from splitting around question marks.
+
+    A question mark (?) in a URL typically indicates the start of a
+    querystring, and the standard library's urlparse function handles the
+    querystring separately.  Unfortunately, question marks can also appear
+    _inside_ the actual URL for some schemas like S3, GS.
+
+    Replaces question marks with newlines prior to splitting.  This is safe because:
+
+    1. The standard library's urlsplit completely ignores newlines
+    2. Raw newlines will never occur in innocuous URLs.  They are always URL-encoded.
+
+    See Also
+    --------
+    https://github.com/python/cpython/blob/3.7/Lib/urllib/parse.py
+    https://github.com/RaRe-Technologies/smart_open/issues/285
+    https://github.com/RaRe-Technologies/smart_open/issues/458
+    """
+    sr = urllib.parse.urlsplit(url.replace('?', '\n'), allow_fragments=False)
+    return urllib.parse.SplitResult(sr.scheme, sr.netloc, sr.path.replace('\n', '?'), '', '')


### PR DESCRIPTION
#### Correctly handle GCS paths that contain '?' char 

#### Motivation

GCS (and s3) paths support the character '?' . Use of urllib.parse.urlsplit was splitting the path at '?' due to which such files cannot be opened.  This was already handled for S3 paths correctly. 
Moved the existing utility function in s3 to utils so that it can be called from both s3 and gcs implementations.

- Fixes #458 

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass

