### PR TITLE
Fix potential infinite loop when reading from webhdfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ See [the migration docs](MIGRATING_FROM_OLDER_VERSIONS.rst) for details.
 - Remove `tests` directory from package (PR [#589](https://github.com/RaRe-Technologies/smart_open/pull/589), [@e-nalepa](https://github.com/e-nalepa))
 - Refactor S3, replace high-level resource/session API with low-level client API (PR [#583](https://github.com/RaRe-Technologies/smart_open/pull/583), [@mpenkov](https://github.com/mpenkov))
 - Add timeout parameter for http/https (PR [#594](https://github.com/RaRe-Technologies/smart_open/pull/594), [@dustymugs](https://github.com/dustymugs))
+- Fix potential infinite loop when reading from webhdfs (PR [#597](https://github.com/RaRe-Technologies/smart_open/pull/597), [@traboukos](https://github.com/traboukos))
 
 # 4.2.0, 15 Feb 2021
 

--- a/smart_open/webhdfs.py
+++ b/smart_open/webhdfs.py
@@ -143,11 +143,21 @@ class BufferedInputBase(io.BufferedIOBase):
             return retval
 
         try:
-            while len(self._buf) < size:
-                self._buf += self._response.raw.read(io.DEFAULT_BUFFER_SIZE)
+            buffers = [self._buf]
+            total_read = 0
+            while total_read < size:
+                raw_data = self._response.raw.read(io.DEFAULT_BUFFER_SIZE)
+                # some times read returns 0 length data without throwing a 
+                # StopIteration exception. We break here if this happens.
+                if len(raw_data) == 0:
+                    break
+
+                total_read += len(raw_data)
+                buffers.append(raw_data)
         except StopIteration:
             pass
 
+        self._buf = b"".join(buffers)
         self._buf, retval = self._buf[size:], self._buf[:size]
         return retval
 

--- a/smart_open/webhdfs.py
+++ b/smart_open/webhdfs.py
@@ -147,7 +147,7 @@ class BufferedInputBase(io.BufferedIOBase):
             total_read = 0
             while total_read < size:
                 raw_data = self._response.raw.read(io.DEFAULT_BUFFER_SIZE)
-                # some times read returns 0 length data without throwing a 
+                # some times read returns 0 length data without throwing a
                 # StopIteration exception. We break here if this happens.
                 if len(raw_data) == 0:
                     break


### PR DESCRIPTION
when data read would return 0 length. The loop was expecting a StopIteration
exception which was never thrown. The 0 bytes returned case is explicitly
handled.

- Fixes #592
