### PR TITLE
Bring back filename parameter to compression_wrapper

### DIFF
--- a/smart_open/compression.py
+++ b/smart_open/compression.py
@@ -68,7 +68,7 @@ def compression_wrapper(file_obj, mode, filename=None):
     [de]compression mechanism based on the extension of the filename.
 
     file_obj must either be a filehandle object, or a class which behaves
-    like one. It must have a .name attribute unless `filename` is given.
+    like one. It must have a .name attribute unless ``filename`` is given.
 
     If the filename extension isn't recognized, will simply return the original
     file_obj.

--- a/smart_open/compression.py
+++ b/smart_open/compression.py
@@ -74,10 +74,9 @@ def compression_wrapper(file_obj, mode, filename=None):
     file_obj.
 
     """
-    if filename is None:
-        filename = file_obj.name
-
     try:
+        if filename is None:
+            filename = file_obj.name
         _, ext = os.path.splitext(filename)
     except (AttributeError, TypeError):
         logger.warning(

--- a/smart_open/compression.py
+++ b/smart_open/compression.py
@@ -62,20 +62,23 @@ def _handle_gzip(file_obj, mode):
     return gzip.GzipFile(fileobj=file_obj, mode=mode)
 
 
-def compression_wrapper(file_obj, mode):
+def compression_wrapper(file_obj, mode, filename=None):
     """
     This function will wrap the file_obj with an appropriate
     [de]compression mechanism based on the extension of the filename.
 
     file_obj must either be a filehandle object, or a class which behaves
-        like one.  It must have a .name attribute.
+    like one. It must have a .name attribute unless `filename` is given.
 
     If the filename extension isn't recognized, will simply return the original
     file_obj.
+
     """
+    if filename is None:
+        filename = file_obj.name
 
     try:
-        _, ext = os.path.splitext(file_obj.name)
+        _, ext = os.path.splitext(filename)
     except (AttributeError, TypeError):
         logger.warning(
             'unable to transparently decompress %r because it '

--- a/smart_open/doctools.py
+++ b/smart_open/doctools.py
@@ -163,7 +163,7 @@ def extract_examples_from_readme_rst(indent='    '):
         start = lines.index('.. _doctools_before_examples:\n')
         end = lines.index(".. _doctools_after_examples:\n")
         lines = lines[start+4:end-2]
-        return ''.join([indent + re.sub('^  ', '', l) for l in lines])
+        return ''.join([indent + re.sub('^  ', '', line) for line in lines])
     except Exception:
         return indent + 'See README.rst'
 

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1250,9 +1250,7 @@ class WebHdfsWriteTest(unittest.TestCase):
 
 
 class CompressionFormatTest(unittest.TestCase):
-    """
-    Test that compression
-    """
+    """Test transparent (de)compression."""
 
     def write_read_assertion(self, suffix):
         test_file = make_buffer(name='file' + suffix)

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -720,7 +720,7 @@ class SmartOpenReadTest(unittest.TestCase):
 
         reader = smart_open.smart_open("s3://mybucket/mykey", "rb")
 
-        actual_lines = [l.decode("utf-8") for l in reader]
+        actual_lines = [line.decode("utf-8") for line in reader]
         self.assertEqual(2, len(actual_lines))
         self.assertEqual(lines[0], actual_lines[0])
         self.assertEqual(lines[1], actual_lines[1])

--- a/smart_open/tests/test_smart_open_old.py
+++ b/smart_open/tests/test_smart_open_old.py
@@ -218,7 +218,7 @@ class SmartOpenReadTest(unittest.TestCase):
 
         reader = smart_open.smart_open("s3://mybucket/mykey", "rb")
 
-        actual_lines = [l.decode("utf-8") for l in reader]
+        actual_lines = [line.decode("utf-8") for line in reader]
         self.assertEqual(2, len(actual_lines))
         self.assertEqual(lines[0], actual_lines[0])
         self.assertEqual(lines[1], actual_lines[1])


### PR DESCRIPTION
Smart_open 1.8.4 used to have a nifty `_compression_wrapper` function. It was internal (`_` prefix) but generally useful.

That function doesn't exist any more in smart_open 2.0.0. It was promoted to a public `compression.compression_wrapper` which is almost identical, but not quite. The new function doesn't accept a filename, and is instead hard-wired to extract the filename from `file_obj.name`. 

This is undesirable in our system, where hacking `file_obj` to add the `.name` attribute is complicated (and unnecessary).

This PR brings back the option of supplying own filename. It's fully backward compatible: with no `filename` specified, it will fall back to `file_obj.name` like before.

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [ ] Linked to any existing issues that your PR will be solving
- [ ] Included tests for any new functionality
- [x] Checked that all unit tests pass