### PR TITLE
Revert "install s3 dependencies by default (#541)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This release modifies the behavior of setup.py with respect to dependencies.
 Previously, `boto3` and other AWS-related packages were installed by default.
 Now, in order to install them, you need to run either:
 
-    pip install smart_open[aws]
+    pip install smart_open[s3]
 
 to install the AWS dependencies only, or
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This release modifies the behavior of setup.py with respect to dependencies.
 Previously, `boto3` and other AWS-related packages were installed by default.
 Now, in order to install them, you need to run either:
 
-    pip install smart_open[s3]
+    pip install smart_open[aws]
 
 to install the AWS dependencies only, or
 

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     license='MIT',
     platforms='any',
 
-    install_requires=install_requires + aws_deps,
+    install_requires=install_requires,
     tests_require=tests_require,
     extras_require={
         'test': tests_require,

--- a/smart_open/tests/test_package.py
+++ b/smart_open/tests/test_package.py
@@ -1,16 +1,11 @@
 # -*- coding: utf-8 -*-
-# import os
+import os
 import unittest
 import pytest
 
 from smart_open import open
 
-#
-# Temporarily disable these tests while we deal with the fallout of the 2.2.0
-# release.
-#
-# skip_tests = "SMART_OPEN_TEST_MISSING_DEPS" not in os.environ
-skip_tests = True
+skip_tests = "SMART_OPEN_TEST_MISSING_DEPS" not in os.environ
 
 
 class PackageTests(unittest.TestCase):


### PR DESCRIPTION
With 2.2.1 released, we can revert the temporary fix and go back to the recently introduced dependency behavior.