### PR TITLE
Change download_as_bytes to download_as_string in gcs submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Refactor s3 submodule to minimize resource usage (PR [#569](https://github.com/RaRe-Technologies/smart_open/pull/569), [@mpenkov](https://github.com/mpenkov))
+- Change download_as_bytes to download_as_string in gcs submodule (PR [#571](https://github.com/RaRe-Technologies/smart_open/pull/571), [@alexandreyc](https://github.com/alexandreyc))
 
 # 4.0.1, 27 Nov 2020
 

--- a/README.rst
+++ b/README.rst
@@ -329,12 +329,12 @@ GCS Credentials
 ---------------
 ``smart_open`` uses the ``google-cloud-storage`` library to talk to GCS.
 ``google-cloud-storage`` uses the ``google-cloud`` package under the hood to handle authentication.
-There are several `options <https://google-cloud-python.readthedocs.io/en/0.32.0/core/auth.html>`__ to provide
+There are several `options <https://googleapis.dev/python/google-api-core/latest/auth.html>`__ to provide
 credentials.
 By default, ``smart_open`` will defer to ``google-cloud-storage`` and let it take care of the credentials.
 
 To override this behavior, pass a ``google.cloud.storage.Client`` object as a transport parameter to the ``open`` function.
-You can `customize the credentials <https://google-cloud-python.readthedocs.io/en/0.32.0/core/client.html>`__
+You can `customize the credentials <https://googleapis.dev/python/storage/latest/client.html>`__
 when constructing the client. ``smart_open`` will then use the client when talking to GCS. To follow allow with
 the example below, `refer to Google's guide <https://cloud.google.com/storage/docs/reference/libraries#setting_up_authentication>`__
 to setting up GCS authentication with a service account.

--- a/smart_open/gcs.py
+++ b/smart_open/gcs.py
@@ -188,10 +188,10 @@ class _RawReader(object):
             #
             binary = b''
         elif size == -1:
-            binary = self._blob.download_as_string(start=start)
+            binary = self._blob.download_as_bytes(start=start)
         else:
             end = position + size
-            binary = self._blob.download_as_string(start=start, end=end)
+            binary = self._blob.download_as_bytes(start=start, end=end)
         return binary
 
 

--- a/smart_open/tests/test_gcs.py
+++ b/smart_open/tests/test_gcs.py
@@ -157,9 +157,9 @@ class FakeBlob(object):
         self._bucket.delete_blob(self)
         self._exists = False
 
-    def download_as_string(self, start=0, end=None):
-        # mimics Google's API by returning bytes, despite the method name
-        # https://google-cloud-python.readthedocs.io/en/0.32.0/storage/blobs.html#google.cloud.storage.blob.Blob.download_as_string
+    def download_as_bytes(self, start=0, end=None):
+        # mimics Google's API by returning bytes
+        # https://googleapis.dev/python/storage/latest/blobs.html#google.cloud.storage.blob.Blob.download_as_bytes
         if end is None:
             end = self.__contents.tell()
         self.__contents.seek(start)
@@ -170,7 +170,7 @@ class FakeBlob(object):
 
     def upload_from_string(self, data):
         # mimics Google's API by accepting bytes or str, despite the method name
-        # https://google-cloud-python.readthedocs.io/en/0.32.0/storage/blobs.html#google.cloud.storage.blob.Blob.upload_from_string
+        # https://googleapis.dev/python/storage/latest/blobs.html#google.cloud.storage.blob.Blob.upload_from_string
         if isinstance(data, str):
             data = bytes(data, 'utf8')
         self.__contents = io.BytesIO(data)
@@ -214,10 +214,10 @@ class FakeBlobTest(unittest.TestCase):
         blob = FakeBlob('fake-blob', self.bucket)
         contents = b'test'
         blob.upload_from_string(contents)
-        self.assertEqual(blob.download_as_string(), b'test')
-        self.assertEqual(blob.download_as_string(start=2), b'st')
-        self.assertEqual(blob.download_as_string(end=2), b'te')
-        self.assertEqual(blob.download_as_string(start=2, end=3), b's')
+        self.assertEqual(blob.download_as_bytes(), b'test')
+        self.assertEqual(blob.download_as_bytes(start=2), b'st')
+        self.assertEqual(blob.download_as_bytes(end=2), b'te')
+        self.assertEqual(blob.download_as_bytes(start=2, end=3), b's')
 
     def test_size(self):
         blob = FakeBlob('fake-blob', self.bucket)
@@ -372,7 +372,7 @@ class FakeAuthorizedSessionTest(unittest.TestCase):
         response = self.session.put(self.upload_url, data, headers=headers)
         self.assertIn(response.status_code, smart_open.gcs._UPLOAD_INCOMPLETE_STATUS_CODES)
         self.session._blob_with_url(self.upload_url, self.client)
-        blob_contents = self.blob.download_as_string()
+        blob_contents = self.blob.download_as_bytes()
         self.assertEqual(blob_contents, b'')
 
     def test_finished_put_writes_to_blob(self):
@@ -384,7 +384,7 @@ class FakeAuthorizedSessionTest(unittest.TestCase):
         response = self.session.put(self.upload_url, data, headers=headers)
         self.assertEqual(response.status_code, 200)
         self.session._blob_with_url(self.upload_url, self.client)
-        blob_contents = self.blob.download_as_string()
+        blob_contents = self.blob.download_as_bytes()
         data.seek(0)
         self.assertEqual(blob_contents, data.read())
 


### PR DESCRIPTION
Hello,

According to the [documentation](https://googleapis.dev/python/storage/latest/blobs.html#google.cloud.storage.blob.Blob.download_as_string) of `download_as_string`, this method is being deprecated in favor of its alias `download_as_bytes`.

Here is a PR that update the related code. I also updated some broken links to the official documentation.

Alexandre
