### PR TITLE
Use exception chaining to convey the original cause of the exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
   - Correctly pass `newline` parameter to built-in `open` function (PR [#478](https://github.com/RaRe-Technologies/smart_open/pull/478), [@burkovae](https://github.com/burkovae))
   - Azure storage blob support
+  - Use exception chaining to convey the original cause of the exception (PR [#508](https://github.com/RaRe-Technologies/smart_open/pull/508), [@cool-RR](https://github.com/cool-RR))
 
 # 2.0.0, 27 April 2020, "Python 3"
 

--- a/smart_open/tests/test_gcs.py
+++ b/smart_open/tests/test_gcs.py
@@ -72,8 +72,8 @@ class FakeBucket(object):
     def get_blob(self, blob_id):
         try:
             return self.blobs[blob_id]
-        except KeyError:
-            raise google.cloud.exceptions.NotFound('Blob {} not found'.format(blob_id))
+        except KeyError as e:
+            raise google.cloud.exceptions.NotFound('Blob {} not found'.format(blob_id)) from e
 
     def list_blobs(self):
         return list(self.blobs.values())
@@ -246,8 +246,8 @@ class FakeClient(object):
     def bucket(self, bucket_id):
         try:
             return self.__buckets[bucket_id]
-        except KeyError:
-            raise google.cloud.exceptions.NotFound('Bucket %s not found' % bucket_id)
+        except KeyError as e:
+            raise google.cloud.exceptions.NotFound('Bucket %s not found' % bucket_id) from e
 
     def create_bucket(self, bucket_id):
         bucket = FakeBucket(self, bucket_id)

--- a/smart_open/transport.py
+++ b/smart_open/transport.py
@@ -72,8 +72,8 @@ def get_transport(scheme):
     )
     try:
         submodule = _REGISTRY[scheme]
-    except KeyError:
-        raise NotImplementedError(message)
+    except KeyError as e:
+        raise NotImplementedError(message) from e
     else:
         return submodule
 


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 