### PR TITLE
Fix error when using GCP urls without deps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,7 +115,7 @@ By default, ``smart_open`` does not install any dependencies, in order to keep t
 You can install these dependencies explicitly using::
 
     pip install smart_open[azure] # Install Azure deps
-    pip install smart_open[gcp] # Install GCP deps
+    pip install smart_open[gcs] # Install GCS deps
     pip install smart_open[s3] # Install S3 deps
 
 Or, if you don't mind installing a large number of third party libraries, you can install all dependencies using::

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     extras_require={
         'test': tests_require,
         's3': aws_deps,
-        'gcp': gcp_deps,
+        'gcs': gcp_deps,
         'azure': azure_deps,
         'all': all_deps,
         'http': http_deps,

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,11 @@ def read(fname):
     return io.open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8').read()
 
 aws_deps = ['boto3']
-gcp_deps = ['google-cloud-storage']
+gcs_deps = ['google-cloud-storage']
 azure_deps = ['azure-storage-blob', 'azure-common', 'azure-core']
 http_deps = ['requests']
 
-all_deps = aws_deps + gcp_deps + azure_deps + http_deps
+all_deps = aws_deps + gcs_deps + azure_deps + http_deps
 tests_require = all_deps + [
     'mock',
     'moto[server]==1.3.14',  # Older versions of moto appear broken

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     extras_require={
         'test': tests_require,
         's3': aws_deps,
-        'gcs': gcp_deps,
+        'gcs': gcs_deps,
         'azure': azure_deps,
         'all': all_deps,
         'http': http_deps,


### PR DESCRIPTION
Currently if you run code like this:

    from smart_open import open
    open("gs://asdf")

This is a fake URL but it works for this problem as is. Without the
Google Cloud deps, you get an error that says to do this:

    pip install smart_open[gcs]

But that doesn't work. You have to do this:

    pip install smart_open[gcp]

It seemed easier to change setup.py to match the error message so that's what I've done here.

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [ ] Checked that all unit tests pass
