### PR TITLE
Support tell() for text mode write on s3/gcs/azure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Support tell() for text mode write on s3/gcs/azure (PR [#582](https://github.com/RaRe-Technologies/smart_open/pull/582), [@markopy](https://github.com/markopy))
+
 # 4.1.2, 18 Jan 2021
 
 - Correctly pass boto3 resource to writers (PR [#576](https://github.com/RaRe-Technologies/smart_open/pull/576), [@jackluo923](https://github.com/jackluo923))

--- a/smart_open/azure.py
+++ b/smart_open/azure.py
@@ -396,6 +396,20 @@ class Writer(io.BufferedIOBase):
         """Return True if the stream supports writing."""
         return True
 
+    def seekable(self):
+        """If False, seek(), tell() and truncate() will raise IOError.
+
+        We offer only tell support, and no seek or truncate support."""
+        return True
+
+    def seek(self, offset, whence=smart_open.constants.WHENCE_START):
+        """Unsupported."""
+        raise io.UnsupportedOperation
+
+    def truncate(self, size=None):
+        """Unsupported."""
+        raise io.UnsupportedOperation
+
     def tell(self):
         """Return the current stream position."""
         return self._total_size

--- a/smart_open/gcs.py
+++ b/smart_open/gcs.py
@@ -446,6 +446,20 @@ class Writer(io.BufferedIOBase):
         """Return True if the stream supports writing."""
         return True
 
+    def seekable(self):
+        """If False, seek(), tell() and truncate() will raise IOError.
+
+        We offer only tell support, and no seek or truncate support."""
+        return True
+
+    def seek(self, offset, whence=constants.WHENCE_START):
+        """Unsupported."""
+        raise io.UnsupportedOperation
+
+    def truncate(self, size=None):
+        """Unsupported."""
+        raise io.UnsupportedOperation
+
     def tell(self):
         """Return the current stream position."""
         return self._total_size

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -813,6 +813,20 @@ multipart upload may fail")
         """Return True if the stream supports writing."""
         return True
 
+    def seekable(self):
+        """If False, seek(), tell() and truncate() will raise IOError.
+
+        We offer only tell support, and no seek or truncate support."""
+        return True
+
+    def seek(self, offset, whence=constants.WHENCE_START):
+        """Unsupported."""
+        raise io.UnsupportedOperation
+
+    def truncate(self, size=None):
+        """Unsupported."""
+        raise io.UnsupportedOperation
+
     def tell(self):
         """Return the current stream position."""
         return self._total_bytes
@@ -981,6 +995,20 @@ class SinglepartWriter(io.BufferedIOBase):
     def writable(self):
         """Return True if the stream supports writing."""
         return True
+
+    def seekable(self):
+        """If False, seek(), tell() and truncate() will raise IOError.
+
+        We offer only tell support, and no seek or truncate support."""
+        return True
+
+    def seek(self, offset, whence=constants.WHENCE_START):
+        """Unsupported."""
+        raise io.UnsupportedOperation
+
+    def truncate(self, size=None):
+        """Unsupported."""
+        raise io.UnsupportedOperation
 
     def tell(self):
         """Return the current stream position."""

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1155,6 +1155,18 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object.seek(0)
         self.assertEqual(content, smart_open_object.read(-1))  # same thing
 
+    @mock_s3
+    def test_s3_tell(self):
+        """Does tell() work when S3 file is opened for text writing? """
+        s3 = boto3.resource('s3')
+        s3.create_bucket(Bucket='mybucket')
+
+        with smart_open.open("s3://mybucket/mykey", "w") as fout:
+            fout.write(u"test")
+            # Note that tell() in general returns an opaque number for text files.
+            # See https://docs.python.org/3/library/io.html#io.TextIOBase.tell
+            self.assertEqual(fout.tell(), 4)
+
 
 class SmartOpenS3KwargsTest(unittest.TestCase):
     @mock.patch('boto3.Session')


### PR DESCRIPTION
This fixes #581

`TextIOWrapper` requires the underlying stream to indicate support for tell via `seekable()`. This was already implemented for S3/Azure/GCS when opening files in read mode. This PR does the same for write mode.
