### PR TITLE
Make our doctools submodule more robust

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -20,6 +20,8 @@ DESCRIPTION
 PACKAGE CONTENTS
     bytebuffer
     compression
+    concurrency
+    constants
     doctools
     gcs
     hdfs
@@ -85,9 +87,11 @@ FUNCTIONS
         
         file (smart_open/local_file.py)
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        Implements the transport for the file:// schema.
         
         gs (smart_open/gcs.py)
         ~~~~~~~~~~~~~~~~~~~~~~
+        Implements file-like objects for reading and writing to/from GCS.
         
         buffer_size: int, optional
             The buffer size to use when performing I/O. For reading only.
@@ -98,9 +102,11 @@ FUNCTIONS
         
         hdfs (smart_open/hdfs.py)
         ~~~~~~~~~~~~~~~~~~~~~~~~~
+        Implements reading and writing to/from HDFS.
         
         http (smart_open/http.py)
         ~~~~~~~~~~~~~~~~~~~~~~~~~
+        Implements file-like objects for reading from http.
         
         kerberos: boolean, optional
             If True, will attempt to use the local Kerberos credentials
@@ -115,6 +121,7 @@ FUNCTIONS
         
         s3 (smart_open/s3.py)
         ~~~~~~~~~~~~~~~~~~~~~
+        Implements file-like objects for reading and writing from/to AWS S3.
         
         buffer_size: int, optional
             The buffer size to use when performing I/O.
@@ -146,6 +153,7 @@ FUNCTIONS
         
         scp (smart_open/ssh.py)
         ~~~~~~~~~~~~~~~~~~~~~~~
+        Implements I/O streams over SSH.
         
         mode: str, optional
             The mode to use for opening the file.
@@ -163,6 +171,7 @@ FUNCTIONS
         
         webhdfs (smart_open/webhdfs.py)
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        Implements reading and writing to/from WebHDFS.
         
         min_part_size: int, optional
             For writing only.
@@ -237,40 +246,34 @@ FUNCTIONS
         
         Notes
         -----
-        
-        
         Supported URI schemes are:
         
+        * file
+        * gs
         * hdfs
-        * s3u
         * http
         * s3
-        * gs
-        * s3n
-        * ssh
-        * webhdfs
         * scp
-        * sftp
-        * https
-        * file
-        * s3a
+        * webhdfs
         
         Valid URI examples::
         
-        * [ssh|scp|sftp]://username@host/path/file
-        * s3://my_key:my_secret@my_server:my_port@my_bucket/my_key
-        * ./local/path/file.gz
-        * ~/local/path/file
-        * hdfs:///path/file
-        * file:///home/user/file.bz2
-        * s3://my_bucket/my_key
         * ./local/path/file
-        * [ssh|scp|sftp]://username@host//path/file
+        * ~/local/path/file
         * local/path/file
-        * s3://my_key:my_secret@my_bucket/my_key
-        * webhdfs://host:port/path/file
+        * ./local/path/file.gz
         * file:///home/user/file
+        * file:///home/user/file.bz2
+        * hdfs:///path/file
         * hdfs://path/file
+        * s3://my_bucket/my_key
+        * s3://my_key:my_secret@my_bucket/my_key
+        * s3://my_key:my_secret@my_server:my_port@my_bucket/my_key
+        * ssh://username@host/path/file
+        * ssh://username@host//path/file
+        * scp://username@host/path/file
+        * sftp://username@host/path/file
+        * webhdfs://host:port/path/file
     
     register_compressor(ext, callback)
         Register a callback for transparently decompressing files with a specific extension.

--- a/help.txt
+++ b/help.txt
@@ -13,19 +13,24 @@ DESCRIPTION
     The main functions are:
     
     * `open()`, which opens the given file for reading/writing
+    * `parse_uri()`
     * `s3_iter_bucket()`, which goes over all keys in an S3 bucket in parallel
     * `register_compressor()`, which registers callbacks for transparent compressor handling
 
 PACKAGE CONTENTS
     bytebuffer
+    compression
     doctools
     gcs
     hdfs
     http
+    local_file
     s3
     smart_open_lib
     ssh
     tests (package)
+    transport
+    utils
     version
     webhdfs
 
@@ -33,26 +38,13 @@ FUNCTIONS
     open(uri, mode='r', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, ignore_ext=False, transport_params=None)
         Open the URI object, returning a file-like object.
         
-        The URI is usually a string in a variety of formats:
-        
-        1. a URI for the local filesystem: `./lines.txt`, `/home/joe/lines.txt.gz`,
-           `file:///home/joe/lines.txt.bz2`
-        2. a URI for HDFS: `hdfs:///some/path/lines.txt`
-        3. a URI for Amazon's S3 (can also supply credentials inside the URI):
-           `s3://my_bucket/lines.txt`, `s3://my_aws_key_id:key_secret@my_bucket/lines.txt`
+        The URI is usually a string in a variety of formats.
+        For a full list of examples, see the :func:`parse_uri` function.
         
         The URI may also be one of:
         
         - an instance of the pathlib.Path class
         - a stream (anything that implements io.IOBase-like functionality)
-        
-        This function supports transparent compression and decompression using the
-        following codec:
-        
-        - ``.gz``
-        - ``.bz2``
-        
-        The function depends on the file extension to determine the appropriate codec.
         
         Parameters
         ----------
@@ -89,7 +81,40 @@ FUNCTIONS
         by the transport layer being used, smart_open will ignore that argument and
         log a warning message.
         
-        S3 (for details, see :mod:`smart_open.s3` and :func:`smart_open.s3.open`):
+        smart_open supports the following transport mechanisms:
+        
+        file (smart_open/local_file.py)
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        
+        gs (smart_open/gcs.py)
+        ~~~~~~~~~~~~~~~~~~~~~~
+        
+        buffer_size: int, optional
+            The buffer size to use when performing I/O. For reading only.
+        min_part_size: int, optional
+            The minimum part size for multipart uploads.  For writing only.
+        client: google.cloud.storage.Client, optional
+            The GCS client to use when working with google-cloud-storage.
+        
+        hdfs (smart_open/hdfs.py)
+        ~~~~~~~~~~~~~~~~~~~~~~~~~
+        
+        http (smart_open/http.py)
+        ~~~~~~~~~~~~~~~~~~~~~~~~~
+        
+        kerberos: boolean, optional
+            If True, will attempt to use the local Kerberos credentials
+        user: str, optional
+            The username for authenticating over HTTP
+        password: str, optional
+            The password for authenticating over HTTP
+        headers: dict, optional
+            Any headers to send in the request. If ``None``, the default headers are sent:
+            ``{'Accept-Encoding': 'identity'}``. To use no headers at all,
+            set this variable to an empty dict, ``{}``.
+        
+        s3 (smart_open/s3.py)
+        ~~~~~~~~~~~~~~~~~~~~~
         
         buffer_size: int, optional
             The buffer size to use when performing I/O.
@@ -119,25 +144,8 @@ FUNCTIONS
             Additional parameters to pass to boto3's object.get function.
             Used during reading only.
         
-        HTTP (for details, see :mod:`smart_open.http` and :func:`smart_open.http.open`):
-        
-        kerberos: boolean, optional
-            If True, will attempt to use the local Kerberos credentials
-        user: str, optional
-            The username for authenticating over HTTP
-        password: str, optional
-            The password for authenticating over HTTP
-        headers: dict, optional
-            Any headers to send in the request. If ``None``, the default headers are sent:
-            ``{'Accept-Encoding': 'identity'}``. To use no headers at all,
-            set this variable to an empty dict, ``{}``.
-        
-        WebHDFS (for details, see :mod:`smart_open.webhdfs` and :func:`smart_open.webhdfs.open`):
-        
-        min_part_size: int, optional
-            For writing only.
-        
-        SSH (for details, see :mod:`smart_open.ssh` and :func:`smart_open.ssh.open`):
+        scp (smart_open/ssh.py)
+        ~~~~~~~~~~~~~~~~~~~~~~~
         
         mode: str, optional
             The mode to use for opening the file.
@@ -153,9 +161,15 @@ FUNCTIONS
         transport_params: dict, optional
             Any additional settings to be passed to paramiko.SSHClient.connect
         
+        webhdfs (smart_open/webhdfs.py)
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        
+        min_part_size: int, optional
+            For writing only.
         
         Examples
         --------
+        
         >>> from smart_open import open
         >>>
         >>> # stream lines from an S3 object
@@ -192,25 +206,14 @@ FUNCTIONS
         >>> for line in open('http://example.com/index.html'):
         ...     print(repr(line))
         ...     break
-        '<!doctype html>\n'
         
-        Other examples of URLs that ``smart_open`` accepts::
+        This function also supports transparent compression and decompression 
+        using the following codecs:
         
-          s3://my_bucket/my_key
-          s3://my_key:my_secret@my_bucket/my_key
-          s3://my_key:my_secret@my_server:my_port@my_bucket/my_key
-          gs://my_bucket/my_blob
-          hdfs:///path/file
-          hdfs://path/file
-          webhdfs://host:port/path/file
-          ./local/path/file
-          ~/local/path/file
-          local/path/file
-          ./local/path/file.gz
-          file:///home/user/file
-          file:///home/user/file.bz2
-          [ssh|scp|sftp]://username@host//path/file
-          [ssh|scp|sftp]://username@host/path/file
+        * .bz2
+        * .gz
+        
+        The function depends on the file extension to determine the appropriate codec.
         
         
         See Also
@@ -219,20 +222,72 @@ FUNCTIONS
         - `smart_open README.rst
           <https://github.com/RaRe-Technologies/smart_open/blob/master/README.rst>`__
     
+    parse_uri(uri_as_string)
+        Parse the given URI from a string.
+        
+        Parameters
+        ----------
+        uri_as_string: str
+            The URI to parse.
+        
+        Returns
+        -------
+        collections.namedtuple
+            The parsed URI.
+        
+        Notes
+        -----
+        
+        
+        Supported URI schemes are:
+        
+        * hdfs
+        * s3u
+        * http
+        * s3
+        * gs
+        * s3n
+        * ssh
+        * webhdfs
+        * scp
+        * sftp
+        * https
+        * file
+        * s3a
+        
+        Valid URI examples::
+        
+        * [ssh|scp|sftp]://username@host/path/file
+        * s3://my_key:my_secret@my_server:my_port@my_bucket/my_key
+        * ./local/path/file.gz
+        * ~/local/path/file
+        * hdfs:///path/file
+        * file:///home/user/file.bz2
+        * s3://my_bucket/my_key
+        * ./local/path/file
+        * [ssh|scp|sftp]://username@host//path/file
+        * local/path/file
+        * s3://my_key:my_secret@my_bucket/my_key
+        * webhdfs://host:port/path/file
+        * file:///home/user/file
+        * hdfs://path/file
+    
     register_compressor(ext, callback)
         Register a callback for transparently decompressing files with a specific extension.
         
         Parameters
         ----------
         ext: str
-            The extension.
+            The extension.  Must include the leading period, e.g. ``.gz``.
         callback: callable
             The callback.  It must accept two position arguments, file_obj and mode.
+            This function will be called when ``smart_open`` is opening a file with
+            the specified extension.
         
         Examples
         --------
         
-        Instruct smart_open to use the identity function whenever opening a file
+        Instruct smart_open to use the `lzma` module whenever opening a file
         with a .xz extension (see README.rst for the complete example showing I/O):
         
         >>> def _handle_xz(file_obj, mode):
@@ -295,12 +350,12 @@ FUNCTIONS
     smart_open(uri, mode='rb', **kw)
 
 DATA
-    __all__ = ['open', 'smart_open', 's3_iter_bucket', 'register_compresso...
+    __all__ = ['open', 'parse_uri', 'register_compressor', 's3_iter_bucket...
 
 VERSION
     1.10.0
 
 FILE
-    /home/misha/git/smart_open/smart_open/__init__.py
+    /Users/misha/git/smart_open/smart_open/__init__.py
 
 

--- a/smart_open/doctools.py
+++ b/smart_open/doctools.py
@@ -20,7 +20,7 @@ import re
 from . import compression
 from . import transport
 
-PLACEHOLDER = '   smart_open/doctools.py magic goes here'
+PLACEHOLDER = '    smart_open/doctools.py magic goes here'
 
 
 def extract_kwargs(docstring):
@@ -186,8 +186,7 @@ def tweak_open_docstring(f):
             heading = '%s (%s)' % (scheme, relpath)
             print('    %s' % heading)
             print('    %s' % ('~' * len(heading)))
-            print()
-            print('    For details, see %s.' % relpath)
+            print('    %s' % submodule.__doc__.split('\n')[0])
             print()
 
             kwargs = extract_kwargs(submodule.open.__doc__)
@@ -230,7 +229,6 @@ def tweak_parse_uri_docstring(f):
             pass
 
     with contextlib.redirect_stdout(buf):
-        print()
         print('    Supported URI schemes are:')
         print()
         for scheme in schemes:

--- a/smart_open/doctools.py
+++ b/smart_open/doctools.py
@@ -11,14 +11,16 @@
 For internal use only.
 """
 
+import contextlib
 import inspect
 import io
 import os.path
 import re
-import warnings
 
 from . import compression
 from . import transport
+
+PLACEHOLDER = '   smart_open/doctools.py magic goes here'
 
 
 def extract_kwargs(docstring):
@@ -166,54 +168,78 @@ def extract_examples_from_readme_rst(indent='    '):
         return indent + 'See README.rst'
 
 
-def tweak_docstrings(open_function, parse_uri_function):
+def tweak_open_docstring(f):
+    buf = io.StringIO()
+    seen = set()
+
+    root_path = os.path.dirname(os.path.dirname(__file__))
+
+    with contextlib.redirect_stdout(buf):
+        print('    smart_open supports the following transport mechanisms:')
+        print()
+        for scheme, submodule in sorted(transport._REGISTRY.items()):
+            if scheme == transport.NO_SCHEME or submodule in seen:
+                continue
+            seen.add(submodule)
+
+            relpath = os.path.relpath(submodule.__file__, start=root_path)
+            heading = '%s (%s)' % (scheme, relpath)
+            print('    %s' % heading)
+            print('    %s' % ('~' * len(heading)))
+            print()
+            print('    For details, see %s.' % relpath)
+            print()
+
+            kwargs = extract_kwargs(submodule.open.__doc__)
+            if kwargs:
+                print(to_docstring(kwargs, lpad=u'    '))
+
+        print('    Examples')
+        print('    --------')
+        print()
+        print(extract_examples_from_readme_rst())
+
+        print('    This function also supports transparent compression and decompression ')
+        print('    using the following codecs:')
+        print()
+        for extension in compression.get_supported_extensions():
+            print('    * %s' % extension)
+        print()
+        print('    The function depends on the file extension to determine the appropriate codec.')
+
     #
     # The docstring can be None if -OO was passed to the interpreter.
     #
-    if not (open_function.__doc__ and parse_uri_function.__doc__):
-        warnings.warn(
-            'docstrings for smart_open function are missing, '
-            'see https://github.com/RaRe-Technologies/smart_open'
-            '/blob/master/README.rst if you need documentation'
-        )
-        return
+    if f.__doc__:
+        f.__doc__ = f.__doc__.replace(PLACEHOLDER, buf.getvalue())
 
-    substrings = {}
-    schemes = io.StringIO()
-    seen_examples = set()
-    uri_examples = io.StringIO()
+
+def tweak_parse_uri_docstring(f):
+    buf = io.StringIO()
+    schemes = set()
+    examples = set()
 
     for scheme, submodule in sorted(transport._REGISTRY.items()):
         if scheme == transport.NO_SCHEME:
             continue
 
-        schemes.write('    * %s\n' % scheme)
-
+        schemes.add(scheme)
         try:
-            fn = submodule.open
+            examples |= set(submodule.URI_EXAMPLES)
         except AttributeError:
-            substrings[scheme] = ''
-        else:
-            kwargs = extract_kwargs(fn.__doc__)
-            substrings[scheme] = to_docstring(kwargs, lpad=u'    ')
+            pass
 
-        try:
-            examples = submodule.URI_EXAMPLES
-        except AttributeError:
-            continue
-        else:
-            for e in examples:
-                if e not in seen_examples:
-                    uri_examples.write('    * %s\n' % e)
-                seen_examples.add(e)
+    with contextlib.redirect_stdout(buf):
+        print()
+        print('    Supported URI schemes are:')
+        print()
+        for scheme in schemes:
+            print('    * %s' % scheme)
+        print()
+        print('    Valid URI examples::')
+        print()
+        for example in examples:
+            print('    * %s' % example)
 
-    substrings['codecs'] = '\n'.join(
-        ['    * %s' % e for e in compression.get_supported_extensions()]
-    )
-    substrings['examples'] = extract_examples_from_readme_rst()
-
-    open_function.__doc__ = open_function.__doc__ % substrings
-    parse_uri_function.__doc__ = parse_uri_function.__doc__ % dict(
-        schemes=schemes.getvalue(),
-        uri_examples=uri_examples.getvalue(),
-    )
+    if f.__doc__:
+        f.__doc__ = f.__doc__.replace(PLACEHOLDER, buf.getvalue())

--- a/smart_open/doctools.py
+++ b/smart_open/doctools.py
@@ -215,16 +215,18 @@ def tweak_open_docstring(f):
 
 def tweak_parse_uri_docstring(f):
     buf = io.StringIO()
-    schemes = set()
-    examples = set()
+    seen = set()
+    schemes = []
+    examples = []
 
     for scheme, submodule in sorted(transport._REGISTRY.items()):
-        if scheme == transport.NO_SCHEME:
+        if scheme == transport.NO_SCHEME or submodule in seen:
             continue
+        schemes.append(scheme)
+        seen.add(submodule)
 
-        schemes.add(scheme)
         try:
-            examples |= set(submodule.URI_EXAMPLES)
+            examples.extend(submodule.URI_EXAMPLES)
         except AttributeError:
             pass
 

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -5,7 +5,7 @@
 # This code is distributed under the terms and conditions
 # from the MIT License (MIT).
 #
-"""Implements file-like objects for reading and writing from/to S3."""
+"""Implements file-like objects for reading and writing from/to AWS S3."""
 
 import io
 import functools

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -84,7 +84,6 @@ def parse_uri(uri_as_string):
 
     Notes
     -----
-
     smart_open/doctools.py magic goes here
     """
     scheme = _sniff_scheme(uri_as_string)
@@ -471,4 +470,10 @@ try:
     doctools.tweak_open_docstring(open)
     doctools.tweak_parse_uri_docstring(parse_uri)
 except Exception as ex:
-    logger.critical(ex)
+    logger.error(
+        'Encountered a non-fatal error while building docstrings (see below). '
+        'help(smart_open) will provide incomplete information as a result. '
+        'For full help text, see '
+        '<https://github.com/RaRe-Technologies/smart_open/blob/master/help.txt>.'
+    )
+    logger.exception(ex)

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -85,16 +85,7 @@ def parse_uri(uri_as_string):
     Notes
     -----
 
-    Supported URI schemes are:
-
-%(schemes)s
-    s3, s3a and s3n are treated the same way.  s3u is s3 but without SSL.
-
-    Valid URI examples::
-
-%(uri_examples)s
-
-
+    smart_open/doctools.py magic goes here
     """
     scheme = _sniff_scheme(uri_as_string)
     submodule = transport.get_transport(scheme)
@@ -138,13 +129,6 @@ def open(
     - an instance of the pathlib.Path class
     - a stream (anything that implements io.IOBase-like functionality)
 
-    This function supports transparent compression and decompression using the
-    following codecs:
-
-%(codecs)s
-
-    The function depends on the file extension to determine the appropriate codec.
-
     Parameters
     ----------
     uri: str or object
@@ -180,22 +164,7 @@ def open(
     by the transport layer being used, smart_open will ignore that argument and
     log a warning message.
 
-    S3 (for details, see :mod:`smart_open.s3` and :func:`smart_open.s3.open`):
-
-%(s3)s
-    HTTP (for details, see :mod:`smart_open.http` and :func:`smart_open.http.open`):
-
-%(http)s
-    WebHDFS (for details, see :mod:`smart_open.webhdfs` and :func:`smart_open.webhdfs.open`):
-
-%(webhdfs)s
-    SSH (for details, see :mod:`smart_open.ssh` and :func:`smart_open.ssh.open`):
-
-%(ssh)s
-
-    Examples
-    --------
-%(examples)s
+    smart_open/doctools.py magic goes here
 
     See Also
     --------
@@ -493,4 +462,13 @@ def _patch_pathlib(func):
     return old_impl
 
 
-doctools.tweak_docstrings(open, parse_uri)
+#
+# Prevent failures with doctools from messing up the entire library.  We don't
+# expect such failures, but contributed modules (e.g. new transport mechanisms)
+# may not be as polished.
+#
+try:
+    doctools.tweak_open_docstring(open)
+    doctools.tweak_parse_uri_docstring(parse_uri)
+except Exception as ex:
+    logger.critical(ex)


### PR DESCRIPTION
- Moved all docstring-related functionality into the doctools submodule
- Make submodules document themselves (use the first line of the docstring to explain what that submodule does, e.g. handle AWS S3)
- Guard against problems in docstring manipulation with general exception (except Exception)
- Add documentation of parse_uri to help