### PR TITLE
drop deprecated ignore_ext parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Unreleased
 
+This release deprecates the old `ignore_ext` parameter.
+Use the `compression` parameter instead.
+
+```python
+fin = smart_open.open("/path/file.gz", ignore_ext=True)  # No
+fin = smart_open.open("/path/file.gz", compression="disable")  # Yes
+
+fin = smart_open.open("/path/file.gz", ignore_ext=False)  # No
+fin = smart_open.open("/path/file.gz")  # Yes
+fin = smart_open.open("/path/file.gz", compression="infer_from_extension")  # Yes, if you want to be explicit
+
+fin = smart_open.open("/path/file", compression=".gz")  # Yes
+```
+
 - Use pytest instead of parameterizedtestcase (PR [#657](https://github.com/RaRe-Technologies/smart_open/pull/657), [@mpenkov](https://github.com/mpenkov))
 - Support container client and blob client for azure blob storage (PR [#652](https://github.com/RaRe-Technologies/smart_open/pull/652), [@cbare](https://github.com/cbare))
 - Support working directly with file descriptors (PR [#659](https://github.com/RaRe-Technologies/smart_open/pull/659), [@mpenkov](https://github.com/mpenkov))

--- a/MIGRATING_FROM_OLDER_VERSIONS.rst
+++ b/MIGRATING_FROM_OLDER_VERSIONS.rst
@@ -1,3 +1,21 @@
+Migrating to the new compression parameter
+==========================================
+
+smart_open versions 6.0.0 and above no longer support the ``ignore_ext`` parameter.
+Use the ``compression`` parameter instead:
+
+```python
+fin = smart_open.open("/path/file.gz", ignore_ext=True)  # No
+fin = smart_open.open("/path/file.gz", compression="disable")  # Yes
+
+fin = smart_open.open("/path/file.gz", ignore_ext=False)  # No
+fin = smart_open.open("/path/file.gz")  # Yes
+fin = smart_open.open("/path/file.gz", compression="infer_from_extension")  # Yes, if you want to be explicit
+
+fin = smart_open.open("/path/file", compression=".gz")  # Yes
+
+```
+
 Migrating to the new client-based S3 API
 ========================================
 

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1708,7 +1708,7 @@ class S3OpenTest(unittest.TestCase):
         #
         # Check that what we've created is a gzip.
         #
-        with smart_open.open(key, "rb", ignore_ext=True) as fin:
+        with smart_open.open(key, "rb", compression='disable') as fin:
             gz = gzip.GzipFile(fileobj=fin)
             self.assertEqual(gz.read().decode("utf-8"), text)
 
@@ -1962,44 +1962,15 @@ def test_s3_write_implicit(url, _compression, expected):
         ("s3://bucket/key.bz2", ".bz2", bz2.compress(_DECOMPRESSED_DATA)),
     ],
 )
-def test_s3_ignore_ext(url, _compression, expected):
-    """Can we handle the deprecated ignore_ext parameter when reading/writing?"""
+def test_s3_disable_compression(url, _compression, expected):
+    """Can we handle the compression parameter when reading/writing?"""
     initialize_bucket()
 
     with smart_open.open(url, "wb") as fout:
         fout.write(_DECOMPRESSED_DATA)
 
-    with smart_open.open(url, "rb", ignore_ext=True) as fin:
+    with smart_open.open(url, "rb", compression='disable') as fin:
         assert fin.read() == expected
-
-
-@pytest.mark.parametrize(
-    "extension,kwargs,error",
-    [
-        ("", dict(compression="foo"), ValueError),
-        ("", dict(compression="foo", ignore_ext=True), ValueError),
-        ("", dict(compression=NO_COMPRESSION, ignore_ext=True), ValueError),
-        (
-            ".gz",
-            dict(compression=INFER_FROM_EXTENSION, ignore_ext=True),
-            ValueError,
-        ),
-        (
-            ".bz2",
-            dict(compression=INFER_FROM_EXTENSION, ignore_ext=True),
-            ValueError,
-        ),
-        ("", dict(compression=".gz", ignore_ext=True), ValueError),
-        ("", dict(compression=".bz2", ignore_ext=True), ValueError),
-    ],
-)
-def test_compression_invalid(extension, kwargs, error):
-    """Should detect and error on these invalid inputs"""
-    with pytest.raises(error):
-        smart_open.open(f"s3://bucket/key{extension}", "wb", **kwargs)
-
-    with pytest.raises(error):
-        smart_open.open(f"s3://bucket/key{extension}", "rb", **kwargs)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is a follow up from https://github.com/RaRe-Technologies/smart_open/issues/607

We currently have two mutually exclusive parameters, ignore_ext (deprecated) and compression. We introduced the new one and marked the old one as deprecated about 6 months ago. I think sufficient time has passed for us to remove this parameter.

We still have a function for compatibility with ancient code (smart_open.smart_open). That's still there and remains the same.

This is a backwards-incompatible change, so we should probably put it in the same release as #660 
