### PR TITLE
Change python_requires version to fix PEP 440 issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You may continue to use `ignore_ext` parameter for now, but it will be deprecate
 - Drop mock dependency; standardize on unittest.mock (PR [#621](https://github.com/RaRe-Technologies/smart_open/pull/621), [@musicinmybrain](https://github.com/musicinmybrain))
 - Fix to_boto3 method (PR [#619](https://github.com/RaRe-Technologies/smart_open/pull/619), [@mpenkov](https://github.com/mpenkov))
 - Work around changes to `urllib.parse.urlsplit` (PR [#633](https://github.com/RaRe-Technologies/smart_open/pull/633), [@judahrand](https://github.com/judahrand)
+- Change python_requires version to fix PEP 440 issue (PR [#639](https://github.com/RaRe-Technologies/smart_open/pull/639), [@lucasvieirasilva](https://github.com/lucasvieirasilva))
 
 # 5.0.0, 30 Mar 2021
 

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         'http': http_deps,
         'webhdfs': http_deps,
     },
-    python_requires=">=3.6.*",
+    python_requires=">=3.6,<4.0",
 
     test_suite="smart_open.tests",
 


### PR DESCRIPTION
#### Title

Fix `python_requires` to use PEP 440 Version Identification

#### Motivation

This PR changes the `python_requires` property in the `setup.py` version to follow the PEP 440 Version Identification, which will be able to install this package using `poetry` version `1.2.0a2`, which validates the PEP 440 as part of the installation process.

- Fixes #638 

#### Tests

No new unit tests are required.

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [ ] <s>Included tests for any new functionality</s>
- [x] Checked that all unit tests pass

#### Workflow

Please avoid rebasing and force-pushing to the branch of the PR once a review is in progress.
Rebasing can make your commits look a bit cleaner, but it also makes life more difficult from the reviewer, because they are no longer able to distinguish between code that has already been reviewed, and unreviewed code.
