### PR TITLE
Work around changes to `urllib.parse.urlsplit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You may continue to use `ignore_ext` parameter for now, but it will be deprecate
 - Add new top-level compression parameter (PR [#609](https://github.com/RaRe-Technologies/smart_open/pull/609), [@dmcguire81](https://github.com/dmcguire81))
 - Drop mock dependency; standardize on unittest.mock (PR [#621](https://github.com/RaRe-Technologies/smart_open/pull/621), [@musicinmybrain](https://github.com/musicinmybrain))
 - Fix to_boto3 method (PR [#619](https://github.com/RaRe-Technologies/smart_open/pull/619), [@mpenkov](https://github.com/mpenkov))
+- Work around changes to `urllib.parse.urlsplit` (PR [#633](https://github.com/RaRe-Technologies/smart_open/pull/633), [@judahrand](https://github.com/judahrand)
 
 # 5.0.0, 30 Mar 2021
 

--- a/smart_open/tests/test_utils.py
+++ b/smart_open/tests/test_utils.py
@@ -5,8 +5,10 @@
 # This code is distributed under the terms and conditions
 # from the MIT License (MIT).
 #
-
 import unittest
+import urllib.parse
+
+import pytest
 
 import smart_open.utils
 
@@ -28,3 +30,17 @@ def test_check_kwargs():
     kwargs = {'client': 'foo', 'unsupported': 'bar', 'client_kwargs': 'boaz'}
     supported = smart_open.utils.check_kwargs(kallable, kwargs)
     assert supported == {'client': 'foo', 'client_kwargs': 'boaz'}
+
+
+@pytest.mark.parametrize(
+    'url,expected',
+    [
+        ('s3://bucket/key', ('s3', 'bucket', '/key', '', '')),
+        ('s3://bucket/key?', ('s3', 'bucket', '/key?', '', '')),
+        ('s3://bucket/???', ('s3', 'bucket', '/???', '', '')),
+        ('https://host/path?foo=bar', ('https', 'host', '/path', 'foo=bar', '')),
+    ]
+)
+def test_safe_urlsplit(url, expected):
+    actual = smart_open.utils.safe_urlsplit(url)
+    assert actual == urllib.parse.SplitResult(*expected)

--- a/smart_open/utils.py
+++ b/smart_open/utils.py
@@ -150,16 +150,16 @@ def safe_urlsplit(url):
     querystring separately.  Unfortunately, question marks can also appear
     _inside_ the actual URL for some schemas like S3, GS.
 
-    Replaces question marks with newlines prior to splitting.  This is safe because:
-
-    1. The standard library's urlsplit completely ignores newlines
-    2. Raw newlines will never occur in innocuous URLs.  They are always URL-encoded.
+    Replaces question marks with null characters prior to splitting.  This is not guarenteed
+    to be safe because any UTF-8 encoded Unicode character is possible but the null character
+    should not, realistically be used in a blob name.
 
     See Also
     --------
+    https://bugs.python.org/issue43882
     https://github.com/python/cpython/blob/3.7/Lib/urllib/parse.py
     https://github.com/RaRe-Technologies/smart_open/issues/285
     https://github.com/RaRe-Technologies/smart_open/issues/458
     """
-    sr = urllib.parse.urlsplit(url.replace('?', '\n'), allow_fragments=False)
-    return urllib.parse.SplitResult(sr.scheme, sr.netloc, sr.path.replace('\n', '?'), '', '')
+    sr = urllib.parse.urlsplit(url.replace('?', '�'), allow_fragments=False)
+    return urllib.parse.SplitResult(sr.scheme, sr.netloc, sr.path.replace('�', '?'), '', '')

--- a/smart_open/utils.py
+++ b/smart_open/utils.py
@@ -15,7 +15,7 @@ import urllib.parse
 logger = logging.getLogger(__name__)
 
 WORKAROUND_SCHEMES = ['s3', 's3n', 's3u', 's3a', 'gs']
-QUESTION_MARK_PLACEHOLDER = '///smart_open.utils._QUESTION_MARK_PLACEHOLDER///'
+QUESTION_MARK_PLACEHOLDER = '///smart_open.utils.QUESTION_MARK_PLACEHOLDER///'
 
 
 def inspect_kwargs(kallable):

--- a/smart_open/utils.py
+++ b/smart_open/utils.py
@@ -10,7 +10,6 @@
 
 import inspect
 import logging
-import string
 import urllib.parse
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
#### Motivation

This attempts to fix the behaviour around question marks in URIs for S3 and GCS. `urllib.parse.urlsplit` is used and a hack was put in place to replace `?` with `\n` to avoid issues withs params splitting. However, the behaviour of `urllib.parse.urlsplit` has changed and now `\n`, `\t` and `\r` are all stripped from the URL before splitting.

https://bugs.python.org/issue43882

My solution is to instead use the 'null character'. This could technically appear in a GCS Blob name... but should it? To me this feels fairrrrrllllly safe?

#### Checklist

Before you create the PR, please make sure you have:

- [ x] Picked a concise, informative and complete title
- [ x] Clearly explained the motivation behind the PR
- [ x] Linked to any existing issues that your PR will be solving
- [ x] Included tests for any new functionality
- [ x] Checked that all unit tests pass

#### Workflow

Please avoid rebasing and force-pushing to the branch of the PR once a review is in progress.
Rebasing can make your commits look a bit cleaner, but it also makes life more difficult from the reviewer, because they are no longer able to distinguish between code that has already been reviewed, and unreviewed code.
