### PR TITLE
Refactor S3, replace high-level resource/session API with low-level client API

### DIFF
--- a/MIGRATING_FROM_OLDER_VERSIONS.rst
+++ b/MIGRATING_FROM_OLDER_VERSIONS.rst
@@ -71,6 +71,24 @@ The `client_kwargs` dict can thus contain the following members:
 - `s3.Client.get_object`
 - `s3.Client.put_object`
 
+Here's a before-and-after example for connecting to a custom endpoint.  Before:
+
+.. code-block:: python
+
+    session = boto3.Session(profile_name='digitalocean')
+    resource_kwargs = {'endpoint_url': 'https://ams3.digitaloceanspaces.com'}
+    with open('s3://bucket/key.txt', 'wb', transport_params={'resource_kwarg': resource_kwargs}) as fout:
+        fout.write(b'here we stand')
+
+After:
+
+.. code-block:: python
+
+    session = boto3.Session(profile_name='digitalocean')
+    client = session.client('s3', endpoint_url='https://ams3.digitaloceanspaces.com')
+    with open('s3://bucket/key.txt', 'wb', transport_params={'client': client}) as fout:
+        fout.write(b'here we stand')
+
 See `README <README.rst>`_ and `HOWTO <howto.md>`_ for more examples.
 
 .. _resource API: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#service-resource

--- a/MIGRATING_FROM_OLDER_VERSIONS.rst
+++ b/MIGRATING_FROM_OLDER_VERSIONS.rst
@@ -4,6 +4,7 @@ Migrating to the new client-based S3 API
 Version of smart_open prior to 5.0.0 used the boto3 `resource API`_ for communicating with S3.
 This API was easy to integrate for smart_open developers, but this came at a cost: it was not thread- or multiprocess-safe.
 Furthermore, as smart_open supported more and more options, the transport parameter list grew, making it less maintainable.
+
 Starting with version 5.0.0, smart_open uses the `client API`_ instead of the resource API.
 Functionally, very little changes for the smart_open user. 
 The only difference is in passing transport parameters to the S3 backend.

--- a/MIGRATING_FROM_OLDER_VERSIONS.rst
+++ b/MIGRATING_FROM_OLDER_VERSIONS.rst
@@ -1,7 +1,7 @@
 Migrating to the new client-based S3 API
 ========================================
 
-Version of smart_open prior to 5.0.0 used the boto3 `resource API_` for communicating with S3.
+Version of smart_open prior to 5.0.0 used the boto3 `resource API`_ for communicating with S3.
 This API was easy to integrate for smart_open developers, but this came at a cost: it was not thread- or multiprocess-safe.
 Furthermore, as smart_open supported more and more options, the transport parameter list grew, making it less maintainable.
 Starting with version 5.0.0, smart_open uses the `client API`_ instead of the resource API.

--- a/MIGRATING_FROM_OLDER_VERSIONS.rst
+++ b/MIGRATING_FROM_OLDER_VERSIONS.rst
@@ -5,7 +5,7 @@ Version of smart_open prior to 5.0.0 used the boto3 `resource API`_ for communic
 This API was easy to integrate for smart_open developers, but this came at a cost: it was not thread- or multiprocess-safe.
 Furthermore, as smart_open supported more and more options, the transport parameter list grew, making it less maintainable.
 Starting with version 5.0.0, smart_open uses the `client API`_ instead of the resource API.
-Functionally, the little changes for the smart_open user. 
+Functionally, very little changes for the smart_open user. 
 The only difference is in passing transport parameters to the S3 backend.
 
 More specifically, the following S3 transport parameters are no longer supported:
@@ -25,23 +25,27 @@ If you were previously passing `session`, then construct an S3 client from the s
 For example, before:
 
 .. code-block:: python
+
     smart_open.open('s3://bucket/key', transport_params={'session': session})
 
 After:
 
 .. code-block:: python
+
     smart_open.open('s3://bucket/key', transport_params={'client': session.client('s3')})
 
 If you were passing `resource`, then replace the resource with a client, and pass that instead.
 For example, before:
 
 .. code-block:: python
+
     resource = session.resource('s3', **resource_kwargs)
     smart_open.open('s3://bucket/key', transport_params={'resource': resource})
 
 After:
 
 .. code-block:: python
+
     client = session.client('s3')
     smart_open.open('s3://bucket/key', transport_params={'client': client})
 

--- a/MIGRATING_FROM_OLDER_VERSIONS.rst
+++ b/MIGRATING_FROM_OLDER_VERSIONS.rst
@@ -74,6 +74,7 @@ See `README <README.rst>`_ and `HOWTO <howto.md>`_ for more examples.
 .. _s3.Object.put: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.ObjectSummary.put
 
 .. _client_API: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#client
+.. _s3.Client: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#client
 .. _s3.Client.create_multipart_upload: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.create_multipart_upload
 .. _s3.Client.get_object: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.get_object
 .. _s3.Client.put_object: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.put_object

--- a/MIGRATING_FROM_OLDER_VERSIONS.rst
+++ b/MIGRATING_FROM_OLDER_VERSIONS.rst
@@ -56,7 +56,7 @@ Parameter name             Resource API method                    Client API fun
 ========================== ====================================== ==========================
 `multipart_upload_kwargs`  `s3.Object.initiate_multipart_upload`_ `s3.Client.create_multipart_upload`_
 `object_kwargs`            `s3.Object.get`_                       `s3.Client.get_object`_
-`resource_kwargs`          s3.resource                            `s3.Client`
+`resource_kwargs`          s3.resource                            `s3.client`_
 `singlepart_upload_kwargs` `s3.Object.put`_                       `s3.Client.put_object`_
 ========================== ====================================== ==========================
 

--- a/MIGRATING_FROM_OLDER_VERSIONS.rst
+++ b/MIGRATING_FROM_OLDER_VERSIONS.rst
@@ -17,7 +17,8 @@ More specifically, the following S3 transport parameters are no longer supported
 - `session`
 - `singlepart_upload_kwargs`
 
-If you weren't using the above parameters, nothing changes for you.
+**If you weren't using the above parameters, nothing changes for you.**
+
 However, if you were using any of the above, then you need to adjust your code.
 Here are some quick recipes below.
 
@@ -196,4 +197,3 @@ or view the help online `here <https://github.com/RaRe-Technologies/smart_open/b
 
 If you pass an invalid parameter name, the ``smart_open.open`` function will warn you about it.
 Keep an eye on your logs for WARNING messages from ``smart_open``.
-

--- a/MIGRATING_FROM_OLDER_VERSIONS.rst
+++ b/MIGRATING_FROM_OLDER_VERSIONS.rst
@@ -68,12 +68,12 @@ The `client_kwargs` dict can thus contain the following members:
 
 See `README <README.rst>`_ and `HOWTO <howto.md>`_ for more examples.
 
-.. _resource_API: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#service-resource
+.. _resource API: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#service-resource
 .. _s3.Object.initiate_multipart_upload: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Object.initiate_multipart_upload
 .. _s3.Object.get: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.ObjectSummary.get
 .. _s3.Object.put: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.ObjectSummary.put
 
-.. _client_API: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#client
+.. _client API: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#client
 .. _s3.Client: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#client
 .. _s3.Client.create_multipart_upload: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.create_multipart_upload
 .. _s3.Client.get_object: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.get_object

--- a/MIGRATING_FROM_OLDER_VERSIONS.rst
+++ b/MIGRATING_FROM_OLDER_VERSIONS.rst
@@ -22,23 +22,26 @@ However, if you were using any of the above, then you need to adjust your code.
 Here are some quick recipes below.
 
 If you were previously passing `session`, then construct an S3 client from the session and pass that instead.
-For example, before::
+For example, before:
 
+.. code-block:: python
     smart_open.open('s3://bucket/key', transport_params={'session': session})
 
-After::
+After:
 
+.. code-block:: python
     smart_open.open('s3://bucket/key', transport_params={'client': session.client('s3')})
 
-
 If you were passing `resource`, then replace the resource with a client, and pass that instead.
-For example, before::
+For example, before:
 
+.. code-block:: python
     resource = session.resource('s3', **resource_kwargs)
     smart_open.open('s3://bucket/key', transport_params={'resource': resource})
 
-After::
+After:
 
+.. code-block:: python
     client = session.client('s3')
     smart_open.open('s3://bucket/key', transport_params={'client': client})
 
@@ -47,18 +50,23 @@ If you were passing any of the `*_kwargs` parameters, you will need to include t
 ========================== ====================================== ==========================
 Parameter name             Resource API method                    Client API function
 ========================== ====================================== ==========================
-`multipart_upload_kwargs`  `s3.Object.initiate_multipart_upload`_ `create_multipart_upload`_
-`object_kwargs`            `s3.Object.get`_                       `get_object`_
-`resource_kwargs`          ???                                    ???
-`singlepart_upload_kwargs` `s3.Object.put`_                       `put_object`_
+`multipart_upload_kwargs`  `s3.Object.initiate_multipart_upload`_ `s3.Client.create_multipart_upload`_
+`object_kwargs`            `s3.Object.get`_                       `s3.Client.get_object`_
+`resource_kwargs`          s3.resource                            `s3.Client`
+`singlepart_upload_kwargs` `s3.Object.put`_                       `s3.Client.put_object`_
 ========================== ====================================== ==========================
+
+Most of the above is self-explanatory, with the exception of `resource_kwargs`.
+These were previously used mostly for passing a custom endpoint URL.
 
 The `client_kwargs` dict can thus contain the following members:
 
-- `s3.Client`: initializer parameters, e.g. those to pass directly to the `boto3.client` function
+- `s3.Client`: initializer parameters, e.g. those to pass directly to the `boto3.client` function, such as `endpoint_url`.
 - `s3.Client.create_multipart_upload`
 - `s3.Client.get_object`
 - `s3.Client.put_object`
+
+See `README <README.rst>`_ and `HOWTO <howto.md>`_ for more examples.
 
 .. _resource_API: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#service-resource
 .. _s3.Object.initiate_multipart_upload: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Object.initiate_multipart_upload
@@ -66,9 +74,9 @@ The `client_kwargs` dict can thus contain the following members:
 .. _s3.Object.put: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.ObjectSummary.put
 
 .. _client_API: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#client
-.. _create_multipart_upload: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.create_multipart_upload
-.. _get_object: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.get_object
-.. _get_object: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.put_object
+.. _s3.Client.create_multipart_upload: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.create_multipart_upload
+.. _s3.Client.get_object: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.get_object
+.. _s3.Client.put_object: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.put_object
 
 Migrating to the new dependency management subsystem
 ====================================================

--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ For the sake of simplicity, the examples below assume you have all the dependenc
     ...     aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
     ... )
     >>> url = 's3://smart-open-py37-benchmark-results/test.txt'
-    >>> with open(url, 'wb', transport_params={'session': session}) as fout:
+    >>> with open(url, 'wb', transport_params={'client': session.client('s3')}) as fout:
     ...     bytes_written = fout.write(b'hello world!')
     ...     print(bytes_written)
     12
@@ -182,12 +182,9 @@ For the sake of simplicity, the examples below assume you have all the dependenc
         print(line)
 
     # Stream to Digital Ocean Spaces bucket providing credentials from boto3 profile
-    transport_params = {
-        'session': boto3.Session(profile_name='digitalocean'),
-        'resource_kwargs': {
-            'endpoint_url': 'https://ams3.digitaloceanspaces.com',
-        }
-    }
+    session = boto3.Session(profile_name='digitalocean')
+    client = session.client('s3', endpoint_url='https://ams3.digitaloceanspaces.com')
+    transport_params = {'client': client}
     with open('s3://bucket/key.txt', 'wb', transport_params=transport_params) as fout:
         fout.write(b'here we stand')
 
@@ -202,7 +199,7 @@ For the sake of simplicity, the examples below assume you have all the dependenc
     # stream from Azure Blob Storage
     connect_str = os.environ['AZURE_STORAGE_CONNECTION_STRING']
     transport_params = {
-        client: azure.storage.blob.BlobServiceClient.from_connection_string(connect_str)
+        'client': azure.storage.blob.BlobServiceClient.from_connection_string(connect_str),
     }
     for line in open('azure://mycontainer/myfile.txt', transport_params=transport_params):
         print(line)
@@ -210,7 +207,7 @@ For the sake of simplicity, the examples below assume you have all the dependenc
     # stream content *into* Azure Blob Storage (write mode):
     connect_str = os.environ['AZURE_STORAGE_CONNECTION_STRING']
     transport_params = {
-        client: azure.storage.blob.BlobServiceClient.from_connection_string(connect_str)
+        'client': azure.storage.blob.BlobServiceClient.from_connection_string(connect_str),
     }
     with open('azure://mycontainer/my_file.txt', 'wb', transport_params=transport_params) as fout:
         fout.write(b'hello world')
@@ -264,7 +261,7 @@ Here are some examples of using this parameter:
 .. code-block:: python
 
   >>> import boto3
-  >>> fin = open('s3://commoncrawl/robots.txt', transport_params=dict(session=boto3.Session()))
+  >>> fin = open('s3://commoncrawl/robots.txt', transport_params=dict(client=boto3.client('s3')))
   >>> fin = open('s3://commoncrawl/robots.txt', transport_params=dict(buffer_size=1024))
 
 For the full list of keyword arguments supported by each transport option, see the documentation:
@@ -292,7 +289,7 @@ You can customize the credentials when constructing the session.
         aws_secret_access_key=SECRET_KEY,
         aws_session_token=SESSION_TOKEN,
     )
-    fin = open('s3://bucket/key', transport_params=dict(session=session), ...)
+    fin = open('s3://bucket/key', transport_params=dict(client=session.client('s3')), ...)
 
 Your second option is to specify the credentials within the S3 URL itself:
 

--- a/README.rst
+++ b/README.rst
@@ -278,8 +278,8 @@ S3 Credentials
 By default, ``smart_open`` will defer to ``boto3`` and let the latter take care of the credentials.
 There are several ways to override this behavior.
 
-The first is to pass a ``boto3.Session`` object as a transport parameter to the ``open`` function.
-You can customize the credentials when constructing the session.
+The first is to pass a ``boto3.Client`` object as a transport parameter to the ``open`` function.
+You can customize the credentials when constructing the session for the client.
 ``smart_open`` will then use the session when talking to S3.
 
 .. code-block:: python
@@ -289,7 +289,8 @@ You can customize the credentials when constructing the session.
         aws_secret_access_key=SECRET_KEY,
         aws_session_token=SESSION_TOKEN,
     )
-    fin = open('s3://bucket/key', transport_params=dict(client=session.client('s3')), ...)
+    client = session.client('s3', endpoint_url=..., config=...)
+    fin = open('s3://bucket/key', transport_params=dict(client=client))
 
 Your second option is to specify the credentials within the S3 URL itself:
 
@@ -297,7 +298,7 @@ Your second option is to specify the credentials within the S3 URL itself:
 
     fin = open('s3://aws_access_key_id:aws_secret_access_key@bucket/key', ...)
 
-*Important*: The two methods above are **mutually exclusive**. If you pass an AWS session *and* the URL contains credentials, ``smart_open`` will ignore the latter.
+*Important*: The two methods above are **mutually exclusive**. If you pass an AWS client *and* the URL contains credentials, ``smart_open`` will ignore the latter.
 
 *Important*: ``smart_open`` ignores configuration files from the older ``boto`` library.
 Port your old ``boto`` settings to ``boto3`` in order to use them with ``smart_open``.

--- a/help.txt
+++ b/help.txt
@@ -137,17 +137,6 @@ FUNCTIONS
             The buffer size to use when performing I/O.
         min_part_size: int, optional
             The minimum part size for multipart uploads.  For writing only.
-        session: object, optional
-            The S3 session to use when working with boto3.
-        resource_kwargs: dict, optional
-            Keyword arguments to use when accessing the S3 resource for reading or writing.
-        multipart_upload_kwargs: dict, optional
-            Additional parameters to pass to boto3's initiate_multipart_upload function.
-            For writing only.
-        singlepart_upload_kwargs: dict, optional
-            Additional parameters to pass to boto3's S3.Object.put function when using single
-            part upload.
-            For writing only.
         multipart_upload: bool, optional
             Default: `True`
             If set to `True`, will use multipart upload for writing to S3. If set
@@ -157,14 +146,18 @@ FUNCTIONS
         version_id: str, optional
             Version of the object, used when reading object.
             If None, will fetch the most recent version.
-        object_kwargs: dict, optional
-            Additional parameters to pass to boto3's object.get function.
-            Used during reading only.
         defer_seek: boolean, optional
             Default: `False`
             If set to `True` on a file opened for reading, GetObject will not be
             called until the first seek() or read().
             Avoids redundant API queries when seeking before reading.
+        client: object, optional
+            The S3 client to use when working with boto3.
+            If you don't specify this, then smart_open will create a new client for you.
+        client_kwargs: dict, optional
+            Additional parameters to pass to the relevant functions of the client.
+            The keys are fully qualified method names, e.g. `S3.Client.create_multipart_upload`.
+            The values are kwargs to pass to that method each time it is called.
         
         scp (smart_open/ssh.py)
         ~~~~~~~~~~~~~~~~~~~~~~~
@@ -318,13 +311,13 @@ FUNCTIONS
     s3_iter_bucket(bucket_name, prefix='', accept_key=None, key_limit=None, workers=16, retries=3, **session_kwargs)
         Deprecated.  Use smart_open.s3.iter_bucket instead.
     
-    smart_open(uri, mode='rb', **kw)
+    smart_open(uri, mode='rb', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, ignore_extension=False, **kwargs)
 
 DATA
     __all__ = ['open', 'parse_uri', 'register_compressor', 's3_iter_bucket...
 
 VERSION
-    2.1.1
+    4.1.2.dev0
 
 FILE
     /home/misha/git/smart_open/smart_open/__init__.py

--- a/howto.md
+++ b/howto.md
@@ -285,7 +285,8 @@ import boto3
 import smart_open
 with smart_open.open('s3://bucket/key', 'wb') as fout:
     fout.write(b'hello world!')
-client = boto3.client('s3').put_object_acl(ACL=acl_as_string)
+client = boto3.client('s3')
+client.put_object_acl(ACL=acl_as_string)
 ```
 
 Here's the same code that passes the above parameter via `smart_open`:

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -666,7 +666,7 @@ class Reader(io.BufferedIOBase):
         `boto3.s3.Object` may not necessarily affect the current instance.
 
         """
-        if not resource:
+        if resource is None:
             resource = boto3.resource('s3')
         obj = resource.Object(self._bucket, self._key)
         if self._version_id is not None:

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -127,41 +127,46 @@ def _consolidate_params(uri, transport_params):
     """
     transport_params = dict(transport_params)
 
-    session = transport_params.get('session')
-    if session is not None and (uri['access_id'] or uri['access_secret']):
+    def inject(**kwargs):
+        try:
+            client_kwargs = transport_params['client_kwargs']
+        except KeyError:
+            client_kwargs = transport_params['client_kwargs'] = {}
+
+        try:
+            ctor_kwargs = client_kwargs['S3.Client']
+        except KeyError:
+            ctor_kwargs = client_kwargs['S3.Client'] = {}
+
+        ctor_kwargs.update(**kwargs)
+
+    client = transport_params.get('client')
+    if client is not None and (uri['access_id'] or uri['access_secret']):
         logger.warning(
             'ignoring credentials parsed from URL because they conflict with '
-            'transport_params["session"]. Set transport_params["session"] to None '
+            'transport_params["client"]. Set transport_params["client"] to None '
             'to suppress this warning.'
         )
         uri.update(access_id=None, access_secret=None)
     elif (uri['access_id'] and uri['access_secret']):
-        transport_params['session'] = boto3.Session(
+        inject(
             aws_access_key_id=uri['access_id'],
             aws_secret_access_key=uri['access_secret'],
         )
         uri.update(access_id=None, access_secret=None)
 
-    if uri['host'] != DEFAULT_HOST:
-        endpoint_url = 'https://%(host)s:%(port)d' % uri
-        _override_endpoint_url(transport_params, endpoint_url)
+    if client is not None and uri['host'] != DEFAULT_HOST:
+        logger.warning(
+            'ignoring endpoint_url parsed from URL because they conflict with '
+            'transport_params["client"]. Set transport_params["client"] to None '
+            'to suppress this warning.'
+        )
+        uri.update(host=None)
+    elif uri['host'] != DEFAULT_HOST:
+        inject(endpoint_url='https://%(host)s:%(port)d' % uri)
+        uri.update(host=None)
 
     return uri, transport_params
-
-
-def _override_endpoint_url(transport_params, url):
-    try:
-        resource_kwargs = transport_params['resource_kwargs']
-    except KeyError:
-        resource_kwargs = transport_params['resource_kwargs'] = {}
-
-    if resource_kwargs.get('endpoint_url'):
-        logger.warning(
-            'ignoring endpoint_url parsed from URL because it conflicts '
-            'with transport_params["resource_kwargs"]["endpoint_url"]'
-        )
-    else:
-        resource_kwargs.update(endpoint_url=url)
 
 
 def open_uri(uri, mode, transport_params):
@@ -178,14 +183,10 @@ def open(
     version_id=None,
     buffer_size=DEFAULT_BUFFER_SIZE,
     min_part_size=DEFAULT_MIN_PART_SIZE,
-    session=None,
-    resource=None,
-    resource_kwargs=None,
-    multipart_upload_kwargs=None,
     multipart_upload=True,
-    singlepart_upload_kwargs=None,
-    object_kwargs=None,
     defer_seek=False,
+    client=None,
+    client_kwargs=None,
 ):
     """Open an S3 object for reading or writing.
 
@@ -201,22 +202,6 @@ def open(
         The buffer size to use when performing I/O.
     min_part_size: int, optional
         The minimum part size for multipart uploads.  For writing only.
-    session: object, optional
-        The S3 session to use when working with boto3.
-        If you don't specify this, then smart_open will create a new session for you.
-    resource: object, optional
-        The S3 resource to use when working with boto3.
-        If you don't specify this, then smart_open will create a new resource for you.
-    resource_kwargs: dict, optional
-        Keyword arguments to use when creating the S3 resource for reading or writing.
-        Will be ignored if you specify the resource object explicitly.
-    multipart_upload_kwargs: dict, optional
-        Additional parameters to pass to boto3's initiate_multipart_upload function.
-        For writing only.
-    singlepart_upload_kwargs: dict, optional
-        Additional parameters to pass to boto3's S3.Object.put function when using single
-        part upload.
-        For writing only.
     multipart_upload: bool, optional
         Default: `True`
         If set to `True`, will use multipart upload for writing to S3. If set
@@ -226,14 +211,16 @@ def open(
     version_id: str, optional
         Version of the object, used when reading object.
         If None, will fetch the most recent version.
-    object_kwargs: dict, optional
-        Additional parameters to pass to boto3's object.get function.
-        Used during reading only.
     defer_seek: boolean, optional
         Default: `False`
         If set to `True` on a file opened for reading, GetObject will not be
         called until the first seek() or read().
         Avoids redundant API queries when seeking before reading.
+    client: object, optional
+        The S3 client to use when working with boto3.
+        If you don't specify this, then smart_open will create a new client for you.
+    client_kwargs: dict, optional
+        Additional parameters to pass to the relevant functions of the client.
     """
     logger.debug('%r', locals())
     if mode not in constants.BINARY_MODES:
@@ -248,11 +235,9 @@ def open(
             key_id,
             version_id=version_id,
             buffer_size=buffer_size,
-            session=session,
-            resource=resource,
-            resource_kwargs=resource_kwargs,
-            object_kwargs=object_kwargs,
             defer_seek=defer_seek,
+            client=client,
+            client_kwargs=client_kwargs,
         )
     elif mode == constants.WRITE_BINARY:
         if multipart_upload:
@@ -260,19 +245,15 @@ def open(
                 bucket_id,
                 key_id,
                 min_part_size=min_part_size,
-                session=session,
-                resource=resource,
-                upload_kwargs=multipart_upload_kwargs,
-                resource_kwargs=resource_kwargs,
+                client=client,
+                client_kwargs=client_kwargs,
             )
         else:
             fileobj = SinglepartWriter(
                 bucket_id,
                 key_id,
-                session=session,
-                resource=resource,
-                upload_kwargs=singlepart_upload_kwargs,
-                resource_kwargs=resource_kwargs,
+                client=client,
+                client_kwargs=client_kwargs,
             )
     else:
         assert False, 'unexpected mode: %r' % mode
@@ -281,15 +262,16 @@ def open(
     return fileobj
 
 
-def _get(s3_object, version=None, **kwargs):
+def _get(client, bucket, key, version, **get_object_kwargs):
     if version is not None:
-        kwargs['VersionId'] = version
+        get_object_kwargs['VersionId'] = version
+
     try:
-        return s3_object.get(**kwargs)
+        return client.get_object(Bucket=bucket, Key=key, **get_object_kwargs)
     except botocore.client.ClientError as error:
         wrapped_error = IOError(
             'unable to access bucket: %r key: %r version: %r error: %s' % (
-                s3_object.bucket_name, s3_object.key, version, error
+                bucket, key, version, error
             )
         )
         wrapped_error.backend_error = error
@@ -312,16 +294,21 @@ class _SeekableRawReader(object):
 
     def __init__(
         self,
-        s3_object,
+        client,
+        bucket,
+        key,
         version_id=None,
-        object_kwargs=None,
+        client_kwargs=None,
     ):
-        self._object = s3_object
-        self._content_length = None
+        self._client = client
+        self._bucket = bucket
+        self._key = key
         self._version_id = version_id
+
+        self._content_length = None
         self._position = 0
         self._body = None
-        self._object_kwargs = object_kwargs if object_kwargs else {}
+        self._client_kwargs = client_kwargs if client_kwargs else {}
 
     def seek(self, offset, whence=constants.WHENCE_START):
         """Seek to the specified position.
@@ -391,10 +378,12 @@ class _SeekableRawReader(object):
         try:
             # Optimistically try to fetch the requested content range.
             response = _get(
-                self._object,
+                self._client,
+                self._bucket,
+                self._key,
                 version=self._version_id,
                 Range=range_string,
-                **self._object_kwargs
+                **self._client_kwargs.get('S3.Client.get_object', {}),
             )
         except IOError as ioe:
             # Handle requested content range exceeding content size.
@@ -468,43 +457,20 @@ class _SeekableRawReader(object):
         raise IOError('%s: failed to read %d bytes after %d attempts' % (self, size, attempt))
 
     def __str__(self):
-        return 'smart_open.s3._SeekableReader(%r, %r)' % (
-            self._object.bucket_name,
-            self._object.key,
-        )
+        return 'smart_open.s3._SeekableReader(%r, %r)' % (self._bucket, self._key)
 
 
-def _initialize_boto3(rw, session, resource, resource_kwargs):
+def _initialize_boto3(rw, client, client_kwargs):
     """Created the required objects for accessing S3.  Ideally, they have
-    been already created for us and we can just reuse them.
+    been already created for us and we can just reuse them."""
+    if client_kwargs is None:
+        client_kwargs = {}
+    rw._client_kwargs = client_kwargs
 
-    We only really need one thing: the resource.  There are multiple ways of
-    getting one, in order of effort:
-
-    1) Directly from the user
-    2) From the session directly specified by the user
-    3) From an entirely new session
-
-    Once we have the resource, we no longer need the session.
-    """
-    if resource_kwargs is None:
-        resource_kwargs = {}
-
-    if resource:
-        if session:
-            logger.warning('ignoring session because resource was passed explicitly')
-        if resource_kwargs:
-            logger.warning('ignoring resource_kwargs because resource was passed explicitly')
-        rw._session = None
-        rw._resource = resource
-    elif session:
-        rw._session = session
-        rw._resource = rw._session.resource('s3', **resource_kwargs)
-        rw._resource_kwargs = resource_kwargs
+    if client:
+        rw._client = client
     else:
-        rw._session = boto3.Session()
-        rw._resource = rw._session.resource('s3', **resource_kwargs)
-        rw._resource_kwargs = resource_kwargs
+        rw._client = boto3.client('s3', **client_kwargs.get('S3.Client', {}))
 
 
 class Reader(io.BufferedIOBase):
@@ -519,29 +485,23 @@ class Reader(io.BufferedIOBase):
         version_id=None,
         buffer_size=DEFAULT_BUFFER_SIZE,
         line_terminator=constants.BINARY_NEWLINE,
-        session=None,
-        resource=None,
-        resource_kwargs=None,
-        object_kwargs=None,
         defer_seek=False,
+        client=None,
+        client_kwargs=None,
     ):
+        self._bucket = bucket
+        self._key = key
+        self._version_id = version_id
         self._buffer_size = buffer_size
 
-        if resource_kwargs is None:
-            resource_kwargs = {}
-        if object_kwargs is None:
-            object_kwargs = {}
-
-        _initialize_boto3(self, session, resource, resource_kwargs)
-
-        self._object_kwargs = object_kwargs
-        self._object = self._resource.Object(bucket, key)
-        self._version_id = version_id
+        _initialize_boto3(self, client, client_kwargs)
 
         self._raw_reader = _SeekableRawReader(
-            self._object,
+            self._client,
+            bucket,
+            key,
             self._version_id,
-            self._object_kwargs,
+            client_kwargs=self._client_kwargs,
         )
         self._current_pos = 0
         self._buffer = smart_open.bytebuffer.ByteBuffer(buffer_size)
@@ -562,7 +522,7 @@ class Reader(io.BufferedIOBase):
 
     def close(self):
         """Flush and close this stream."""
-        self._object = None
+        pass
 
     def readable(self):
         """Return True if the stream can be read from."""
@@ -668,7 +628,7 @@ class Reader(io.BufferedIOBase):
         """Do nothing."""
         pass
 
-    def to_boto3(self):
+    def to_boto3(self, resource=None):
         """Create an **independent** `boto3.s3.Object` instance that points to
         the same resource as this instance.
 
@@ -677,13 +637,13 @@ class Reader(io.BufferedIOBase):
         `boto3.s3.Object` may not necessarily affect the current instance.
 
         """
+        if not resource:
+            resource = boto3.resource('s3')
+        obj = resource.Object(self._bucket, self._key)
         if self._version_id is not None:
-            return self._resource.Object(
-                self._object.bucket_name,
-                self._object.key,
-            ).Version(self._version_id)
+            return obj.Version(self._version_id)
         else:
-            return self._resource.Object(self._object.bucket_name, self._object.key)
+            return obj
 
     #
     # Internal methods.
@@ -704,9 +664,7 @@ class Reader(io.BufferedIOBase):
                 self._eof = True
 
     def __str__(self):
-        return "smart_open.s3.Reader(%r, %r)" % (
-            self._object.bucket_name, self._object.key
-        )
+        return "smart_open.s3.Reader(%r, %r)" % (self._bucket, self._key)
 
     def __repr__(self):
         return (
@@ -715,17 +673,13 @@ class Reader(io.BufferedIOBase):
             "key=%r, "
             "version_id=%r, "
             "buffer_size=%r, "
-            "line_terminator=%r, "
-            "session=%r, "
-            "resource_kwargs=%r)"
+            "line_terminator=%r)"
         ) % (
-            self._object.bucket_name,
-            self._object.key,
+            self._bucket,
+            self._key,
             self._version_id,
             self._buffer_size,
             self._line_terminator,
-            self._session,
-            self._resource_kwargs,
         )
 
 
@@ -739,27 +693,27 @@ class MultipartWriter(io.BufferedIOBase):
         bucket,
         key,
         min_part_size=DEFAULT_MIN_PART_SIZE,
-        session=None,
-        resource=None,
-        resource_kwargs=None,
-        upload_kwargs=None,
+        client=None,
+        client_kwargs=None,
     ):
+        self._bucket = bucket
+        self._key = key
+
         if min_part_size < MIN_MIN_PART_SIZE:
             logger.warning("S3 requires minimum part size >= 5MB; \
 multipart upload may fail")
+        self._min_part_size = min_part_size
 
-        _initialize_boto3(self, session, resource, resource_kwargs)
-
-        if upload_kwargs is None:
-            upload_kwargs = {}
-
-        self._upload_kwargs = upload_kwargs
+        _initialize_boto3(self, client, client_kwargs)
 
         try:
-            self._object = self._resource.Object(bucket, key)
-            self._min_part_size = min_part_size
-            partial = functools.partial(self._object.initiate_multipart_upload, **self._upload_kwargs)
-            self._mp = _retry_if_failed(partial)
+            partial = functools.partial(
+                self._client.create_multipart_upload,
+                Bucket=bucket,
+                Key=key,
+                **self._client_kwargs.get('S3.Client.create_multipart_upload', {}),
+            )
+            self._upload_id = _retry_if_failed(partial)['UploadId']
         except botocore.client.ClientError as error:
             raise ValueError(
                 'the bucket %r does not exist, or is forbidden for access (%r)' % (
@@ -787,11 +741,17 @@ multipart upload may fail")
         if self._buf.tell():
             self._upload_next_part()
 
-        if self._total_bytes and self._mp:
-            partial = functools.partial(self._mp.complete, MultipartUpload={'Parts': self._parts})
+        if self._total_bytes and self._upload_id:
+            partial = functools.partial(
+                self._client.complete_multipart_upload,
+                Bucket=self._bucket,
+                Key=self._key,
+                UploadId=self._upload_id,
+                MultipartUpload={'Parts': self._parts},
+            )
             _retry_if_failed(partial)
             logger.debug('%s: completed multipart upload', self)
-        elif self._mp:
+        elif self._upload_id:
             #
             # AWS complains with "The XML you provided was not well-formed or
             # did not validate against our published schema" when the input is
@@ -799,15 +759,19 @@ multipart upload may fail")
             #
             # We work around this by creating an empty file explicitly.
             #
-            assert self._mp, "no multipart upload in progress"
-            self._mp.abort()
-            self._object.put(Body=b'')
+            assert self._upload_id, "no multipart upload in progress"
+            self._client.abort_multipart_upload(
+                Bucket=self._bucket,
+                Key=self._key,
+                UploadId=self._upload_id,
+            )
+            self._client.put_object(Bucket=self._bucket, Key=self._key, Body=b'')
             logger.debug('%s: wrote 0 bytes to imitate multipart upload', self)
-        self._mp = None
+        self._upload_id = None
 
     @property
     def closed(self):
-        return self._mp is None
+        return self._upload_id is None
 
     def writable(self):
         """Return True if the stream supports writing."""
@@ -842,11 +806,15 @@ multipart upload may fail")
 
     def terminate(self):
         """Cancel the underlying multipart upload."""
-        assert self._mp, "no multipart upload in progress"
-        self._mp.abort()
-        self._mp = None
+        assert self._upload_id, "no multipart upload in progress"
+        self._client.abort_multipart_upload(
+            Bucket=self._bucket,
+            Key=self._key,
+            UploadId=self._upload_id,
+        )
+        self._upload_id = None
 
-    def to_boto3(self):
+    def to_boto3(self, resource=None):
         """Create an **independent** `boto3.s3.Object` instance that points to
         the same resource as this instance.
 
@@ -855,7 +823,9 @@ multipart upload may fail")
         `boto3.s3.Object` may not necessary affect the current instance.
 
         """
-        return self._resource.Object(self._object.bucket_name, self._object.key)
+        if not resource:
+            resource = boto3.resource('s3')
+        return resource.Object(self._bucket, self._key)
 
     #
     # Internal methods.
@@ -870,7 +840,6 @@ multipart upload may fail")
             self._total_bytes / 1024.0 ** 3,
         )
         self._buf.seek(0)
-        part = self._mp.Part(part_num)
 
         #
         # Network problems in the middle of an upload are particularly
@@ -878,7 +847,16 @@ multipart upload may fail")
         # of a temporary connection problem, so this part needs to be
         # especially robust.
         #
-        upload = _retry_if_failed(functools.partial(part.upload, Body=self._buf))
+        upload = _retry_if_failed(
+            functools.partial(
+                self._client.upload_part,
+                Bucket=self._bucket,
+                Key=self._key,
+                UploadId=self._upload_id,
+                PartNumber=part_num,
+                Body=self._buf,
+            )
+        )
 
         self._parts.append({'ETag': upload['ETag'], 'PartNumber': part_num})
         logger.debug("%s: upload of part_num #%i finished", self, part_num)
@@ -896,21 +874,13 @@ multipart upload may fail")
             self.close()
 
     def __str__(self):
-        return "smart_open.s3.MultipartWriter(%r, %r)" % (
-            self._object.bucket_name, self._object.key,
-        )
+        return "smart_open.s3.MultipartWriter(%r, %r)" % (self._bucket, self._key)
 
     def __repr__(self):
-        return (
-            "smart_open.s3.MultipartWriter(bucket=%r, key=%r, "
-            "min_part_size=%r, session=%r, resource_kwargs=%r, upload_kwargs=%r)"
-        ) % (
-            self._object.bucket_name,
-            self._object.key,
+        return "smart_open.s3.MultipartWriter(bucket=%r, key=%r, min_part_size=%r)" % (
+            self._bucket,
+            self._key,
             self._min_part_size,
-            self._session,
-            self._resource_kwargs,
-            self._upload_kwargs,
         )
 
 
@@ -923,25 +893,19 @@ class SinglepartWriter(io.BufferedIOBase):
     the data be written to S3 and the buffer is released."""
 
     def __init__(
-            self,
-            bucket,
-            key,
-            session=None,
-            resource=None,
-            resource_kwargs=None,
-            upload_kwargs=None,
-            ):
+        self,
+        bucket,
+        key,
+        client=None,
+        client_kwargs=None,
+    ):
+        self._bucket = bucket
+        self._key = key
 
-        _initialize_boto3(self, session, resource, resource_kwargs)
-
-        if upload_kwargs is None:
-            upload_kwargs = {}
-
-        self._upload_kwargs = upload_kwargs
+        _initialize_boto3(self, client, client_kwargs)
 
         try:
-            self._object = self._resource.Object(bucket, key)
-            self._resource.meta.client.head_bucket(Bucket=bucket)
+            self._object = self._client.head_bucket(Bucket=bucket)
         except botocore.client.ClientError as e:
             raise ValueError('the bucket %r does not exist, or is forbidden for access' % bucket) from e
 
@@ -966,10 +930,15 @@ class SinglepartWriter(io.BufferedIOBase):
         self._buf.seek(0)
 
         try:
-            self._object.put(Body=self._buf, **self._upload_kwargs)
+            self._client.put_object(
+                Bucket=self._bucket,
+                Key=self._key,
+                Body=self._buf,
+                **self._client_kwargs.get('S3.Client.put_object', {}),
+            )
         except botocore.client.ClientError as e:
             raise ValueError(
-                'the bucket %r does not exist, or is forbidden for access' % self._object.bucket_name) from e
+                'the bucket %r does not exist, or is forbidden for access' % self._bucket) from e
 
         logger.debug("%s: direct upload finished", self)
         self._buf = None
@@ -1023,16 +992,7 @@ class SinglepartWriter(io.BufferedIOBase):
         return "smart_open.s3.SinglepartWriter(%r, %r)" % (self._object.bucket_name, self._object.key)
 
     def __repr__(self):
-        return (
-            "smart_open.s3.SinglepartWriter(bucket=%r, key=%r, session=%r, "
-            "resource_kwargs=%r, upload_kwargs=%r)"
-        ) % (
-            self._object.bucket_name,
-            self._object.key,
-            self._session,
-            self._resource_kwargs,
-            self._upload_kwargs,
-        )
+        return "smart_open.s3.SinglepartWriter(bucket=%r, key=%r)" % (self._bucket, self._key)
 
 
 def _retry_if_failed(
@@ -1055,13 +1015,6 @@ def _retry_if_failed(
     else:
         logger.critical('Unable to connect to the endpoint. Giving up.')
         raise IOError('Unable to connect to the endpoint after %d attempts' % attempts)
-
-
-#
-# For backward compatibility
-#
-SeekableBufferedInputBase = Reader
-BufferedOutputBase = MultipartWriter
 
 
 def _accept_all(key):

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -241,6 +241,8 @@ def open(
         If you don't specify this, then smart_open will create a new client for you.
     client_kwargs: dict, optional
         Additional parameters to pass to the relevant functions of the client.
+        The keys are fully qualified method names, e.g. `S3.Client.create_multipart_upload`.
+        The values are kwargs to pass to that method each time it is called.
     """
     logger.debug('%r', locals())
     if mode not in constants.BINARY_MODES:

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -141,7 +141,7 @@ class SeekableRawReaderTest(unittest.TestCase):
         self._local_resource = boto3.resource('s3', endpoint_url='http://localhost:5000')
         self._local_resource.Bucket(BUCKET_NAME).create()
         self._local_resource.Object(BUCKET_NAME, KEY_NAME).put(Body=self._body)
-        self._local_client('s3', endpoint_url='http://localhost:5000')
+        self._local_client = boto3.client('s3', endpoint_url='http://localhost:5000')
 
     def tearDown(self):
         self._local_resource.Object(BUCKET_NAME, KEY_NAME).delete()

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -958,8 +958,8 @@ def test_client_propagation_singlepart():
         client=client,
         multipart_upload=False,
     ) as writer:
-        assert writer._client == client
-        assert id(writer._client) == id(client)
+        assert writer._client.client == client
+        assert id(writer._client.client) == id(client)
 
 
 @moto.mock_s3()
@@ -979,8 +979,8 @@ def test_client_propagation_multipart():
         client=client,
         multipart_upload=True,
     ) as writer:
-        assert writer._client == client
-        assert id(writer._client) == id(client)
+        assert writer._client.client == client
+        assert id(writer._client.client) == id(client)
 
 
 @moto.mock_s3()
@@ -997,8 +997,8 @@ def test_resource_propagation_reader():
         writer.write(b'hello world')
 
     with smart_open.s3.open(BUCKET_NAME, WRITE_KEY_NAME, mode='rb', client=client) as reader:
-        assert reader._client == client
-        assert id(reader._client) == id(client)
+        assert reader._client.client == client
+        assert id(reader._client.client) == id(client)
 
 
 if __name__ == '__main__':

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -136,20 +136,19 @@ class BaseTest(unittest.TestCase):
     'The test case needs a Moto server running on the local 5000 port.'
 )
 class SeekableRawReaderTest(unittest.TestCase):
-
     def setUp(self):
         self._body = b'123456'
         self._local_resource = boto3.resource('s3', endpoint_url='http://localhost:5000')
         self._local_resource.Bucket(BUCKET_NAME).create()
         self._local_resource.Object(BUCKET_NAME, KEY_NAME).put(Body=self._body)
+        self._local_client('s3', endpoint_url='http://localhost:5000')
 
     def tearDown(self):
         self._local_resource.Object(BUCKET_NAME, KEY_NAME).delete()
         self._local_resource.Bucket(BUCKET_NAME).delete()
 
     def test_read_from_a_closed_body(self):
-        obj = self._local_resource.Object(BUCKET_NAME, KEY_NAME)
-        reader = smart_open.s3._SeekableRawReader(obj)
+        reader = smart_open.s3._SeekableRawReader(self._local_client, BUCKET_NAME, KEY_NAME)
         self.assertEqual(reader.read(1), b'1')
         reader._body.close()
         self.assertEqual(reader.read(2), b'23')

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1162,11 +1162,14 @@ class SmartOpenS3KwargsTest(unittest.TestCase):
         smart_open.open('s3://mybucket/mykey', transport_params=dict(defer_seek=True))
         mock_session.return_value.resource.assert_called_with('s3')
 
-    @mock.patch('boto3.Session')
-    def test_credentials(self, mock_session):
+    @mock.patch('boto3.client')
+    def test_credentials(self, mock_client):
         smart_open.open('s3://access_id:access_secret@mybucket/mykey', transport_params=dict(defer_seek=True))
-        mock_session.assert_called_with(aws_access_key_id='access_id', aws_secret_access_key='access_secret')
-        mock_session.return_value.resource.assert_called_with('s3')
+        mock_client.assert_called_with(
+            's3',
+            aws_access_key_id='access_id',
+            aws_secret_access_key='access_secret',
+        )
 
     @mock.patch('boto3.Session')
     def test_host(self, mock_session):
@@ -1181,47 +1184,23 @@ class SmartOpenS3KwargsTest(unittest.TestCase):
             endpoint_url='http://aa.domain.com',
         )
 
-    @mock.patch('boto3.Session')
-    def test_s3_upload(self, mock_session):
-        smart_open.open(
-            "s3://bucket/key", 'wb', transport_params={
-                'multipart_upload_kwargs': {
+    @mock.patch('boto3.client')
+    def test_s3_upload(self, mock_client):
+        tp = {
+            'client_kwargs': {
+                'S3.Client.create_multipart_upload': {
                     'ServerSideEncryption': 'AES256',
                     'ContentType': 'application/json',
                 }
             }
-        )
-
-        # Locate the s3.Object instance (mock)
-        s3_resource = mock_session.return_value.resource.return_value
-        s3_object = s3_resource.Object.return_value
-
-        # Check that `initiate_multipart_upload` was called
-        # with the desired args
-        s3_object.initiate_multipart_upload.assert_called_with(
+        }
+        smart_open.open("s3://bucket/key", 'wb', transport_params=tp)
+        mock_client.return_value.create_multipart_upload.assert_called_with(
+            Bucket='bucket',
+            Key='key',
             ServerSideEncryption='AES256',
-            ContentType='application/json'
+            ContentType='application/json',
         )
-
-    def test_session_read_mode(self):
-        """
-        Read stream should use a custom boto3.Session
-        """
-        session = boto3.Session()
-        session.resource = mock.MagicMock()
-
-        smart_open.open('s3://bucket/key', transport_params={'session': session, 'defer_seek': True})
-        session.resource.assert_called_with('s3')
-
-    def test_session_write_mode(self):
-        """
-        Write stream should use a custom boto3.Session
-        """
-        session = boto3.Session()
-        session.resource = mock.MagicMock()
-
-        smart_open.open('s3://bucket/key', 'wb', transport_params={'session': session})
-        session.resource.assert_called_with('s3')
 
 
 class SmartOpenTest(unittest.TestCase):
@@ -1789,15 +1768,19 @@ class S3OpenTest(unittest.TestCase):
     @mock.patch('smart_open.s3.Reader')
     def test_transport_params_is_not_mutable(self, mock_open):
         smart_open.open('s3://access_key:secret_key@host@bucket/key')
-        smart_open.open('s3://bucket/key')
+        actual = mock_open.call_args_list[0][1]['client_kwargs']
+        expected = {
+            'S3.Client': {
+                'aws_access_key_id': 'access_key',
+                'aws_secret_access_key': 'secret_key',
+                'endpoint_url': 'https://host:443',
+            }
+        }
+        assert actual == expected
 
-        #
-        # The first call should have a non-null session, because the session
-        # keys were explicitly specified in the URL.  The second call should
-        # _not_ have a session.
-        #
-        self.assertIsNone(mock_open.call_args_list[1][1]['session'])
-        self.assertIsNotNone(mock_open.call_args_list[0][1]['session'])
+        smart_open.open('s3://bucket/key')
+        actual = mock_open.call_args_list[1][1].get('client_kwargs')
+        assert actual is None
 
     @mock.patch('smart_open.s3.Reader')
     def test_respects_endpoint_url_read(self, mock_open):
@@ -1805,7 +1788,7 @@ class S3OpenTest(unittest.TestCase):
         smart_open.open(url)
 
         expected = {'endpoint_url': 'https://play.min.io:9000'}
-        self.assertEqual(mock_open.call_args[1]['resource_kwargs'], expected)
+        self.assertEqual(mock_open.call_args[1]['client_kwargs']['S3.Client'], expected)
 
     @mock.patch('smart_open.s3.MultipartWriter')
     def test_respects_endpoint_url_write(self, mock_open):
@@ -1813,7 +1796,7 @@ class S3OpenTest(unittest.TestCase):
         smart_open.open(url, 'wb')
 
         expected = {'endpoint_url': 'https://play.min.io:9000'}
-        self.assertEqual(mock_open.call_args[1]['resource_kwargs'], expected)
+        self.assertEqual(mock_open.call_args[1]['client_kwargs']['S3.Client'], expected)
 
 
 def function(a, b, c, foo='bar', baz='boz'):


### PR DESCRIPTION
While functionally they are the same, the session/resource stuff is not safe to use across multiple threads and subprocesses, and the client stuff is. The former _is_ a bit easier to use directly than the latter, but this does not impact the user, because smart_open is doing all the work.

I also refactored the way we pass keyword parameters to boto3. Previously, we had a separate parameter for each boto3 function. This was a pain, because this made parameter lists longer for each new function, e.g.

- resource_kwargs
- multipart_upload_kwargs
- singlepart_upload_kwargs
- object_kwargs

This PR moves all of the above parameters into a single nested dict and introduces a wrapper that transparently injects the parameters into the required function call.

This does break backwards compatibility, so will need a major version bump when releasing.