### PR TITLE
Fix outdated credentials example for s3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ For the sake of simplicity, the examples below assume you have all the dependenc
     ...     aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
     ... )
     >>> url = 's3://smart-open-py37-benchmark-results/test.txt'
-    >>> with open(url, 'wb', transport_params={'client': session.client('s3')}) as fout:
+    >>> with open(url, 'wb', transport_params={'session': session}) as fout:
     ...     bytes_written = fout.write(b'hello world!')
     ...     print(bytes_written)
     12


### PR DESCRIPTION
It seems the transport_params wants a boto3 session instead of a client now.

#### Fix s3 transport_params example

#### Motivation

The example for passing credentials to smart_open with s3 did not work. I looked at the implementation and corrected it.


#### Tests

No tests, just documentation.

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [ ] Linked to any existing issues that your PR will be solving
- [ ] Included tests for any new functionality
- [ ] Checked that all unit tests pass

#### Workflow

Please avoid rebasing and force-pushing to the branch of the PR once a review is in progress.
Rebasing can make your commits look a bit cleaner, but it also makes life more difficult from the reviewer, because they are no longer able to distinguish between code that has already been reviewed, and unreviewed code.
