### PR TITLE
Allow SFTP connection with SSH key

### DIFF
--- a/smart_open/ssh.py
+++ b/smart_open/ssh.py
@@ -91,7 +91,7 @@ def _connect(hostname, username, port, password, transport_params):
         ssh.load_system_host_keys()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         kwargs = transport_params.get('connect_kwargs', {}).copy()
-        # if 'key_filename' is present in transport_params, then I do not 
+        # if 'key_filename' is present in transport_params, then I do not
         #   overwrite the credentials.
         if 'key_filename' not in kwargs:
             kwargs.setdefault('password', password)

--- a/smart_open/ssh.py
+++ b/smart_open/ssh.py
@@ -91,7 +91,10 @@ def _connect(hostname, username, port, password, transport_params):
         ssh.load_system_host_keys()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         kwargs = transport_params.get('connect_kwargs', {}).copy()
-        kwargs.setdefault('password', password)
+        # if 'key_filename' is present in transport_params, then I do not 
+        #   overwrite the credentials.
+        if 'key_filename' not in kwargs:
+            kwargs.setdefault('password', password)
         kwargs.setdefault('username', username)
         ssh.connect(hostname, port, **kwargs)
     return ssh

--- a/smart_open/tests/test_ssh.py
+++ b/smart_open/tests/test_ssh.py
@@ -49,6 +49,7 @@ class SSHOpen(unittest.TestCase):
         )
         mock_connect.assert_called_with("some-host", 22, username="user", key_filename="key")
 
+
 if __name__ == "__main__":
     logging.basicConfig(format="%(asctime)s : %(levelname)s : %(message)s", level=logging.DEBUG)
     unittest.main()

--- a/smart_open/tests/test_ssh.py
+++ b/smart_open/tests/test_ssh.py
@@ -41,6 +41,13 @@ class SSHOpen(unittest.TestCase):
         )
         mock_connect.assert_called_with("some-host", 22, username="ubuntu", password="pwd")
 
+    @mock_ssh
+    def test_open_with_key_filename(self, mock_connect, get_transp_mock):
+        smart_open.open(
+            "ssh://user@some-host/",
+            transport_params={"connect_kwargs": {"key_filename": "key"}},
+        )
+        mock_connect.assert_called_with("some-host", 22, username="user", key_filename="key")
 
 if __name__ == "__main__":
     logging.basicConfig(format="%(asctime)s : %(levelname)s : %(message)s", level=logging.DEBUG)


### PR DESCRIPTION
#### Allow SFTP connection with SSH key

#### Motivation

We do not use password to connect to SFTP server, instead we use SSH Key. 
`paramiko` provides the possibility to set the `key_filename` in the `connect` `kwargs` argument.
However this is not used due to the fact that the `ssh._connect()` forcefully set the `password` argument.
