### PR TITLE
Add max_concurrency support for azure

### DIFF
--- a/smart_open/azure.py
+++ b/smart_open/azure.py
@@ -153,7 +153,8 @@ class _RawReader(object):
         elif size == -1:
             stream = self._blob.download_blob(offset=self._position, max_concurrency=self._concurrency)
         else:
-            stream = self._blob.download_blob(offset=self._position, max_concurrency=self._concurrency, length=size)
+            stream = self._blob.download_blob(
+                offset=self._position, max_concurrency=self._concurrency, length=size)
         logging.debug('reading with a max concurrency of %d', self._concurrency)
         if isinstance(stream, azure.storage.blob.StorageStreamDownloader):
             binary = stream.readall()

--- a/smart_open/tests/test_azure.py
+++ b/smart_open/tests/test_azure.py
@@ -369,7 +369,7 @@ class ReaderTest(unittest.TestCase):
         self.assertEqual(content[:6], fin.read(6))
         self.assertEqual(content[6:14], fin.read(8))  # ř is 2 bytes
         self.assertEqual(content[14:], fin.read())  # read the rest
-    
+
     def test_read_max_concurrency(self):
         """Are Azure Blob Storage files read correctly?"""
         content = u"hello wořld\nhow are you?".encode('utf8')

--- a/smart_open/tests/test_azure.py
+++ b/smart_open/tests/test_azure.py
@@ -60,7 +60,7 @@ class FakeBlobClient(object):
     def delete_blob(self):
         self._container_client.delete_blob(self)
 
-    def download_blob(self, offset=None, length=None):
+    def download_blob(self, offset=None, length=None, max_concurrency=1):
         if offset is None:
             return self.__contents
         self.__contents.seek(offset)
@@ -366,6 +366,18 @@ class ReaderTest(unittest.TestCase):
         logger.debug('content: %r len: %r', content, len(content))
 
         fin = smart_open.azure.Reader(CONTAINER_NAME, blob_name, CLIENT)
+        self.assertEqual(content[:6], fin.read(6))
+        self.assertEqual(content[6:14], fin.read(8))  # ř is 2 bytes
+        self.assertEqual(content[14:], fin.read())  # read the rest
+    
+    def test_read_max_concurrency(self):
+        """Are Azure Blob Storage files read correctly?"""
+        content = u"hello wořld\nhow are you?".encode('utf8')
+        blob_name = "test_read_%s" % BLOB_NAME
+        put_to_container(blob_name, contents=content)
+        logger.debug('content: %r len: %r', content, len(content))
+
+        fin = smart_open.azure.Reader(CONTAINER_NAME, blob_name, CLIENT, max_concurrency=4)
         self.assertEqual(content[:6], fin.read(6))
         self.assertEqual(content[6:14], fin.read(8))  # ř is 2 bytes
         self.assertEqual(content[14:], fin.read())  # read the rest


### PR DESCRIPTION
#### Motivation

`download_blob` in `azure.storage.blob` supports setting a max concurrency for downloading blobs, which can improve download speeds. In a similar implementation of `smart_open`, we've noticed that downloading a 313 GiB file averaged 83 minutes download time, whilst `smart_open` at 122 minutes.

Some benchmarks (*note*: these also calculates the sha256 checksum of the blob downloaded)
`buffer_size` is set to `268435456`

<table>
<tr>
	<th>smart_open (max_concurrency=4)
	<th>smart_open (max_concurrency=1)
	<th>our implementation (max_concurrency=4)
	<th>our implementation (max_concurrency=1)
<tr>
	<td>49.8843s
	<td>69.1530s
	<td>49.7495s
	<td>69.4825s
<tr>
	<td>49.3389s
	<td>69.1241s
	<td>49.0315s
	<td>68.9774s
<tr>
	<td>49.3781s
	<td>66.0186s
	<td>48.4432s
	<td>69.1307s
<tr>
	<th>avg: 49.5338s
	<th>avg: 68.0986s
	<th>avg: 49.0747s
	<th>avg: 69.1969s
</table>

As one can see, setting max_concurrency to 4, gives a decrease of 27%, which I think is significant, and is a nice feature to add to the `azure` connector in `smart_open`


#### Tests

> If there are any failures, please fix them before creating the PR (or mark it as WIP, see below).

Failing tests seems to not be related to `azure`, but `s3`


#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [X] Clearly explained the motivation behind the PR
- [ ] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [ ] Checked that all unit tests pass
