### PR TITLE
Remove TODO in file opener logic

### DIFF
--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -400,8 +400,7 @@ def _open_binary_stream(uri, mode, transport_params):
     submodule = transport.get_transport(scheme)
     fobj = submodule.open_uri(uri, mode, transport_params)
     if not hasattr(fobj, 'name'):
-        logger.critical('TODO')
-        fobj.name = 'unknown'
+        fobj.name = uri
 
     return fobj
 


### PR DESCRIPTION
At this stage, we're sure that `uri` is a string, so we can use it to
name any unnamed object.

Fix #519 