### PR TITLE
Fix Python version specification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         'http': http_deps,
         'webhdfs': http_deps,
     },
-    python_requires=">=3.6.*",
+    python_requires=">=3.6.0",
 
     test_suite="smart_open.tests",
 

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         'http': http_deps,
         'webhdfs': http_deps,
     },
-    python_requires=">=3.6.0",
+    python_requires=">=3.6",
 
     test_suite="smart_open.tests",
 


### PR DESCRIPTION
Changes >=3.6.* to >=3.6.0 since >=3.6.* is not PEP 440 compliant.

Fixes #638.
