### PR TITLE
Don't leak compressed stream (#630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You may continue to use `ignore_ext` parameter for now, but it will be deprecate
 - Drop mock dependency; standardize on unittest.mock (PR [#621](https://github.com/RaRe-Technologies/smart_open/pull/621), [@musicinmybrain](https://github.com/musicinmybrain))
 - Fix to_boto3 method (PR [#619](https://github.com/RaRe-Technologies/smart_open/pull/619), [@mpenkov](https://github.com/mpenkov))
 - Work around changes to `urllib.parse.urlsplit` (PR [#633](https://github.com/RaRe-Technologies/smart_open/pull/633), [@judahrand](https://github.com/judahrand)
+- Don't leak compressed stream (PR [#636](https://github.com/RaRe-Technologies/smart_open/pull/636), [@ampanasiuk](https://github.com/ampanasiuk))
 
 # 5.0.0, 30 Mar 2021
 


### PR DESCRIPTION
* Don't leak compressed stream

Transparent compression works by adapting the binary stream with the
GzipFile or BZ2File class. These, however, by design don't close the
adapted stream. Add a matching
CompressionFormatTest.test_closes_compressed_stream test.
- Fixes #630 