### PR TITLE
Mark concurrency-related tests as "expected to fail" on MacOS

### DIFF
--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -22,6 +22,7 @@ import boto3
 import botocore.client
 import botocore.endpoint
 import moto
+import pytest
 
 import smart_open
 import smart_open.s3
@@ -732,10 +733,11 @@ class IterBucketTest(unittest.TestCase):
     def tearDown(self):
         cleanup_bucket()
 
-    @unittest.skipIf(sys.platform == 'win32', reason="does not run on windows")
-    @unittest.skipIf(
-        sys.platform == 'darwin',
-        reason="does not run on macos due to multiprocessing using `spawn` rather than `fork` as on Unix")
+    @pytest.mark.skipif(condition=sys.platform == 'win32', reason="does not run on windows")
+    @pytest.mark.xfail(
+        condition=sys.platform == 'darwin',
+        reason="MacOS uses spawn rather than fork for multiprocessing",
+    )
     def test_iter_bucket(self):
         populate_bucket()
         results = list(smart_open.s3.iter_bucket(BUCKET_NAME))
@@ -753,10 +755,11 @@ class IterBucketTest(unittest.TestCase):
             # verify the suggested new import is in the warning
             assert "from smart_open.s3 import iter_bucket as s3_iter_bucket" in cm.output[0]
 
-    @unittest.skipIf(sys.platform == 'win32', reason="does not run on windows")
-    @unittest.skipIf(
-        sys.platform == 'darwin',
-        reason="does not run on macos due to multiprocessing using `spawn` rather than `fork` as on Unix")
+    @pytest.mark.skipif(condition=sys.platform == 'win32', reason="does not run on windows")
+    @pytest.mark.xfail(
+        condition=sys.platform == 'darwin',
+        reason="MacOS uses spawn rather than fork for multiprocessing",
+    )
     def test_accepts_boto3_bucket(self):
         populate_bucket()
         bucket = boto3.resource('s3').Bucket(BUCKET_NAME)
@@ -783,11 +786,15 @@ class IterBucketTest(unittest.TestCase):
 
 
 @moto.mock_s3
-@unittest.skipIf(not smart_open.concurrency._CONCURRENT_FUTURES, 'concurrent.futures unavailable')
-@unittest.skipIf(sys.platform == 'win32', reason="does not run on windows")
-@unittest.skipIf(
-    sys.platform == 'darwin',
-    reason="does not run on macos due to multiprocessing using `spawn` rather than `fork` as on Unix")
+@pytest.mark.skipif(
+    condition=not smart_open.concurrency._CONCURRENT_FUTURES,
+    reason='concurrent.futures unavailable',
+)
+@pytest.mark.skipif(condition=sys.platform == 'win32', reason="does not run on windows")
+@pytest.mark.xfail(
+    condition=sys.platform == 'darwin',
+    reason="MacOS uses spawn rather than fork for multiprocessing",
+)
 class IterBucketConcurrentFuturesTest(unittest.TestCase):
     def setUp(self):
         self.old_flag_multi = smart_open.concurrency._MULTIPROCESSING
@@ -809,11 +816,15 @@ class IterBucketConcurrentFuturesTest(unittest.TestCase):
 
 
 @moto.mock_s3
-@unittest.skipIf(not smart_open.concurrency._MULTIPROCESSING, 'multiprocessing unavailable')
-@unittest.skipIf(sys.platform == 'win32', reason="does not run on windows")
-@unittest.skipIf(
-    sys.platform == 'darwin',
-    reason="does not run on macos due to multiprocessing using `spawn` rather than `fork` as on Unix")
+@pytest.mark.skipif(
+    condition=not smart_open.concurrency._MULTIPROCESSING,
+    reason='multiprocessing unavailable',
+)
+@pytest.mark.skipif(condition=sys.platform == 'win32', reason="does not run on windows")
+@pytest.mark.xfail(
+    condition=sys.platform == 'darwin',
+    reason="MacOS uses spawn rather than fork for multiprocessing",
+)
 class IterBucketMultiprocessingTest(unittest.TestCase):
     def setUp(self):
         self.old_flag_concurrent = smart_open.concurrency._CONCURRENT_FUTURES

--- a/smart_open/tests/test_s3.py
+++ b/smart_open/tests/test_s3.py
@@ -733,6 +733,9 @@ class IterBucketTest(unittest.TestCase):
         cleanup_bucket()
 
     @unittest.skipIf(sys.platform == 'win32', reason="does not run on windows")
+    @unittest.skipIf(
+        sys.platform == 'darwin',
+        reason="does not run on macos due to multiprocessing using `spawn` rather than `fork` as on Unix")
     def test_iter_bucket(self):
         populate_bucket()
         results = list(smart_open.s3.iter_bucket(BUCKET_NAME))
@@ -751,6 +754,9 @@ class IterBucketTest(unittest.TestCase):
             assert "from smart_open.s3 import iter_bucket as s3_iter_bucket" in cm.output[0]
 
     @unittest.skipIf(sys.platform == 'win32', reason="does not run on windows")
+    @unittest.skipIf(
+        sys.platform == 'darwin',
+        reason="does not run on macos due to multiprocessing using `spawn` rather than `fork` as on Unix")
     def test_accepts_boto3_bucket(self):
         populate_bucket()
         bucket = boto3.resource('s3').Bucket(BUCKET_NAME)
@@ -779,6 +785,9 @@ class IterBucketTest(unittest.TestCase):
 @moto.mock_s3
 @unittest.skipIf(not smart_open.concurrency._CONCURRENT_FUTURES, 'concurrent.futures unavailable')
 @unittest.skipIf(sys.platform == 'win32', reason="does not run on windows")
+@unittest.skipIf(
+    sys.platform == 'darwin',
+    reason="does not run on macos due to multiprocessing using `spawn` rather than `fork` as on Unix")
 class IterBucketConcurrentFuturesTest(unittest.TestCase):
     def setUp(self):
         self.old_flag_multi = smart_open.concurrency._MULTIPROCESSING
@@ -802,6 +811,9 @@ class IterBucketConcurrentFuturesTest(unittest.TestCase):
 @moto.mock_s3
 @unittest.skipIf(not smart_open.concurrency._MULTIPROCESSING, 'multiprocessing unavailable')
 @unittest.skipIf(sys.platform == 'win32', reason="does not run on windows")
+@unittest.skipIf(
+    sys.platform == 'darwin',
+    reason="does not run on macos due to multiprocessing using `spawn` rather than `fork` as on Unix")
 class IterBucketMultiprocessingTest(unittest.TestCase):
     def setUp(self):
         self.old_flag_concurrent = smart_open.concurrency._CONCURRENT_FUTURES


### PR DESCRIPTION
#### Motivation

Some tests fail to run on MacOS. I think this is probably due the use of `spawn` rather than `fork` for multiprocessing. This means that the keys held in memory by `moto` are lost in the subprocesses. My reasoning started with this comment: https://github.com/spulec/moto/issues/2111#issuecomment-480000481

And then looking here: https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods

I discovered that Windows and MacOS use `spawn` and Linux uses `fork`. It is quite possible (likely even?) that the `spawn` mechanism fails to identify the `moto` parts of the process memory as needed.