### PR TITLE
New blob_properties transport parameter for GCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You may continue to use `ignore_ext` parameter for now, but it will be deprecate
 - Drop mock dependency; standardize on unittest.mock (PR [#621](https://github.com/RaRe-Technologies/smart_open/pull/621), [@musicinmybrain](https://github.com/musicinmybrain))
 - Fix to_boto3 method (PR [#619](https://github.com/RaRe-Technologies/smart_open/pull/619), [@mpenkov](https://github.com/mpenkov))
 - Work around changes to `urllib.parse.urlsplit` (PR [#633](https://github.com/RaRe-Technologies/smart_open/pull/633), [@judahrand](https://github.com/judahrand)
+- New blob_properties transport parameter for GCS (PR [#632](https://github.com/RaRe-Technologies/smart_open/pull/632), [@FHTheron](https://github.com/FHTheron))
 
 # 5.0.0, 30 Mar 2021
 

--- a/smart_open/tests/test_gcs.py
+++ b/smart_open/tests/test_gcs.py
@@ -801,6 +801,18 @@ class WriterTest(unittest.TestCase):
 
         self.assertEqual(output, [])
 
+    def test_write_05(self):
+        """Do blob_properties get applied?"""
+        smart_open_write = smart_open.gcs.Writer(BUCKET_NAME, WRITE_BLOB_NAME,
+            blob_properties={
+                "content_type": "random/x-test",
+                "content_encoding": "coded"
+            }
+        )
+        with smart_open_write as fout:  # noqa
+            assert fout._blob.content_type == "random/x-test"
+            assert fout._blob.content_encoding == "coded"
+
     def test_gzip(self):
         expected = u'а не спеть ли мне песню... о любви'.encode('utf-8')
         with smart_open.gcs.Writer(BUCKET_NAME, WRITE_BLOB_NAME) as fout:


### PR DESCRIPTION
#### Title
Add GCS transport parameter `blob_properties` to allow custom properties to be specified for newly created blobs.

#### Motivation

This allows setting the GCS file (or blob) content_type and content_encoding (or any other GCS blob properties) regardless of the filename. Callers can use `mimetypes.guess_type` or manually specify specific values. 

Example:
```
smart_open.open("gs://somewhere/somefile.json.gz", transport_params={
  "blob_properties": {
    "content_type": "application/json",
    "content_encoding": "gzip"
  }
}
```

Possibly useful for https://github.com/RaRe-Technologies/smart_open/issues/429 

#### Checklist

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass
