### PR TITLE
Remove `tests` directory from package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     description='Utils for streaming large files (S3, HDFS, GCS, Azure Blob Storage, gzip, bz2...)',
     long_description=read('README.rst'),
 
-    packages=find_packages(),
+    packages=find_packages(exclude=["smart_open.tests*"]),
     package_data={
         "smart_open.tests": ["test_data/*"],
     },


### PR DESCRIPTION
Fix #588

This PR removes `tests` directory from package, and so reduces the size of the package by 60%.
(Keeping a small package size is important when using a package on AWS Lambda).

No new test is added, I checked the following points:
- Current tests are still passing
- `tests` directory is not any more present after a `$ pip install`

Before you create the PR, please make sure you have:

- [X] Picked a concise, informative and complete title
- [X] Clearly explained the motivation behind the PR
- [X] Linked to any existing issues that your PR will be solving
- [X] Included tests for any new functionality
- [X] Checked that all unit tests pass