### PR TITLE
Add new top-level compression parameter

### DIFF
--- a/smart_open/compression.py
+++ b/smart_open/compression.py
@@ -25,6 +25,10 @@ See get_supported_extensions().
 
 
 def get_supported_compression_types():
+    """Return the list of supported compression types available to open.
+    
+    See compression paratemeter to smart_open.open().
+    """
     return [NO_COMPRESSION, INFER_FROM_EXTENSION] + [ext[1:] for ext in get_supported_extensions()]
 
 

--- a/smart_open/compression.py
+++ b/smart_open/compression.py
@@ -15,6 +15,14 @@ logger = logging.getLogger(__name__)
 _COMPRESSOR_REGISTRY = {}
 
 
+NO_COMPRESSION = 'none'
+INFER_FROM_EXTENSION = 'extension'
+
+
+def get_supported_compression_types():
+    return [NO_COMPRESSION, INFER_FROM_EXTENSION] + [ext[1:] for ext in get_supported_extensions()]
+
+
 def get_supported_extensions():
     """Return the list of file extensions for which we have registered compressors."""
     return sorted(_COMPRESSOR_REGISTRY.keys())

--- a/smart_open/compression.py
+++ b/smart_open/compression.py
@@ -16,6 +16,7 @@ _COMPRESSOR_REGISTRY = {}
 
 
 NO_COMPRESSION = 'none'
+"""Use no compression. Read/write the data as-is."""
 INFER_FROM_EXTENSION = 'extension'
 
 

--- a/smart_open/compression.py
+++ b/smart_open/compression.py
@@ -18,6 +18,10 @@ _COMPRESSOR_REGISTRY = {}
 NO_COMPRESSION = 'none'
 """Use no compression. Read/write the data as-is."""
 INFER_FROM_EXTENSION = 'extension'
+"""Determine the compression to use from the file extension.
+
+See get_supported_extensions().
+"""
 
 
 def get_supported_compression_types():

--- a/smart_open/compression.py
+++ b/smart_open/compression.py
@@ -26,7 +26,7 @@ See get_supported_extensions().
 
 def get_supported_compression_types():
     """Return the list of supported compression types available to open.
-    
+
     See compression paratemeter to smart_open.open().
     """
     return [NO_COMPRESSION, INFER_FROM_EXTENSION] + [ext[1:] for ext in get_supported_extensions()]

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -174,16 +174,13 @@ def open(
 
     if compression and ignore_ext:
         raise ValueError('ignore_ext and compression parameters are mutually exclusive')
-
-    if not compression:
-        if ignore_ext:
-            compression = so_compression.NO_COMPRESSION
-            warnings.warn("'ignore_ext' will be deprecated in a future release", PendingDeprecationWarning)
-        else:
-            compression = so_compression.INFER_FROM_EXTENSION
-
-    if compression not in so_compression.get_supported_compression_types():
+    elif compression and compression not in so_compression.get_supported_compression_types():
         raise ValueError(f'invalid compression type: {compression}')
+    elif ignore_ext:
+        compression = so_compression.NO_COMPRESSION
+        warnings.warn("'ignore_ext' will be deprecated in a future release", PendingDeprecationWarning)
+    elif compression is None:
+        compression = so_compression.INFER_FROM_EXTENSION
 
     if transport_params is None:
         transport_params = {}

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -172,7 +172,7 @@ def open(
         raise TypeError('mode should be a string')
 
     if compression and ignore_ext:
-        raise ValueError('can not simultaneously define and disable compression')
+        raise ValueError('ignore_ext and compression parameters are mutually exclusive')
 
     if not compression:
         if ignore_ext:

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -141,7 +141,8 @@ def open(
     ignore_ext: boolean, optional
         Disable transparent compression/decompression based on the file extension.
     compression: str, optional (SEE smart_open.compression.get_supported_compression_types)
-        Override transparent compression/decompression based on the file extension.
+        Explicitly specify the compression/decompression behavior.
+        If you specify this parameter, then ignore_ext must not be specified.
     transport_params: dict, optional
         Additional parameters for the transport layer (see notes below).
 

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -30,8 +30,8 @@ import warnings
 # smart_open.submodule to reference to the submodules.
 #
 import smart_open.local_file as so_file
+import smart_open.compression as so_compression
 
-from smart_open import compression
 from smart_open import doctools
 from smart_open import transport
 
@@ -107,6 +107,7 @@ def open(
         closefd=True,
         opener=None,
         ignore_ext=False,
+        compression=None,
         transport_params=None,
         ):
     r"""Open the URI object, returning a file-like object.
@@ -139,6 +140,8 @@ def open(
         Mimicks built-in open parameter of the same name.  Ignored.
     ignore_ext: boolean, optional
         Disable transparent compression/decompression based on the file extension.
+    compression: str, optional (SEE smart_open.compression.get_supported_compression_types)
+        Override transparent compression/decompression based on the file extension.
     transport_params: dict, optional
         Additional parameters for the transport layer (see notes below).
 
@@ -168,13 +171,22 @@ def open(
     if not isinstance(mode, str):
         raise TypeError('mode should be a string')
 
+    if compression and ignore_ext:
+        raise ValueError('can not simultaneously define and disable compression')
+
+    if not compression:
+        compression = so_compression.NO_COMPRESSION if ignore_ext else so_compression.INFER_FROM_EXTENSION
+
+    if compression not in so_compression.get_supported_compression_types():
+        raise ValueError(f'invalid compression type: {compression}')
+
     if transport_params is None:
         transport_params = {}
 
     fobj = _shortcut_open(
         uri,
         mode,
-        ignore_ext=ignore_ext,
+        compression=compression,
         buffering=buffering,
         encoding=encoding,
         errors=errors,
@@ -219,10 +231,13 @@ def open(
         raise NotImplementedError(ve.args[0])
 
     binary = _open_binary_stream(uri, binary_mode, transport_params)
-    if ignore_ext:
+    if compression == so_compression.NO_COMPRESSION:
         decompressed = binary
+    elif compression == so_compression.INFER_FROM_EXTENSION:
+        decompressed = so_compression.compression_wrapper(binary, binary_mode)
     else:
-        decompressed = compression.compression_wrapper(binary, binary_mode)
+        faked_extension = f"{binary.name}.{compression.lower()}"
+        decompressed = so_compression.compression_wrapper(binary, binary_mode, filename=faked_extension)
 
     if 'b' not in mode or explicit_encoding is not None:
         decoded = _encoding_wrapper(
@@ -295,7 +310,7 @@ def _get_binary_mode(mode_str):
 def _shortcut_open(
         uri,
         mode,
-        ignore_ext=False,
+        compression,
         buffering=-1,
         encoding=None,
         errors=None,
@@ -309,12 +324,13 @@ def _shortcut_open(
     This is only possible under the following conditions:
 
         1. Opening a local file; and
-        2. Ignore extension is set to True
+        2. Compression is disabled
 
     If it is not possible to use the built-in open for the specified URI, returns None.
 
     :param str uri: A string indicating what to open.
     :param str mode: The mode to pass to the open function.
+    :param str compression: The compression type selected.
     :returns: The opened file
     :rtype: file
     """
@@ -326,8 +342,11 @@ def _shortcut_open(
         return None
 
     local_path = so_file.extract_local_path(uri)
-    _, extension = P.splitext(local_path)
-    if extension in compression.get_supported_extensions() and not ignore_ext:
+    if compression == so_compression.INFER_FROM_EXTENSION:
+        _, extension = P.splitext(local_path)
+        if extension in so_compression.get_supported_extensions():
+            return None
+    elif compression != so_compression.NO_COMPRESSION:
         return None
 
     open_kwargs = {}

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -140,7 +140,7 @@ def open(
         Mimicks built-in open parameter of the same name.  Ignored.
     ignore_ext: boolean, optional
         Disable transparent compression/decompression based on the file extension.
-    compression: str, optional (SEE smart_open.compression.get_supported_compression_types)
+    compression: str, optional (see smart_open.compression.get_supported_compression_types)
         Explicitly specify the compression/decompression behavior.
         If you specify this parameter, then ignore_ext must not be specified.
     transport_params: dict, optional

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -175,7 +175,11 @@ def open(
         raise ValueError('can not simultaneously define and disable compression')
 
     if not compression:
-        compression = so_compression.NO_COMPRESSION if ignore_ext else so_compression.INFER_FROM_EXTENSION
+        if ignore_ext:
+            compression = so_compression.NO_COMPRESSION
+            warnings.warn("'ignore_ext' will be deprecated in a future release", PendingDeprecationWarning)
+        else:
+            compression = so_compression.INFER_FROM_EXTENSION
 
     if compression not in so_compression.get_supported_compression_types():
         raise ValueError(f'invalid compression type: {compression}')

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1679,7 +1679,6 @@ class S3OpenTest(unittest.TestCase):
         with smart_open.open(key, "rb") as fin:
             self.assertEqual(fin.read().decode("utf-8"), text)
 
-
     @mock_s3
     @mock.patch('smart_open.smart_open_lib._inspect_kwargs', mock.Mock(return_value={}))
     def test_gzip_write_mode(self):
@@ -1848,20 +1847,20 @@ class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
     # 'gz'        | False      | Override |
     # 'bz2'       | False      | Override |
     @parameterizedtestcase.ParameterizedTestCase.parameterize(
-        ('_compression', 'decompressor'),
+        ("_compression", "decompressor"),
         [
-            ('gz', lambda fileobj: gzip.GzipFile(fileobj=fileobj)),
-            ('bz2', lambda fileobj: bz2.BZ2File(fileobj))
-        ]
+            ("gz", lambda fileobj: gzip.GzipFile(fileobj=fileobj)),
+            ("bz2", lambda fileobj: bz2.BZ2File(fileobj)),
+        ],
     )
     @mock_s3
     def test_rw_compression_prescribed(self, _compression, decompressor):
         """Should read/write files with `_compression`, as prescribed."""
-        s3 = boto3.resource('s3')
-        s3.create_bucket(Bucket='bucket')
+        s3 = boto3.resource("s3")
+        s3.create_bucket(Bucket="bucket")
         key = "s3://bucket/key.txt"
 
-        text = u"не слышны в саду даже шорохи"
+        text = "не слышны в саду даже шорохи"
         with smart_open.open(key, "wb", compression=_compression) as fout:
             fout.write(text.encode("utf-8"))
 
@@ -1885,22 +1884,45 @@ class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
     # None        | False      | Enable   |
     # None        | True       | Disable  |
     @parameterizedtestcase.ParameterizedTestCase.parameterize(
-        ('_compression', 'decompressor', 'compression_kwargs', 'no_compression_kwargs'),
+        ("_compression", "decompressor", "compression_kwargs", "no_compression_kwargs"),
         [
-            ('gz', lambda fileobj: gzip.GzipFile(fileobj=fileobj), dict(compression=INFER_FROM_EXTENSION), dict(compression=NO_COMPRESSION)),
-            ('bz2', lambda fileobj: bz2.BZ2File(fileobj), dict(compression=INFER_FROM_EXTENSION), dict(compression=NO_COMPRESSION)),
-            ('gz', lambda fileobj: gzip.GzipFile(fileobj=fileobj), dict(), dict(ignore_ext=True)),
-            ('bz2', lambda fileobj: bz2.BZ2File(fileobj), dict(), dict(ignore_ext=True))
-        ]
+            (
+                "gz",
+                lambda fileobj: gzip.GzipFile(fileobj=fileobj),
+                dict(compression=INFER_FROM_EXTENSION),
+                dict(compression=NO_COMPRESSION),
+            ),
+            (
+                "bz2",
+                lambda fileobj: bz2.BZ2File(fileobj),
+                dict(compression=INFER_FROM_EXTENSION),
+                dict(compression=NO_COMPRESSION),
+            ),
+            (
+                "gz",
+                lambda fileobj: gzip.GzipFile(fileobj=fileobj),
+                dict(),
+                dict(ignore_ext=True),
+            ),
+            (
+                "bz2",
+                lambda fileobj: bz2.BZ2File(fileobj),
+                dict(),
+                dict(ignore_ext=True),
+            ),
+        ],
     )
     @mock_s3
-    def test_rw_compression_by_extension(self, _compression, decompressor, compression_kwargs, no_compression_kwargs):
-        """Should read/write files with `_compression`, explicitily or implicitly inferred by file extension."""
-        s3 = boto3.resource('s3')
-        s3.create_bucket(Bucket='bucket')
+    def test_rw_compression_by_extension(
+        self, _compression, decompressor, compression_kwargs, no_compression_kwargs
+    ):
+        """Should read/write files with `_compression`, explicitily or implicitly
+        inferred by file extension."""
+        s3 = boto3.resource("s3")
+        s3.create_bucket(Bucket="bucket")
         key = f"s3://bucket/key.{_compression}"
 
-        text = u"не слышны в саду даже шорохи"
+        text = "не слышны в саду даже шорохи"
         with smart_open.open(key, "wb", **compression_kwargs) as fout:
             fout.write(text.encode("utf-8"))
 
@@ -1926,22 +1948,30 @@ class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
     # <any>     | 'gz'        | True       | Error    |
     # <any>     | 'bz2'       | True       | Error    |
     @parameterizedtestcase.ParameterizedTestCase.parameterize(
-        ('extension', 'kwargs', 'error'),
+        ("extension", "kwargs", "error"),
         [
-            ('', dict(compression="foo"), ValueError),
-            ('', dict(compression="foo", ignore_ext=True), ValueError),
-            ('', dict(compression=NO_COMPRESSION, ignore_ext=True), ValueError),
-            ('.gz', dict(compression=INFER_FROM_EXTENSION, ignore_ext=True), ValueError),
-            ('.bz2', dict(compression=INFER_FROM_EXTENSION, ignore_ext=True), ValueError),
-            ('', dict(compression='gz', ignore_ext=True), ValueError),
-            ('', dict(compression='bz2', ignore_ext=True), ValueError),
-        ]
+            ("", dict(compression="foo"), ValueError),
+            ("", dict(compression="foo", ignore_ext=True), ValueError),
+            ("", dict(compression=NO_COMPRESSION, ignore_ext=True), ValueError),
+            (
+                ".gz",
+                dict(compression=INFER_FROM_EXTENSION, ignore_ext=True),
+                ValueError,
+            ),
+            (
+                ".bz2",
+                dict(compression=INFER_FROM_EXTENSION, ignore_ext=True),
+                ValueError,
+            ),
+            ("", dict(compression="gz", ignore_ext=True), ValueError),
+            ("", dict(compression="bz2", ignore_ext=True), ValueError),
+        ],
     )
     @mock_s3
     def test_compression_invalid(self, extension, kwargs, error):
         """Should detect and error on these invalid inputs"""
-        s3 = boto3.resource('s3')
-        s3.create_bucket(Bucket='bucket')
+        s3 = boto3.resource("s3")
+        s3.create_bucket(Bucket="bucket")
         key = f"s3://bucket/key{extension}"
 
         with pytest.raises(error):

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1842,6 +1842,8 @@ class CheckKwargsTest(unittest.TestCase):
 
 
 _RAW_DATA = "не слышны в саду даже шорохи".encode("utf-8")
+
+
 class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
     # compression | ignore_ext | behavior |
     # ----------- | ---------- | -------- |

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1857,7 +1857,7 @@ class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
     def test_rw_compression_prescribed(self, _compression, decompressor):
         """Should read/write files with `_compression`, as prescribed."""
         s3 = boto3.resource("s3")
-        s3.create_bucket(Bucket="bucket")
+        s3.create_bucket(Bucket="bucket").wait_until_exists()
         key = "s3://bucket/key.txt"
 
         text = "не слышны в саду даже шорохи"

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1860,22 +1860,22 @@ class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
         s3.create_bucket(Bucket="bucket").wait_until_exists()
         key = "s3://bucket/key.txt"
 
-        text = "не слышны в саду даже шорохи"
+        data = "не слышны в саду даже шорохи".encode("utf-8")
         with smart_open.open(key, "wb", compression=_compression) as fout:
-            fout.write(text.encode("utf-8"))
+            fout.write(data)
 
         #
         # Check that what we've created is of type `_compression`.
         #
         with smart_open.open(key, "rb", compression=NO_COMPRESSION) as fin:
             dfin = decompressor(fin)
-            self.assertEqual(dfin.read().decode("utf-8"), text)
+            self.assertEqual(dfin.read(), data)
 
         #
         # We should be able to read it back as well.
         #
         with smart_open.open(key, "rb", compression=_compression) as fin:
-            self.assertEqual(fin.read().decode("utf-8"), text)
+            self.assertEqual(fin.read(), data)
 
     # compression | ignore_ext | behavior |
     # ----------- | ---------- | -------- |
@@ -1922,22 +1922,22 @@ class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
         s3.create_bucket(Bucket="bucket")
         key = f"s3://bucket/key.{_compression}"
 
-        text = "не слышны в саду даже шорохи"
+        data = "не слышны в саду даже шорохи".encode("utf-8")
         with smart_open.open(key, "wb", **compression_kwargs) as fout:
-            fout.write(text.encode("utf-8"))
+            fout.write(data)
 
         #
         # Check that what we've created is of type `_compression`.
         #
         with smart_open.open(key, "rb", **no_compression_kwargs) as fin:
             dfin = decompressor(fin)
-            self.assertEqual(dfin.read().decode("utf-8"), text)
+            self.assertEqual(dfin.read(), data)
 
         #
         # We should be able to read it back as well.
         #
         with smart_open.open(key, "rb", **compression_kwargs) as fin:
-            self.assertEqual(fin.read().decode("utf-8"), text)
+            self.assertEqual(fin.read(), data)
 
     # extension | compression | ignore_ext | behavior |
     # ----------| ----------- | ---------- | -------- |

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1871,13 +1871,13 @@ class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
         #
         with smart_open.open(key, "rb", compression=NO_COMPRESSION) as fin:
             data = decompressor(fin.read())
-            self.assertEqual(data, _RAW_DATA)
+            assert data == _RAW_DATA
 
         #
         # We should be able to read it back as well.
         #
         with smart_open.open(key, "rb", compression=_compression) as fin:
-            self.assertEqual(fin.read(), _RAW_DATA)
+            assert fin.read() == _RAW_DATA
 
     # compression | ignore_ext | behavior |
     # ----------- | ---------- | -------- |
@@ -1916,14 +1916,13 @@ class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
         # Check that what we've created is compressed as expected.
         #
         with smart_open.open(key, "rb", **no_compression_kwargs) as fin:
-            data = decompressor(fin.read())
-            self.assertEqual(data, _RAW_DATA)
+            assert decompressor(fin.read()) == _RAW_DATA
 
         #
         # We should be able to read it back as well.
         #
         with smart_open.open(key, "rb", **compression_kwargs) as fin:
-            self.assertEqual(fin.read(), _RAW_DATA)
+            assert fin.read() == _RAW_DATA
 
     # compression | ignore_ext | behavior |
     # ----------- | ---------- | -------- |
@@ -1961,14 +1960,13 @@ class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
         # Check that what we've created is compressed as expected.
         #
         with smart_open.open(key, "rb", **kwargs) as fin:
-            data = decompressor(fin.read())
-            self.assertEqual(data, _RAW_DATA)
+            assert decompressor(fin.read()) == _RAW_DATA
 
         #
         # We should be able to read it back as well.
         #
         with smart_open.open(key, "rb") as fin:
-            self.assertEqual(fin.read(), _RAW_DATA)
+            assert fin.read() == _RAW_DATA
 
     # extension | compression | ignore_ext | behavior |
     # ----------| ----------- | ---------- | -------- |

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1844,7 +1844,13 @@ class CheckKwargsTest(unittest.TestCase):
 _RAW_DATA = "не слышны в саду даже шорохи".encode("utf-8")
 
 
+@mock_s3
 class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
+
+    def setUp(self):
+        s3 = boto3.resource("s3")
+        s3.create_bucket(Bucket="bucket").wait_until_exists()
+
     # compression | ignore_ext | behavior |
     # ----------- | ---------- | -------- |
     # 'gz'        | False      | Override |
@@ -1856,11 +1862,8 @@ class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
             ("bz2", bz2.decompress),
         ],
     )
-    @mock_s3
     def test_rw_compression_prescribed(self, _compression, decompressor):
         """Should read/write files with `_compression`, as prescribed."""
-        s3 = boto3.resource("s3")
-        s3.create_bucket(Bucket="bucket").wait_until_exists()
         key = "s3://bucket/key.txt"
 
         with smart_open.open(key, "wb", compression=_compression) as fout:
@@ -1896,13 +1899,10 @@ class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
             )
         ],
     )
-    @mock_s3
     def test_rw_compression_by_extension(
         self, _compression, decompressor
     ):
         """Should read/write files with `_compression`, explicitily inferred by file extension."""
-        s3 = boto3.resource("s3")
-        s3.create_bucket(Bucket="bucket")
         key = f"s3://bucket/key.{_compression}"
 
         with smart_open.open(key, "wb", compression=INFER_FROM_EXTENSION) as fout:
@@ -1938,13 +1938,10 @@ class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
             ),
         ],
     )
-    @mock_s3
     def test_rw_compression_by_extension_deprecated(
         self, _compression, decompressor
     ):
         """Should read/write files with `_compression`, implicitly inferred by file extension."""
-        s3 = boto3.resource("s3")
-        s3.create_bucket(Bucket="bucket")
         key = f"s3://bucket/key.{_compression}"
 
         with smart_open.open(key, "wb") as fout:
@@ -1991,11 +1988,8 @@ class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
             ("", dict(compression="bz2", ignore_ext=True), ValueError),
         ],
     )
-    @mock_s3
     def test_compression_invalid(self, extension, kwargs, error):
         """Should detect and error on these invalid inputs"""
-        s3 = boto3.resource("s3")
-        s3.create_bucket(Bucket="bucket")
         key = f"s3://bucket/key{extension}"
 
         with pytest.raises(error):

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1876,12 +1876,6 @@ class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
             data = decompressor(fin.read())
             assert data == _RAW_DATA
 
-        #
-        # We should be able to read it back as well.
-        #
-        with smart_open.open(key, "rb", compression=_compression) as fin:
-            assert fin.read() == _RAW_DATA
-
     # compression | ignore_ext | behavior |
     # ----------- | ---------- | -------- |
     # 'extension' | False      | Enable   |
@@ -1914,17 +1908,10 @@ class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
         with smart_open.open(key, "rb", compression=NO_COMPRESSION) as fin:
             assert decompressor(fin.read()) == _RAW_DATA
 
-        #
-        # We should be able to read it back as well.
-        #
-        with smart_open.open(key, "rb", compression=INFER_FROM_EXTENSION) as fin:
-            assert fin.read() == _RAW_DATA
-
     # compression | ignore_ext | behavior |
     # ----------- | ---------- | -------- |
     # None        | False      | Enable   |
     # None        | True       | Disable  |
-
     @parameterizedtestcase.ParameterizedTestCase.parameterize(
         ("_compression", "decompressor"),
         [
@@ -1953,12 +1940,6 @@ class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
         with smart_open.open(key, "rb", ignore_ext=True) as fin:
             assert decompressor(fin.read()) == _RAW_DATA
 
-        #
-        # We should be able to read it back as well.
-        #
-        with smart_open.open(key, "rb") as fin:
-            assert fin.read() == _RAW_DATA
-
     # extension | compression | ignore_ext | behavior |
     # ----------| ----------- | ---------- | -------- |
     # <any>     | <invalid>   | <any>      | Error    |
@@ -1967,7 +1948,6 @@ class HandleS3CompressionTestCase(parameterizedtestcase.ParameterizedTestCase):
     # 'bz2'     | 'extension' | True       | Error    |
     # <any>     | 'gz'        | True       | Error    |
     # <any>     | 'bz2'       | True       | Error    |
-
     @parameterizedtestcase.ParameterizedTestCase.parameterize(
         ("extension", "kwargs", "error"),
         [


### PR DESCRIPTION
#### Title

Feature to add compression parameter to override inference by file extension

#### Motivation

A [previous PR](https://github.com/RaRe-Technologies/smart_open/pull/608) was closed for being incompatible with the long-term API design for `smart_open.open`. Because the long-term goal, discussed in the [linked issue](https://github.com/RaRe-Technologies/smart_open/issues/607) is to add an enum-like `compression` parameter, and deprecate the `ignore_ext` parameter, which would be a breaking change, this is a backwards-compatible compromise that provides a clean upgrade path. Specifically, it preserves the existing `ignore_ext` parameter, instead adding a `PendingDeprecationWarning`, and makes its use mutually-exclusive with the new `compression` parameter, verified by comprehensive unit testing (the truth tables used to build the test suites are provided in comments for any discussion of refinement needed). On the next major version, the `ignore_ext` parameter can be removed and the default for `compression` changed to `INFER_FROM_EXTENSION`, since it won't be necessary to apply a MUTEX on the parameters, at that point (i.e.: lines 177-182 can just be removed).

Fixes #607.

#### Tests

Added `test_smart_open.HandleS3CompressionTestCase`. This is specific to S3 (where the mocking is the best), but could be easily extended to any other backend. However, it looked as though S3 is the go-to backend for verifying shared behavior.

#### Checklist

Before you create the PR, please make sure you have:

- [X] Picked a concise, informative and complete title
- [X] Clearly explained the motivation behind the PR
- [X] Linked to any existing issues that your PR will be solving
- [X] Included tests for any new functionality
- [x] Checked that all unit tests pass

