### PR TITLE
Replace codecs with TextIOWrapper to fix newline issues when reading text files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Correctly pass boto3 resource to writers (PR [#576](https://github.com/RaRe-Technologies/smart_open/pull/576), [@jackluo923](https://github.com/jackluo923))
 - Improve robustness of S3 reading (PR [#552](https://github.com/RaRe-Technologies/smart_open/pull/552), [@mpenkov](https://github.com/mpenkov))
+- Replace codecs with TextIOWrapper to fix newline issues when reading text files (PR [#578](https://github.com/RaRe-Technologies/smart_open/pull/578), [@markopy](https://github.com/markopy))
 
 # 4.1.0, 30 Dec 2020
 

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -225,8 +225,13 @@ def open(
         decompressed = compression.compression_wrapper(binary, binary_mode)
 
     if 'b' not in mode or explicit_encoding is not None:
-        decoded = _encoding_wrapper(decompressed, mode, encoding=encoding, errors=errors,
-                                    newline=newline)
+        decoded = _encoding_wrapper(
+            decompressed,
+            mode,
+            encoding=encoding,
+            errors=errors,
+            newline=newline,
+        )
     else:
         decoded = decompressed
 
@@ -411,8 +416,13 @@ def _encoding_wrapper(fileobj, mode, encoding=None, errors=None, newline=None):
     if encoding is None:
         encoding = DEFAULT_ENCODING
 
-    fileobj = io.TextIOWrapper(fileobj, encoding=encoding, errors=errors, newline=newline,
-                               write_through=True)
+    fileobj = io.TextIOWrapper(
+        fileobj,
+        encoding=encoding,
+        errors=errors,
+        newline=newline,
+        write_through=True,
+    )
     return fileobj
 
 

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -15,8 +15,8 @@ The main functions are:
 
 """
 
-import codecs
 import collections
+import io
 import locale
 import logging
 import os
@@ -225,7 +225,8 @@ def open(
         decompressed = compression.compression_wrapper(binary, binary_mode)
 
     if 'b' not in mode or explicit_encoding is not None:
-        decoded = _encoding_wrapper(decompressed, mode, encoding=encoding, errors=errors)
+        decoded = _encoding_wrapper(decompressed, mode, encoding=encoding, errors=errors,
+                                    newline=newline)
     else:
         decoded = decompressed
 
@@ -381,7 +382,7 @@ def _open_binary_stream(uri, mode, transport_params):
     return fobj
 
 
-def _encoding_wrapper(fileobj, mode, encoding=None, errors=None):
+def _encoding_wrapper(fileobj, mode, encoding=None, errors=None, newline=None):
     """Decode bytes into text, if necessary.
 
     If mode specifies binary access, does nothing, unless the encoding is
@@ -410,11 +411,8 @@ def _encoding_wrapper(fileobj, mode, encoding=None, errors=None):
     if encoding is None:
         encoding = DEFAULT_ENCODING
 
-    kw = {'errors': errors} if errors else {}
-    if mode[0] == 'r' or mode.endswith('+'):
-        fileobj = codecs.getreader(encoding)(fileobj, **kw)
-    if mode[0] in ('w', 'a') or mode.endswith('+'):
-        fileobj = codecs.getwriter(encoding)(fileobj, **kw)
+    fileobj = io.TextIOWrapper(fileobj, encoding=encoding, errors=errors, newline=newline,
+                               write_through=True)
     return fileobj
 
 

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -745,17 +745,15 @@ class SmartOpenReadTest(unittest.TestCase):
         self.assertEqual(r.read(), b"")
 
     @mock_s3
-    def test_newline_read(self):
+    def test_read_newline_none(self):
         """Does newline open() parameter for reading work according to
            https://docs.python.org/3/library/functions.html#open-newline-parameter
         """
-        s3 = boto3.resource('s3')
-        s3.create_bucket(Bucket='mybucket')
+        boto3.resource('s3').create_bucket(Bucket='mybucket')
         # Unicode line separator and various others must never split lines
         test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
         with smart_open.open("s3://mybucket/mykey", "wb") as fout:
             fout.write(test_file.encode("utf-8"))
-
         # No newline parameter means newline=None i.e. universal newline mode with all
         # line endings translated to '\n'
         with smart_open.open("s3://mybucket/mykey", "r", encoding='utf-8') as fin:
@@ -766,6 +764,12 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"last line"
             ])
 
+    @mock_s3
+    def test_read_newline_empty(self):
+        boto3.resource('s3').create_bucket(Bucket='mybucket')
+        test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
+        with smart_open.open("s3://mybucket/mykey", "wb") as fout:
+            fout.write(test_file.encode("utf-8"))
         # If newline='' universal newline mode is enabled but line separators are not replaced
         with smart_open.open("s3://mybucket/mykey", "r", encoding='utf-8',  newline='') as fin:
             self.assertEqual(list(fin), [
@@ -775,6 +779,12 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"last line"
             ])
 
+    @mock_s3
+    def test_read_newline_cr(self):
+        boto3.resource('s3').create_bucket(Bucket='mybucket')
+        test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
+        with smart_open.open("s3://mybucket/mykey", "wb") as fout:
+            fout.write(test_file.encode("utf-8"))
         # If newline='\r' only CR splits lines
         with smart_open.open("s3://mybucket/mykey", "r", encoding='utf-8', newline='\r') as fin:
             self.assertEqual(list(fin), [
@@ -783,6 +793,12 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"\nlast line"
             ])
 
+    @mock_s3
+    def test_read_newline_lf(self):
+        boto3.resource('s3').create_bucket(Bucket='mybucket')
+        test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
+        with smart_open.open("s3://mybucket/mykey", "wb") as fout:
+            fout.write(test_file.encode("utf-8"))
         # If newline='\n' only LF splits lines
         with smart_open.open("s3://mybucket/mykey", "r", encoding='utf-8', newline='\n') as fin:
             self.assertEqual(list(fin), [
@@ -791,6 +807,12 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"last line"
             ])
 
+    @mock_s3
+    def test_read_newline_crlf(self):
+        boto3.resource('s3').create_bucket(Bucket='mybucket')
+        test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
+        with smart_open.open("s3://mybucket/mykey", "wb") as fout:
+            fout.write(test_file.encode("utf-8"))
         # If newline='\r\n' only CRLF splits lines
         with smart_open.open("s3://mybucket/mykey", "r", encoding='utf-8', newline='\r\n') as fin:
             self.assertEqual(list(fin), [
@@ -798,6 +820,12 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"last line"
             ])
 
+    @mock_s3
+    def test_read_newline_slurp(self):
+        boto3.resource('s3').create_bucket(Bucket='mybucket')
+        test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
+        with smart_open.open("s3://mybucket/mykey", "wb") as fout:
+            fout.write(test_file.encode("utf-8"))
         # Even reading the whole file with read() must replace newlines
         with smart_open.open("s3://mybucket/mykey", "r", encoding='utf-8', newline=None) as fin:
             self.assertEqual(
@@ -805,6 +833,12 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"line\u2028 LF\nline\x1c CR\nline\x85 CRLF\nlast line"
             )
 
+    @mock_s3
+    def test_read_newline_binary(self):
+        boto3.resource('s3').create_bucket(Bucket='mybucket')
+        test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
+        with smart_open.open("s3://mybucket/mykey", "wb") as fout:
+            fout.write(test_file.encode("utf-8"))
         # If the file is opened in binary mode only LF splits lines
         with smart_open.open("s3://mybucket/mykey", "rb") as fin:
             self.assertEqual(list(fin), [
@@ -814,15 +848,13 @@ class SmartOpenReadTest(unittest.TestCase):
             ])
 
     @mock_s3
-    def test_newline_write(self):
+    def test_write_newline_none(self):
         """Does newline open() parameter for writing work according to
            https://docs.python.org/3/library/functions.html#open-newline-parameter
         """
-        s3 = boto3.resource('s3')
-        s3.create_bucket(Bucket='mybucket')
+        boto3.resource('s3').create_bucket(Bucket='mybucket')
         # Unicode line separator and various others must never split lines
         test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
-
         # No newline parameter means newline=None, all LF are translatest to os.linesep
         with smart_open.open("s3://mybucket/mykey", "w", encoding='utf-8') as fout:
             fout.write(test_file)
@@ -834,6 +866,10 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"last line"
             )
 
+    @mock_s3
+    def test_write_newline_empty(self):
+        boto3.resource('s3').create_bucket(Bucket='mybucket')
+        test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
         # If newline='' nothing is changed
         with smart_open.open("s3://mybucket/mykey", "w", encoding='utf-8', newline='') as fout:
             fout.write(test_file)
@@ -843,6 +879,10 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
             )
 
+    @mock_s3
+    def test_write_newline_lf(self):
+        boto3.resource('s3').create_bucket(Bucket='mybucket')
+        test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
         # If newline='\n' nothing is changed
         with smart_open.open("s3://mybucket/mykey", "w", encoding='utf-8', newline='\n') as fout:
             fout.write(test_file)
@@ -852,6 +892,10 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
             )
 
+    @mock_s3
+    def test_write_newline_cr(self):
+        boto3.resource('s3').create_bucket(Bucket='mybucket')
+        test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
         # If newline='\r' all LF are replaced by CR
         with smart_open.open("s3://mybucket/mykey", "w", encoding='utf-8', newline='\r') as fout:
             fout.write(test_file)
@@ -861,6 +905,10 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"line\u2028 LF\rline\x1c CR\rline\x85 CRLF\r\rlast line"
             )
 
+    @mock_s3
+    def test_write_newline_crlf(self):
+        boto3.resource('s3').create_bucket(Bucket='mybucket')
+        test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
         # If newline='\r\n' all LF are replaced by CRLF
         with smart_open.open("s3://mybucket/mykey", "w", encoding='utf-8', newline='\r\n') as fout:
             fout.write(test_file)

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -427,9 +427,11 @@ class SmartOpenHttpTest(unittest.TestCase):
     def test_https_readline(self):
         """Does https readline method work correctly"""
         responses.add(responses.GET, "https://127.0.0.1/index.html",
-                      body='line1\nline2', stream=True)
+                      body=u'line1\u2028still line1\nline2', stream=True)
         smart_open_object = smart_open.open("https://127.0.0.1/index.html", 'rb')
-        self.assertEqual(smart_open_object.readline().decode("utf-8"), "line1\n")
+        self.assertEqual(smart_open_object.readline().decode("utf-8"), u"line1\u2028still line1\n")
+        smart_open_object = smart_open.open("https://127.0.0.1/index.html", 'r', encoding='utf-8')
+        self.assertEqual(smart_open_object.readline(), u"line1\u2028still line1\n")
 
     @responses.activate
     def test_http_pass(self):
@@ -587,7 +589,11 @@ class SmartOpenFileObjTest(unittest.TestCase):
         """Attempts to write directly to a text stream should fail."""
         buf = make_buffer(io.StringIO)
         with smart_open.open(buf, 'w') as sf:
-            self.assertRaises(TypeError, sf.write, SAMPLE_TEXT)  # we expect binary mode
+            with self.assertRaises(TypeError):
+                sf.write(SAMPLE_TEXT)  # we expect binary mode
+                # Need to flush because TextIOWrapper may buffer and we need
+                # to write to the underlying StringIO to get the TypeError.
+                sf.flush()
 
     def test_read_text_from_bytestream(self):
         buf = make_buffer(initial_value=SAMPLE_BYTES)
@@ -739,23 +745,149 @@ class SmartOpenReadTest(unittest.TestCase):
         self.assertEqual(r.read(), b"")
 
     @mock_s3
+    def test_newline_read(self):
+        """Does newline open() parameter for reading work according to
+           https://docs.python.org/3/library/functions.html#open-newline-parameter
+        """
+        s3 = boto3.resource('s3')
+        s3.create_bucket(Bucket='mybucket')
+        # Unicode line separator and various others must never split lines
+        test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
+        with smart_open.open("s3://mybucket/mykey", "wb") as fout:
+            fout.write(test_file.encode("utf-8"))
+
+        # No newline parameter means newline=None i.e. universal newline mode with all
+        # line endings translated to '\n'
+        with smart_open.open("s3://mybucket/mykey", "r", encoding='utf-8') as fin:
+            self.assertEqual(list(fin), [
+                u"line\u2028 LF\n",
+                u"line\x1c CR\n",
+                u"line\x85 CRLF\n",
+                u"last line"
+            ])
+
+        # If newline='' universal newline mode is enabled but line separators are not replaced
+        with smart_open.open("s3://mybucket/mykey", "r", encoding='utf-8',  newline='') as fin:
+            self.assertEqual(list(fin), [
+                u"line\u2028 LF\n",
+                u"line\x1c CR\r",
+                u"line\x85 CRLF\r\n",
+                u"last line"
+            ])
+
+        # If newline='\r' only CR splits lines
+        with smart_open.open("s3://mybucket/mykey", "r", encoding='utf-8', newline='\r') as fin:
+            self.assertEqual(list(fin), [
+                u"line\u2028 LF\nline\x1c CR\r",
+                u"line\x85 CRLF\r",
+                u"\nlast line"
+            ])
+
+        # If newline='\n' only LF splits lines
+        with smart_open.open("s3://mybucket/mykey", "r", encoding='utf-8', newline='\n') as fin:
+            self.assertEqual(list(fin), [
+                u"line\u2028 LF\n",
+                u"line\x1c CR\rline\x85 CRLF\r\n",
+                u"last line"
+            ])
+
+        # If newline='\r\n' only CRLF splits lines
+        with smart_open.open("s3://mybucket/mykey", "r", encoding='utf-8', newline='\r\n') as fin:
+            self.assertEqual(list(fin), [
+                u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\n",
+                u"last line"
+            ])
+
+        # Even reading the whole file with read() must replace newlines
+        with smart_open.open("s3://mybucket/mykey", "r", encoding='utf-8', newline=None) as fin:
+            self.assertEqual(
+                fin.read(),
+                u"line\u2028 LF\nline\x1c CR\nline\x85 CRLF\nlast line"
+            )
+
+        # If the file is opened in binary mode only LF splits lines
+        with smart_open.open("s3://mybucket/mykey", "rb") as fin:
+            self.assertEqual(list(fin), [
+                u"line\u2028 LF\n".encode('utf-8'),
+                u"line\x1c CR\rline\x85 CRLF\r\n".encode('utf-8'),
+                u"last line".encode('utf-8')
+            ])
+
+    @mock_s3
+    def test_newline_write(self):
+        """Does newline open() parameter for writing work according to
+           https://docs.python.org/3/library/functions.html#open-newline-parameter
+        """
+        s3 = boto3.resource('s3')
+        s3.create_bucket(Bucket='mybucket')
+        # Unicode line separator and various others must never split lines
+        test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
+
+        # No newline parameter means newline=None, all LF are translatest to os.linesep
+        with smart_open.open("s3://mybucket/mykey", "w", encoding='utf-8') as fout:
+            fout.write(test_file)
+        with smart_open.open("s3://mybucket/mykey", "rb") as fin:
+            self.assertEqual(
+                fin.read().decode('utf-8'),
+                u"line\u2028 LF" + os.linesep +
+                u"line\x1c CR\rline\x85 CRLF\r" + os.linesep +
+                u"last line"
+            )
+
+        # If newline='' nothing is changed
+        with smart_open.open("s3://mybucket/mykey", "w", encoding='utf-8', newline='') as fout:
+            fout.write(test_file)
+        with smart_open.open("s3://mybucket/mykey", "rb") as fin:
+            self.assertEqual(
+                fin.read().decode('utf-8'),
+                u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
+            )
+
+        # If newline='\n' nothing is changed
+        with smart_open.open("s3://mybucket/mykey", "w", encoding='utf-8', newline='\n') as fout:
+            fout.write(test_file)
+        with smart_open.open("s3://mybucket/mykey", "rb") as fin:
+            self.assertEqual(
+                fin.read().decode('utf-8'),
+                u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
+            )
+
+        # If newline='\r' all LF are replaced by CR
+        with smart_open.open("s3://mybucket/mykey", "w", encoding='utf-8', newline='\r') as fout:
+            fout.write(test_file)
+        with smart_open.open("s3://mybucket/mykey", "rb") as fin:
+            self.assertEqual(
+                fin.read().decode('utf-8'),
+                u"line\u2028 LF\rline\x1c CR\rline\x85 CRLF\r\rlast line"
+            )
+
+        # If newline='\r\n' all LF are replaced by CRLF
+        with smart_open.open("s3://mybucket/mykey", "w", encoding='utf-8', newline='\r\n') as fout:
+            fout.write(test_file)
+        with smart_open.open("s3://mybucket/mykey", "rb") as fin:
+            self.assertEqual(
+                fin.read().decode('utf-8'),
+                u"line\u2028 LF\r\nline\x1c CR\rline\x85 CRLF\r\r\nlast line"
+            )
+
+    @mock_s3
     def test_readline(self):
         """Does readline() return the correct file content?"""
         s3 = boto3.resource('s3')
         s3.create_bucket(Bucket='mybucket')
-        test_string = u"hello žluťoučký world!\nhow are you?".encode('utf8')
+        test_string = u"hello žluťoučký\u2028world!\nhow are you?".encode('utf8')
         with smart_open.open("s3://mybucket/mykey", "wb") as fout:
             fout.write(test_string)
 
         reader = smart_open.open("s3://mybucket/mykey", "rb")
-        self.assertEqual(reader.readline(), u"hello žluťoučký world!\n".encode("utf-8"))
+        self.assertEqual(reader.readline(), u"hello žluťoučký\u2028world!\n".encode("utf-8"))
 
     @mock_s3
     def test_readline_iter(self):
         """Does __iter__ return the correct file content?"""
         s3 = boto3.resource('s3')
         s3.create_bucket(Bucket='mybucket')
-        lines = [u"всем привет!\n", u"что нового?"]
+        lines = [u"всем\u2028привет!\n", u"что нового?"]
         with smart_open.open("s3://mybucket/mykey", "wb") as fout:
             fout.write("".join(lines).encode("utf-8"))
 
@@ -787,13 +919,14 @@ class SmartOpenReadTest(unittest.TestCase):
         # create fake bucket and fake key
         s3 = boto3.resource('s3')
         s3.create_bucket(Bucket='mybucket')
-        test_string = u"hello žluťoučký world!\nhow are you?".encode('utf8')
+        test_string = u"hello žluťoučký\u2028world!\nhow are you?".encode('utf8')
         with smart_open.open("s3://mybucket/mykey", "wb") as fin:
             fin.write(test_string)
 
         # call s3_iter_lines and check output
         reader = smart_open.open("s3://mybucket/mykey", "rb")
         output = list(reader)
+        self.assertEqual(len(output), 2)
         self.assertEqual(b''.join(output), test_string)
 
     # TODO: add more complex test for file://
@@ -1126,8 +1259,8 @@ class SmartOpenTest(unittest.TestCase):
         #
         # See https://github.com/RaRe-Technologies/smart_open/issues/477
         #
-        rows = [{'name': 'alice', 'color': 'aqua'}, {'name': 'bob', 'color': 'blue'}]
-        expected = 'name,color\nalice,aqua\nbob,blue\n'
+        rows = [{'name': 'alice\u2028beatrice', 'color': 'aqua'}, {'name': 'bob', 'color': 'blue'}]
+        expected = 'name,color\nalice\u2028beatrice,aqua\nbob,blue\n'
 
         with named_temporary_file(mode='w') as tmp:
             with smart_open.open(tmp.name, 'w+', newline='\n') as fout:

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -725,7 +725,7 @@ class SmartOpenReadTest(unittest.TestCase):
         fpath = os.path.join(CURR_DIR, 'test_data/cp852.tsv.txt')
         with open(fpath, 'rb') as fin:
             expected = fin.read().decode('cp852')
-        with smart_open.open(pathlib.Path(fpath), mode='r', encoding='cp852') as fin:
+        with smart_open.open(pathlib.Path(fpath), mode='r', encoding='cp852', newline='') as fin:
             actual = fin.read()
         self.assertEqual(expected, actual)
 
@@ -1311,7 +1311,7 @@ class SmartOpenTest(unittest.TestCase):
         expected = 'name,color\nalice\u2028beatrice,aqua\nbob,blue\n'
 
         with named_temporary_file(mode='w') as tmp:
-            with smart_open.open(tmp.name, 'w+', newline='\n') as fout:
+            with smart_open.open(tmp.name, 'w+', encoding='utf-8', newline='') as fout:
                 out = csv.DictWriter(fout, fieldnames=['name', 'color'])
                 out.writeheader()
                 out.writerows(rows)

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1308,15 +1308,18 @@ class SmartOpenTest(unittest.TestCase):
         # See https://github.com/RaRe-Technologies/smart_open/issues/477
         #
         rows = [{'name': 'alice\u2028beatrice', 'color': 'aqua'}, {'name': 'bob', 'color': 'blue'}]
-        expected = 'name,color\nalice\u2028beatrice,aqua\nbob,blue\n'
+        expected = 'name,color\r\nalice\u2028beatrice,aqua\r\nbob,blue\r\n'
 
         with named_temporary_file(mode='w') as tmp:
+            # The csv module recommends using newline='' when opening files and letting
+            # the csv writer handle line endings. By default it uses the 'excel' dialect which
+            # emits \r\n as line terminator.
             with smart_open.open(tmp.name, 'w+', encoding='utf-8', newline='') as fout:
                 out = csv.DictWriter(fout, fieldnames=['name', 'color'])
                 out.writeheader()
                 out.writerows(rows)
 
-            with open(tmp.name, 'r') as fin:
+            with open(tmp.name, 'r', encoding='utf-8', newline='') as fin:
                 content = fin.read()
 
         assert content == expected

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -771,7 +771,7 @@ class SmartOpenReadTest(unittest.TestCase):
         with smart_open.open("s3://mybucket/mykey", "wb") as fout:
             fout.write(test_file.encode("utf-8"))
         # If newline='' universal newline mode is enabled but line separators are not replaced
-        with smart_open.open("s3://mybucket/mykey", "r", encoding='utf-8',  newline='') as fin:
+        with smart_open.open("s3://mybucket/mykey", "r", encoding='utf-8', newline='') as fin:
             self.assertEqual(list(fin), [
                 u"line\u2028 LF\n",
                 u"line\x1c CR\r",
@@ -861,9 +861,9 @@ class SmartOpenReadTest(unittest.TestCase):
         with smart_open.open("s3://mybucket/mykey", "rb") as fin:
             self.assertEqual(
                 fin.read().decode('utf-8'),
-                u"line\u2028 LF" + os.linesep +
-                u"line\x1c CR\rline\x85 CRLF\r" + os.linesep +
-                u"last line"
+                u"line\u2028 LF" + os.linesep
+                + u"line\x1c CR\rline\x85 CRLF\r" + os.linesep
+                + u"last line"
             )
 
     @mock_s3


### PR DESCRIPTION
#### Title

Use `TextIOWrapper` instead of `codecs` to fix various newline issues when opening files in text mode.

#### Motivation

smart_open currently uses the `codecs` module to read text files which incorrectly splits lines as described in #557. This patch replaces `codecs` with `TextIOWrapper` fixing those issues and making the `newline` parameter work as expected for all files. Previously it was ignored unless the file was local and the builtin `open` was used.

- Fixes #557
- Fixes #536
- Fixes #394
- Fixes #269

#### Tests

New tests `test_newline_read` and `test_newline_write` have been added to ensure behavior of the `newline` parameter is the same as for python's builtin `open`.

Unicode line separator has been added to several other test for `readline()` to ensure line separation behavior is correct for differnent use cases.

#### Benchmarks

There seems to be no practical speed difference when reading read/writing text files on S3.
```
master branch:
---------------------------------------------------------------------------------------- benchmark: 2 tests ----------------------------------------------------------------------------------------
Name (time in ms)                    Min                 Max                Mean             StdDev              Median                IQR            Outliers     OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_s3_readwrite_text_gzip     220.6736 (1.0)      781.1166 (1.06)     317.5370 (1.00)     76.3814 (1.10)     300.2566 (1.02)     78.3614 (1.16)         16;2  3.1492 (1.00)        100           1
test_s3_readwrite_text          228.1418 (1.03)     735.1833 (1.0)      316.9454 (1.0)      69.3133 (1.0)      295.4379 (1.0)      67.6500 (1.0)          14;5  3.1551 (1.0)         100           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

this PR:
---------------------------------------------------------------------------------------- benchmark: 2 tests ----------------------------------------------------------------------------------------
Name (time in ms)                    Min                 Max                Mean             StdDev              Median                IQR            Outliers     OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_s3_readwrite_text          227.0207 (1.0)      595.1862 (1.13)     312.4748 (1.01)     61.7262 (1.09)     298.0243 (1.01)     79.3987 (1.10)         20;3  3.2003 (0.99)        100           1
test_s3_readwrite_text_gzip     228.5019 (1.01)     528.6511 (1.0)      308.6282 (1.0)      56.8423 (1.0)      295.3955 (1.0)      72.4423 (1.0)          22;2  3.2401 (1.0)         100           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
