### PR TITLE
Fix reading empty file or seeking past end of file for s3 backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  - Fix reading empty file or seeking past end of file for s3 backend (PR [#549](https://github.com/RaRe-Technologies/smart_open/pull/549), [@jcushman](https://github.com/jcushman))
+
 # 3.0.0, 8 Oct 2020
 
 This release modifies the behavior of setup.py with respect to dependencies.

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -89,6 +89,27 @@ def ignore_resource_warnings():
     warnings.filterwarnings("ignore", category=ResourceWarning, message="unclosed.*<ssl.SSLSocket.*>")  # noqa
 
 
+@contextmanager
+def patch_invalid_range_response(actual_size):
+    """ Work around a bug in moto (https://github.com/spulec/moto/issues/2981) where the
+     API response doesn't match when requesting an invalid range of bytes from an S3 GetObject. """
+    _real_get = smart_open.s3._get
+
+    def mock_get(*args, **kwargs):
+        try:
+            return _real_get(*args, **kwargs)
+        except IOError as ioe:
+            error_response = smart_open.s3._unwrap_ioerror(ioe)
+            if error_response and error_response.get('Message') == 'Requested Range Not Satisfiable':
+                error_response['ActualObjectSize'] = actual_size
+                error_response['Code'] = 'InvalidRange'
+                error_response['Message'] = 'The requested range is not satisfiable'
+            raise
+
+    with patch('smart_open.s3._get', new=mock_get):
+        yield
+
+
 class BaseTest(unittest.TestCase):
     @contextmanager
     def assertApiCalls(self, **expected_api_calls):
@@ -236,6 +257,15 @@ class SeekableBufferedInputBaseTest(BaseTest):
             self.assertEqual(seek, len(content) - 4)
             self.assertEqual(fin.read(), b'you?')
 
+    def test_seek_past_end(self):
+        content = u"hello wořld\nhow are you?".encode('utf8')
+        put_to_bucket(contents=content)
+
+        with self.assertApiCalls(GetObject=1), patch_invalid_range_response(str(len(content))):
+            fin = smart_open.s3.SeekableBufferedInputBase(BUCKET_NAME, KEY_NAME, defer_seek=True)
+            seek = fin.seek(60)
+            self.assertEqual(seek, len(content))
+
     def test_detect_eof(self):
         content = u"hello wořld\nhow are you?".encode('utf8')
         put_to_bucket(contents=content)
@@ -352,6 +382,15 @@ class SeekableBufferedInputBaseTest(BaseTest):
             fin.seek(10)
             self.assertEqual(fin.read(), content[10:])
 
+    def test_read_empty_file(self):
+        put_to_bucket(contents=b'')
+
+        with self.assertApiCalls(GetObject=1), patch_invalid_range_response('0'):
+            with smart_open.s3.SeekableBufferedInputBase(BUCKET_NAME, KEY_NAME) as fin:
+                data = fin.read()
+
+        self.assertEqual(data, b'')
+
 
 @moto.mock_s3
 class MultipartWriterTest(unittest.TestCase):
@@ -426,7 +465,8 @@ class MultipartWriterTest(unittest.TestCase):
             pass
 
         # read back the same key and check its content
-        output = list(smart_open.s3.open(BUCKET_NAME, WRITE_KEY_NAME, 'rb'))
+        with patch_invalid_range_response('0'):
+            output = list(smart_open.s3.open(BUCKET_NAME, WRITE_KEY_NAME, 'rb'))
 
         self.assertEqual(output, [])
 
@@ -548,7 +588,8 @@ class SinglepartWriterTest(unittest.TestCase):
             pass
 
         # read back the same key and check its content
-        output = list(smart_open.s3.open(BUCKET_NAME, WRITE_KEY_NAME, 'rb'))
+        with patch_invalid_range_response('0'):
+            output = list(smart_open.s3.open(BUCKET_NAME, WRITE_KEY_NAME, 'rb'))
         self.assertEqual(output, [])
 
     def test_buffered_writer_wrapper_works(self):

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -262,7 +262,7 @@ class SeekableBufferedInputBaseTest(BaseTest):
         put_to_bucket(contents=content)
 
         with self.assertApiCalls(GetObject=1), patch_invalid_range_response(str(len(content))):
-            fin = smart_open.s3.SeekableBufferedInputBase(BUCKET_NAME, KEY_NAME, defer_seek=True)
+            fin = smart_open.s3.Reader(BUCKET_NAME, KEY_NAME, defer_seek=True)
             seek = fin.seek(60)
             self.assertEqual(seek, len(content))
 
@@ -386,7 +386,7 @@ class SeekableBufferedInputBaseTest(BaseTest):
         put_to_bucket(contents=b'')
 
         with self.assertApiCalls(GetObject=1), patch_invalid_range_response('0'):
-            with smart_open.s3.SeekableBufferedInputBase(BUCKET_NAME, KEY_NAME) as fin:
+            with smart_open.s3.Reader(BUCKET_NAME, KEY_NAME) as fin:
                 data = fin.read()
 
         self.assertEqual(data, b'')

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -28,6 +28,7 @@ import smart_open
 from smart_open import smart_open_lib
 from smart_open import webhdfs
 from smart_open.smart_open_lib import patch_pathlib, _patch_pathlib
+from smart_open.tests.test_s3 import patch_invalid_range_response
 
 logger = logging.getLogger(__name__)
 
@@ -758,11 +759,12 @@ class SmartOpenReadTest(unittest.TestCase):
         with smart_open.open("s3://mybucket/mykey", "wb"):
             pass
 
-        reader = smart_open.open("s3://mybucket/mykey", "rb")
+        with patch_invalid_range_response('0'):
+            reader = smart_open.open("s3://mybucket/mykey", "rb")
 
-        self.assertEqual(reader.readline(), b"")
-        self.assertEqual(reader.readline(), b"")
-        self.assertEqual(reader.readline(), b"")
+            self.assertEqual(reader.readline(), b"")
+            self.assertEqual(reader.readline(), b"")
+            self.assertEqual(reader.readline(), b"")
 
     @mock_s3
     def test_s3_iter_lines(self):


### PR DESCRIPTION
#### Motivation

This PR fixes seeking past the end of an s3 file, which I broke in #495. E.g. this will now work instead of raising a boto error:

```
with open('s3://some/random/uri', 'rb') as file:
    file.seek(1_000_000_000)
```

`file.tell()` will then give the current position as the actual end of the file, and `f.read()` will return `b''`.

This also fixes opening an empty file for reading, as reported in #548 -- that turns out to be a special case of seeking past the end of a file being broken.

The reason this wasn't working before is that moto doesn't return the same API response as real S3 when requesting an invalid range with GetObject, [as reported here](https://github.com/spulec/moto/issues/2981). We were correctly handling moto-style responses but failing to handle real-S3-style responses. So this PR:

* Updates _SeekableRawReader to expect responses as provided by real S3
* Mocks `_get` in the relevant tests to return real-S3-style responses. This mock could be removed when the upstream bug in moto is fixed
* Adds tests for reading an empty file and seeking past the end of a file

Fixes #548

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass
