### PR TITLE
Fix typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Installation
 ------------
 
 ``smart_open`` supports a wide range of storage solutions, including AWS S3, Google Cloud and Azure.
-Each individul solution has its own dependencies.
+Each individual solution has its own dependencies.
 By default, ``smart_open`` does not install any dependencies, in order to keep the installation size small.
 You can install these dependencies explicitly using::
 


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `individual` rather than `individul`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md