### PR TITLE
support container client and blob client for azure blob storage

### DIFF
--- a/smart_open/azure.py
+++ b/smart_open/azure.py
@@ -11,6 +11,7 @@
 import base64
 import io
 import logging
+from typing import Union
 
 import smart_open.bytebuffer
 import smart_open.constants
@@ -68,7 +69,7 @@ def open(
         container_id,
         blob_id,
         mode,
-        client=None,  # type: azure.storage.blob.BlobServiceClient
+        client=None,  # type: Union[azure.storage.blob.BlobServiceClient,azure.storage.blob.ContainerClient,azure.storage.blob.BlobClient]
         buffer_size=DEFAULT_BUFFER_SIZE,
         min_part_size=_DEFAULT_MIN_PART_SIZE,
         max_concurrency=DEFAULT_MAX_CONCURRENCY,
@@ -114,6 +115,25 @@ def open(
         )
     else:
         raise NotImplementedError('Azure Blob Storage support for mode %r not implemented' % mode)
+
+
+def _get_blob_client(client, container, blob):
+    # type: (Union[azure.storage.blob.BlobServiceClient,azure.storage.blob.ContainerClient,azure.storage.blob.BlobClient], str, str) -> azure.storage.blob.BlobClient
+    """
+    Return an Azure BlobClient starting with any of BlobServiceClient,
+    ContainerClient, or BlobClient plus container name and blob name.
+    """
+    if hasattr(client, "get_container_client"):
+        client = client.get_container_client(container)
+
+    if hasattr(client, "container_name") and client.container_name != container:
+        raise ValueError("""Container client for "{}" doesn't match container "{}".""".format(
+            client.container_name, container))
+
+    if hasattr(client, "get_blob_client"):
+        client = client.get_blob_client(blob)
+
+    return client
 
 
 class _RawReader(object):
@@ -175,15 +195,16 @@ class Reader(io.BufferedIOBase):
             self,
             container,
             blob,
-            client,  # type: azure.storage.blob.BlobServiceClient
+            client,  # type: Union[azure.storage.blob.BlobServiceClient,azure.storage.blob.ContainerClient,azure.storage.blob.BlobClient]
             buffer_size=DEFAULT_BUFFER_SIZE,
             line_terminator=smart_open.constants.BINARY_NEWLINE,
             max_concurrency=DEFAULT_MAX_CONCURRENCY,
     ):
-        self._container_client = client.get_container_client(container)
-        # type: azure.storage.blob.ContainerClient
+        self._container_name = container
 
-        self._blob = self._container_client.get_blob_client(blob)
+        self._blob = _get_blob_client(client, container, blob)
+        # type: azure.storage.blob.BlobClient
+
         if self._blob is None:
             raise azure.core.exceptions.ResourceNotFoundError(
                 'blob %s not found in %s' % (blob, container)
@@ -345,12 +366,12 @@ class Reader(io.BufferedIOBase):
 
     def __str__(self):
         return "(%s, %r, %r)" % (self.__class__.__name__,
-                                 self._container.container_name,
+                                 self._container_name,
                                  self._blob.blob_name)
 
     def __repr__(self):
         return "%s(container=%r, blob=%r)" % (
-            self.__class__.__name__, self._container_client.container_name, self._blob.blob_name,
+            self.__class__.__name__, self._container_name, self._blob.blob_name,
         )
 
 
@@ -363,13 +384,15 @@ class Writer(io.BufferedIOBase):
             self,
             container,
             blob,
-            client,  # type: azure.storage.blob.BlobServiceClient
+            client,  # type: Union[azure.storage.blob.BlobServiceClient,azure.storage.blob.ContainerClient,azure.storage.blob.BlobClient]
             min_part_size=_DEFAULT_MIN_PART_SIZE,
     ):
-        self._client = client
-        self._container_client = self._client.get_container_client(container)
-        # type: azure.storage.blob.ContainerClient
-        self._blob = self._container_client.get_blob_client(blob)  # type: azure.storage.blob.BlobClient
+        self._is_closed = False
+        self._container_name = container
+
+        self._blob = _get_blob_client(client, container, blob)
+        # type: azure.storage.blob.BlobClient
+
         self._min_part_size = min_part_size
 
         self._total_size = 0
@@ -396,12 +419,12 @@ class Writer(io.BufferedIOBase):
                 self._upload_part()
             self._blob.commit_block_list(self._block_list)
             self._block_list = []
-            self._client = None
+            self._is_closed = True
         logger.debug("successfully closed")
 
     @property
     def closed(self):
-        return self._client is None
+        return self._is_closed
 
     def writable(self):
         """Return True if the stream supports writing."""
@@ -483,14 +506,14 @@ class Writer(io.BufferedIOBase):
     def __str__(self):
         return "(%s, %r, %r)" % (
             self.__class__.__name__,
-            self._container_client.container_name,
+            self._container_name,
             self._blob.blob_name
         )
 
     def __repr__(self):
         return "%s(container=%r, blob=%r, min_part_size=%r)" % (
             self.__class__.__name__,
-            self._container_client.container_name,
+            self._container_name,
             self._blob.blob_name,
             self._min_part_size
         )

--- a/smart_open/tests/test_azure.py
+++ b/smart_open/tests/test_azure.py
@@ -526,6 +526,31 @@ class ReaderTest(unittest.TestCase):
 
         self.assertEqual(data, content)
 
+    def test_read_container_client(self):
+        content = "spirits in the material world".encode("utf-8")
+        blob_name = "test_read_container_client_%s" % BLOB_NAME
+        put_to_container(blob_name, contents=content)
+
+        container_client = CLIENT.get_container_client(CONTAINER_NAME)
+
+        with smart_open.azure.Reader(CONTAINER_NAME, blob_name, container_client) as fin:
+            data = fin.read(100)
+
+        self.assertEqual(data, content)
+
+    def test_read_blob_client(self):
+        content = "walking on the moon".encode("utf-8")
+        blob_name = "test_read_blob_client_%s" % BLOB_NAME
+        put_to_container(blob_name, contents=content)
+
+        container_client = CLIENT.get_container_client(CONTAINER_NAME)
+        blob_client = container_client.get_blob_client(blob_name)
+
+        with smart_open.azure.Reader(CONTAINER_NAME, blob_name, blob_client) as fin:
+            data = fin.read(100)
+
+        self.assertEqual(data, content)
+
 
 class WriterTest(unittest.TestCase):
     """Test writing into Azure Blob files."""
@@ -545,6 +570,23 @@ class WriterTest(unittest.TestCase):
             "azure://%s/%s" % (CONTAINER_NAME, blob_name),
             "rb",
             transport_params=dict(client=CLIENT),
+        ))
+        self.assertEqual(output, [test_string])
+
+    def test_write_container_client(self):
+        """Does writing into Azure Blob Storage work correctly?"""
+        test_string = u"Hiszékeny Öngyilkos Vasárnap".encode('utf8')
+        blob_name = "test_write_container_client_%s" % BLOB_NAME
+
+        container_client = CLIENT.get_container_client(CONTAINER_NAME)
+
+        with smart_open.azure.Writer(CONTAINER_NAME, blob_name, container_client) as fout:
+            fout.write(test_string)
+
+        output = list(smart_open.open(
+            "azure://%s/%s" % (CONTAINER_NAME, blob_name),
+            "rb",
+            transport_params=dict(client=container_client),
         ))
         self.assertEqual(output, [test_string])
 


### PR DESCRIPTION
#### Support ContainerClient and BlobClient in Azure storage

Support use of ContainerClient and BlobClient to access blobs in Azure storage in addition to existing support for BlobServiceClient. Overloads transport_params['client'] to accept any of the three types of clients supported by Azure storage, for example:

```python
transport_params = {
    'client': ContainerClient.from_container_url(container_sas_url),
}

with smart_open.open('azure://path/to/blob', mode='wb', transport_parameters=transport_parameters) as fout:
   fout.write(data)
```

#### Motivation

This allows for a least-privilege approach. You can access azure storage with a SAS URL scoped down to a specific container or blob, rather having the full run of the storage account.

```
- Fixes #651 
```

#### Tests

in smart_open/tests/test_azure.py

- test_read_container_client
- test_read_blob_client
- test_write_container_client
