### PR TITLE
Add a feature to override file extension defining compression

### DIFF
--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -107,6 +107,7 @@ def open(
         closefd=True,
         opener=None,
         ignore_ext=False,
+        override_ext=None,
         transport_params=None,
         ):
     r"""Open the URI object, returning a file-like object.
@@ -139,6 +140,8 @@ def open(
         Mimicks built-in open parameter of the same name.  Ignored.
     ignore_ext: boolean, optional
         Disable transparent compression/decompression based on the file extension.
+    override_ext: str, optional
+        Force transparent compression/decompression on files based on supplied extension.
     transport_params: dict, optional
         Additional parameters for the transport layer (see notes below).
 
@@ -221,6 +224,8 @@ def open(
     binary = _open_binary_stream(uri, binary_mode, transport_params)
     if ignore_ext:
         decompressed = binary
+    elif override_ext:
+        decompressed = compression.compression_wrapper(binary, binary_mode, filename=binary.name + override_ext)
     else:
         decompressed = compression.compression_wrapper(binary, binary_mode)
 

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1679,6 +1679,30 @@ class S3OpenTest(unittest.TestCase):
             self.assertEqual(fin.read().decode("utf-8"), text)
 
     @mock_s3
+    def test_rw_gzip_override(self):
+        """Should read/write gzip files on extension override, implicitly and explicitly."""
+        s3 = boto3.resource('s3')
+        s3.create_bucket(Bucket='bucket')
+        key = "s3://bucket/key"
+
+        text = u"не слышны в саду даже шорохи"
+        with smart_open.open(key, "wb", override_ext=".gz") as fout:
+            fout.write(text.encode("utf-8"))
+
+        #
+        # Check that what we've created is a gzip.
+        #
+        with smart_open.open(key, "rb", ignore_ext=True) as fin:
+            gz = gzip.GzipFile(fileobj=fin)
+            self.assertEqual(gz.read().decode("utf-8"), text)
+
+        #
+        # We should be able to read it back as well.
+        #
+        with smart_open.open(key, "rb", override_ext=".gz") as fin:
+            self.assertEqual(fin.read().decode("utf-8"), text)
+
+    @mock_s3
     @mock.patch('smart_open.smart_open_lib._inspect_kwargs', mock.Mock(return_value={}))
     def test_gzip_write_mode(self):
         """Should always open in binary mode when writing through a codec."""


### PR DESCRIPTION
#### Title

Add a feature to override file extension defining compression.

#### Motivation

```
- Implements #607
```

#### Tests

Added `test_smart_open.S3OpenTest.test_rw_gzip_override` and verified it fails as follows without the feature:

```
FAILED smart_open/tests/test_smart_open.py::S3OpenTest::test_rw_gzip_override  - OSError: Not a gzipped file...
```

Full test suite run output:

```
...
=============================================== short test summary info ===============================================
SKIPPED [1] smart_open/tests/test_package.py:18: requires missing dependencies
SKIPPED [1] smart_open/tests/test_package.py:13: requires missing dependencies
SKIPPED [1] smart_open/tests/test_package.py:24: requires missing dependencies
============================ 369 passed, 3 skipped, 7 warnings in 41.56s ==============================================
```

#### Checklist

Before you create the PR, please make sure you have:

- [X] Picked a concise, informative and complete title
- [X] Clearly explained the motivation behind the PR
- [X] Linked to any existing issues that your PR will be solving
- [X] Included tests for any new functionality
- [X] Checked that all unit tests pass

