### PR TITLE
Drop mock dependency; standardize on unittest.mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add warning for recently deprecated s3 parameters (PR [#618](https://github.com/RaRe-Technologies/smart_open/pull/618), [@mpenkov](https://github.com/mpenkov))
 - Add new top-level compression parameter (PR [#609](https://github.com/RaRe-Technologies/smart_open/pull/609), [@dmcguire81](https://github.com/dmcguire81))
+- Drop mock dependency; standardize on unittest.mock (PR [#621](https://github.com/RaRe-Technologies/smart_open/pull/621), [@musicinmybrain](https://github.com/musicinmybrain))
 
 # 5.0.0, 30 Mar 2021
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ http_deps = ['requests']
 
 all_deps = aws_deps + gcs_deps + azure_deps + http_deps
 tests_require = all_deps + [
-    'mock',
     'moto[server]==1.3.14',  # Older versions of moto appear broken
     'pathlib2',
     'responses',

--- a/smart_open/tests/test_gcs.py
+++ b/smart_open/tests/test_gcs.py
@@ -13,10 +13,7 @@ import os
 import time
 import uuid
 import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 import warnings
 from collections import OrderedDict
 

--- a/smart_open/tests/test_hdfs.py
+++ b/smart_open/tests/test_hdfs.py
@@ -10,9 +10,8 @@ import os
 import os.path as P
 import subprocess
 import unittest
+from unittest import mock
 import sys
-
-import mock
 
 import smart_open.hdfs
 

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -15,13 +15,12 @@ import time
 import unittest
 import warnings
 from contextlib import contextmanager
-from unittest.mock import patch
+from unittest import mock
 import sys
 
 import boto3
 import botocore.client
 import botocore.endpoint
-import mock
 import moto
 
 import smart_open
@@ -108,7 +107,7 @@ def patch_invalid_range_response(actual_size):
                 error_response['Message'] = 'The requested range is not satisfiable'
             raise
 
-    with patch('smart_open.s3._get', new=mock_get):
+    with mock.patch('smart_open.s3._get', new=mock_get):
         yield
 
 
@@ -123,7 +122,7 @@ class BaseTest(unittest.TestCase):
             api_calls[operation_model.name] += 1
             return _real_make_request(self, operation_model, *args, **kwargs)
 
-        patcher = patch('botocore.endpoint.Endpoint.make_request', new=mock_make_request)
+        patcher = mock.patch('botocore.endpoint.Endpoint.make_request', new=mock_make_request)
         patcher.start()
         try:
             yield api_calls

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -17,10 +17,10 @@ import os
 from smart_open.compression import INFER_FROM_EXTENSION, NO_COMPRESSION
 import tempfile
 import unittest
+from unittest import mock
 import warnings
 
 import boto3
-import mock
 from moto import mock_s3
 import parameterizedtestcase
 import pytest

--- a/smart_open/tests/test_ssh.py
+++ b/smart_open/tests/test_ssh.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import logging
-import mock
 import unittest
+from unittest import mock
 
 import smart_open.ssh
 


### PR DESCRIPTION
#### Title

Drop mock dependency; standardize on unittest.mock

#### Motivation

Since the package requires Python 3.6+, `unittest.mock` is available, and it was already used in some of the tests. Migrate any tests still using the PyPI backport package `mock` to `unittest.mock`, and drop the dependency.

This came up while looking at a [candidate package for Fedora Linux](https://bugzilla.redhat.com/show_bug.cgi?id=1961149), where the PyPI `mock` package is [deprecated](https://fedoraproject.org/wiki/Changes/DeprecatePythonMock).

#### Tests

No tests to add; existing tests pass.

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving **N/A**
- [x] Included tests for any new functionality **N/A**
- [x] Checked that all unit tests pass

#### Workflow

Please avoid rebasing and force-pushing to the branch of the PR once a review is in progress.
Rebasing can make your commits look a bit cleaner, but it also makes life more difficult from the reviewer, because they are no longer able to distinguish between code that has already been reviewed, and unreviewed code.
