### PR TITLE
Bypass unnecessary GCS storage.buckets.get permission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,8 @@ target/
 # PyCharm
 .idea/
 
+# VSCode
+.vscode/
+
 # env files
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  - Bypass unnecessary GCS storage.buckets.get permission (PR [#516](https://github.com/RaRe-Technologies/smart_open/pull/516), [@gelioz](https://github.com/gelioz))
+
 # 2.1.0, 1 July 2020
 
   - Azure storage blob support ([@nclsmitchell](https://github.com/nclsmitchell) and [@petedannemann](https://github.com/petedannemann))

--- a/smart_open/gcs.py
+++ b/smart_open/gcs.py
@@ -211,7 +211,7 @@ class Reader(io.BufferedIOBase):
         if client is None:
             client = google.cloud.storage.Client()
 
-        self._blob = client.get_bucket(bucket).get_blob(key)  # type: google.cloud.storage.Blob
+        self._blob = client.bucket(bucket).get_blob(key)  # type: google.cloud.storage.Blob
 
         if self._blob is None:
             raise google.cloud.exceptions.NotFound('blob %s not found in %s' % (key, bucket))


### PR DESCRIPTION
#### Motivation

`smart_open.gcs.Reader` class uses `google.cloud.storage.Client.get_bucket` method which not only returns instance of `google.cloud.storage.Blob`, but also [performs GET request to retrieve bucket metadata](https://googleapis.dev/python/storage/latest/client.html#google.cloud.storage.client.Client.get_bucket).
This request requires Cloud IAM `storage.buckets.get` permission which isn't a part of predefined ["Storage Object Viewer" IAM role](https://cloud.google.com/storage/docs/access-control/iam-roles) and this cause unjustifiable troubles with roles management:
```
Traceback (most recent call last):
  File "example.py", line 3, in <module>
    smart_open.open("gs://bucket_name/file.txt")
  File "/usr/local/lib/python3.7/site-packages/smart_open/smart_open_lib.py", line 225, in open
    binary = _open_binary_stream(uri, binary_mode, transport_params)
  File "/usr/local/lib/python3.7/site-packages/smart_open/smart_open_lib.py", line 401, in _open_binary_stream
    fobj = submodule.open_uri(uri, mode, transport_params)
  File "/usr/local/lib/python3.7/site-packages/smart_open/gcs.py", line 102, in open_uri
    return open(parsed_uri['bucket_id'], parsed_uri['blob_id'], mode, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/smart_open/gcs.py", line 137, in open
    client=client,
  File "/usr/local/lib/python3.7/site-packages/smart_open/gcs.py", line 214, in __init__
    self._blob = client.get_bucket(bucket).get_blob(key)  # type: google.cloud.storage.Blob
  File "/usr/local/lib/python3.7/site-packages/google/cloud/storage/client.py", line 351, in get_bucket
    if_metageneration_not_match=if_metageneration_not_match,
  File "/usr/local/lib/python3.7/site-packages/google/cloud/storage/bucket.py", line 869, in reload
    if_metageneration_not_match=if_metageneration_not_match,
  File "/usr/local/lib/python3.7/site-packages/google/cloud/storage/_helpers.py", line 207, in reload
    timeout=timeout,
  File "/usr/local/lib/python3.7/site-packages/google/cloud/_http.py", line 423, in api_request
    raise exceptions.from_http_response(response)
google.api_core.exceptions.Forbidden: 403 GET https://storage.googleapis.com/storage/v1/b/bucket_name?projection=noAcl: account_name@proj_name.iam.gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket.
```

Since retrieved bucket metadata is not used at all, `google.cloud.storage.Client.get_bucket` method can be safely replaced with `google.cloud.storage.Client.bucket` method which [not performs API call to bucket endpoint](https://googleapis.dev/python/storage/latest/client.html#google.cloud.storage.client.Client.bucket) and returns the same `google.cloud.storage.Blob` instance.

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [ ] Linked to any existing issues that your PR will be solving
- [ ] Included tests for any new functionality
- [x] Checked that all unit tests pass