### PR TITLE
Bump minimum Python version to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,6 @@ os: linux
 
 jobs:
   include:
-    - python: '3.7'
-      name: "flake8"
-      env: TOXENV="flake8"
-
-    - python: '3.5'
-      env: TOXENV="check_keys,py35-test,py35-integration"
-
     - python: '3.6'
       env:
         - SO_BUCKET: smart-open
@@ -27,10 +20,15 @@ jobs:
         - BOTO_CONFIG: "/dev/null"
         - SO_ENABLE_MOTO_SERVER: "1"
         - TOXENV: "check_keys,py37-doctest,enable_moto_server,py37-test,py37-benchmark,py37-integration,disable_moto_server"
+
     - python: '3.8'
       env:
         - BOTO_CONFIG: "/dev/null"
         - TOXENV: "check_keys,py38-doctest,test_coverage,py38-integration"
+
+    - python: '3.8'
+      name: "flake8"
+      env: TOXENV="flake8"
 
 install:
   - pip install tox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix reading empty file or seeking past end of file for s3 backend (PR [#549](https://github.com/RaRe-Technologies/smart_open/pull/549), [@jcushman](https://github.com/jcushman))
 - Fix handling of rt/wt mode when working with gzip compression (PR [#559](https://github.com/RaRe-Technologies/smart_open/pull/559), [@mpenkov](https://github.com/mpenkov))
+- Bump minimum Python version to 3.6 (PR [#562](https://github.com/RaRe-Technologies/smart_open/pull/562), [@mpenkov](https://github.com/mpenkov))
 
 # 3.0.0, 8 Oct 2020
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ environment:
     TOX_PARALLEL_NO_SPINNER: 1
 
   matrix:
-  - TOXENV: "check_keys,py35-test"
   - TOXENV: "check_keys,py36-test"
   - TOXENV: "check_keys,py37-test"
   - TOXENV: "check_keys,py38-test"

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
         'azure': azure_deps,
         'all': all_deps,
     },
-    python_requires=">=3.5.*",
+    python_requires=">=3.6.*",
 
     test_suite="smart_open.tests",
 
@@ -101,9 +101,9 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: System :: Distributed Computing',
         'Topic :: Database :: Front-Ends',
     ],

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,9 @@ install_requires = [
 aws_deps = ['boto3']
 gcp_deps = ['google-cloud-storage']
 azure_deps = ['azure-storage-blob', 'azure-common', 'azure-core']
+http_deps = ['requests']
 
-all_deps = install_requires + aws_deps + gcp_deps + azure_deps
+all_deps = install_requires + aws_deps + gcp_deps + azure_deps + http_deps
 
 setup(
     name='smart_open',
@@ -90,6 +91,8 @@ setup(
         'gcp': gcp_deps,
         'azure': azure_deps,
         'all': all_deps,
+        'http': http_deps,
+        'webhdfs': http_deps,
     },
     python_requires=">=3.6.*",
 

--- a/smart_open/http.py
+++ b/smart_open/http.py
@@ -12,7 +12,10 @@ import logging
 import os.path
 import urllib.parse
 
-import requests
+try:
+    import requests
+except ImportError:
+    MISSING_DEPS = True
 
 from smart_open import bytebuffer, constants
 import smart_open.utils

--- a/smart_open/webhdfs.py
+++ b/smart_open/webhdfs.py
@@ -16,7 +16,10 @@ import io
 import logging
 import urllib.parse
 
-import requests
+try:
+    import requests
+except ImportError:
+    MISSING_DEPS = True
 
 from smart_open import utils, constants
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-envlist = py{35,36,37,38}-{test,doctest,integration,benchmark}, sdist, flake8
+envlist = py{36,37,38}-{test,doctest,integration,benchmark}, sdist, flake8
 
 [pytest]
 addopts = -rfxEXs --durations=20 --showlocals


### PR DESCRIPTION
Python 3.5 has reached end of life and we no longer need to support it.

Also made `requests` an optional dependency. It occupies over a MB of storage (via its chardet dependency) and that matters when deploying in tight environments, like AWS Lambda.