### PR TITLE
Add timeout support for http/https requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ See [the migration docs](MIGRATING_FROM_OLDER_VERSIONS.rst) for details.
 
 - Remove `tests` directory from package (PR [#589](https://github.com/RaRe-Technologies/smart_open/pull/589), [@e-nalepa](https://github.com/e-nalepa))
 - Refactor S3, replace high-level resource/session API with low-level client API (PR [#583](https://github.com/RaRe-Technologies/smart_open/pull/583), [@mpenkov](https://github.com/mpenkov))
+- Add timeout parameter for http/https (PR [#594](https://github.com/RaRe-Technologies/smart_open/pull/594), [@dustymugs](https://github.com/dustymugs))
 
 # 4.2.0, 15 Feb 2021
 

--- a/smart_open/tests/test_http.py
+++ b/smart_open/tests/test_http.py
@@ -8,6 +8,7 @@
 import os
 import unittest
 
+import pytest
 import responses
 
 import smart_open.http
@@ -150,3 +151,11 @@ class HttpTest(unittest.TestCase):
             fin.seek(-10, whence=smart_open.constants.WHENCE_CURRENT)
             read_bytes_2 = fin.read(size=10)
             self.assertEqual(read_bytes_1, read_bytes_2)
+
+    @responses.activate
+    def test_timeout_attribute(self):
+        timeout = 1
+        responses.add_callback(responses.GET, URL, callback=request_callback)
+        reader = smart_open.open(URL, "rb", transport_params={'timeout': timeout})
+        assert hasattr(reader, 'timeout')
+        assert reader.timeout == timeout

--- a/smart_open/tests/test_http.py
+++ b/smart_open/tests/test_http.py
@@ -8,7 +8,6 @@
 import os
 import unittest
 
-import pytest
 import responses
 
 import smart_open.http


### PR DESCRIPTION
#### Title

Add timeout support for http/https requests

#### Motivation

Requests supports timeouts and their own docs recommend setting a timeout for production use. 

[Timeouts](https://requests.readthedocs.io/en/master/user/quickstart/#timeouts)

This is especially true in cloud envs (e.g. AWS Lambda) where you are charged by the millisecond and can only be so patient for an HTTP endpoint to respond.

#### Work in progress

If you're still working on your PR, include "WIP" in the title.
We'll skip reviewing it for the time being.
Once you're ready to review, remove the "WIP" from the title, and ping one of the maintainers (e.g. mpenkov).

#### Checklist

Before you create the PR, please make sure you have:

- [X] Picked a concise, informative and complete title
- [X] Clearly explained the motivation behind the PR
- [X] Linked to any existing issues that your PR will be solving
- [X] Included tests for any new functionality
- [X] Checked that all unit tests pass