### PR TITLE
Expose certain transport-specific methods in top layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added support for viewfs:// URLs (PR [#665](https://github.com/RaRe-Technologies/smart_open/pull/665), [@ChandanChainani](https://github.com/ChandanChainani))
 - Drop support for passing buffers to smart_open.open (PR [#660](https://github.com/RaRe-Technologies/smart_open/pull/660), [@mpenkov](https://github.com/mpenkov))
 - Pin google-cloud-storage to >=1.31.1 in extras (PR [#687](https://github.com/RaRe-Technologies/smart_open/pull/687), [@PLPeeters](https://github.com/PLPeeters))
+- Expose certain transport-specific methods e.g. to_boto3 in top layer (PR [#664](https://github.com/RaRe-Technologies/smart_open/pull/664), [@mpenkov](https://github.com/mpenkov))
 
 # 5.2.1, 28 August 2021
 

--- a/README.rst
+++ b/README.rst
@@ -502,3 +502,4 @@ issues or pull requests there. Suggestions, pull requests and improvements welco
 
 ``smart_open`` is open source software released under the `MIT license <https://github.com/piskvorky/smart_open/blob/master/LICENSE>`_.
 Copyright (c) 2015-now `Radim Řehůřek <https://radimrehurek.com>`_.
+

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -247,7 +247,7 @@ def open(
         decoded = decompressed
 
     #
-    # There some useful methods in the binary readers, e.g. to_boto3, that get
+    # There are some useful methods in the binary readers, e.g. to_boto3, that get
     # hidden by the multiple layers of wrapping we just performed.  Promote
     # them so they are visible to the user.
     #

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -246,6 +246,19 @@ def open(
     else:
         decoded = decompressed
 
+    #
+    # There some useful methods in the binary readers, e.g. to_boto3, that get
+    # hidden by the multiple layers of wrapping we just performed.  Promote
+    # them so they are visible to the user.
+    #
+    if decoded != binary:
+        promoted_attrs = ['to_boto3']
+        for attr in promoted_attrs:
+            try:
+                setattr(decoded, attr, getattr(binary, attr))
+            except AttributeError:
+                pass
+
     return decoded
 
 

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1923,7 +1923,12 @@ def test_write_file_descriptor():
 def test_to_boto3():
     resource = boto3.resource('s3')
     resource.create_bucket(Bucket='mybucket')
-    with smart_open.open('s3://mybucket/key.txt', 'wt') as fout:
+    #
+    # If we don't specify encoding explicitly, the platform-dependent encoding
+    # will be used, and it may not necessarily support Unicode, breaking this
+    # test under Windows on github actions.
+    #
+    with smart_open.open('s3://mybucket/key.txt', 'wt', encoding='utf-8') as fout:
         fout.write('я бегу по вызженной земле, гермошлем захлопнув на ходу')
         obj = fout.to_boto3(resource)
     assert obj.bucket_name == 'mybucket'

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -21,7 +21,7 @@ from unittest import mock
 import warnings
 
 import boto3
-from moto import mock_s3
+import moto
 import pytest
 import responses
 
@@ -738,7 +738,7 @@ class SmartOpenReadTest(unittest.TestCase):
             actual = fin.read()
         self.assertEqual(expected, actual)
 
-    @mock_s3
+    @moto.mock_s3
     def test_read_never_returns_none(self):
         """read should never return None."""
         s3 = boto3.resource('s3')
@@ -753,7 +753,7 @@ class SmartOpenReadTest(unittest.TestCase):
         self.assertEqual(r.read(), b"")
         self.assertEqual(r.read(), b"")
 
-    @mock_s3
+    @moto.mock_s3
     def test_read_newline_none(self):
         """Does newline open() parameter for reading work according to
            https://docs.python.org/3/library/functions.html#open-newline-parameter
@@ -773,7 +773,7 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"last line"
             ])
 
-    @mock_s3
+    @moto.mock_s3
     def test_read_newline_empty(self):
         boto3.resource('s3').create_bucket(Bucket='mybucket')
         test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
@@ -788,7 +788,7 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"last line"
             ])
 
-    @mock_s3
+    @moto.mock_s3
     def test_read_newline_cr(self):
         boto3.resource('s3').create_bucket(Bucket='mybucket')
         test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
@@ -802,7 +802,7 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"\nlast line"
             ])
 
-    @mock_s3
+    @moto.mock_s3
     def test_read_newline_lf(self):
         boto3.resource('s3').create_bucket(Bucket='mybucket')
         test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
@@ -816,7 +816,7 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"last line"
             ])
 
-    @mock_s3
+    @moto.mock_s3
     def test_read_newline_crlf(self):
         boto3.resource('s3').create_bucket(Bucket='mybucket')
         test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
@@ -829,7 +829,7 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"last line"
             ])
 
-    @mock_s3
+    @moto.mock_s3
     def test_read_newline_slurp(self):
         boto3.resource('s3').create_bucket(Bucket='mybucket')
         test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
@@ -842,7 +842,7 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"line\u2028 LF\nline\x1c CR\nline\x85 CRLF\nlast line"
             )
 
-    @mock_s3
+    @moto.mock_s3
     def test_read_newline_binary(self):
         boto3.resource('s3').create_bucket(Bucket='mybucket')
         test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
@@ -856,7 +856,7 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"last line".encode('utf-8')
             ])
 
-    @mock_s3
+    @moto.mock_s3
     def test_write_newline_none(self):
         """Does newline open() parameter for writing work according to
            https://docs.python.org/3/library/functions.html#open-newline-parameter
@@ -875,7 +875,7 @@ class SmartOpenReadTest(unittest.TestCase):
                 + u"last line"
             )
 
-    @mock_s3
+    @moto.mock_s3
     def test_write_newline_empty(self):
         boto3.resource('s3').create_bucket(Bucket='mybucket')
         test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
@@ -888,7 +888,7 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
             )
 
-    @mock_s3
+    @moto.mock_s3
     def test_write_newline_lf(self):
         boto3.resource('s3').create_bucket(Bucket='mybucket')
         test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
@@ -901,7 +901,7 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
             )
 
-    @mock_s3
+    @moto.mock_s3
     def test_write_newline_cr(self):
         boto3.resource('s3').create_bucket(Bucket='mybucket')
         test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
@@ -914,7 +914,7 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"line\u2028 LF\rline\x1c CR\rline\x85 CRLF\r\rlast line"
             )
 
-    @mock_s3
+    @moto.mock_s3
     def test_write_newline_crlf(self):
         boto3.resource('s3').create_bucket(Bucket='mybucket')
         test_file = u"line\u2028 LF\nline\x1c CR\rline\x85 CRLF\r\nlast line"
@@ -927,7 +927,7 @@ class SmartOpenReadTest(unittest.TestCase):
                 u"line\u2028 LF\r\nline\x1c CR\rline\x85 CRLF\r\r\nlast line"
             )
 
-    @mock_s3
+    @moto.mock_s3
     def test_readline(self):
         """Does readline() return the correct file content?"""
         s3 = boto3.resource('s3')
@@ -939,7 +939,7 @@ class SmartOpenReadTest(unittest.TestCase):
         reader = smart_open.open("s3://mybucket/mykey", "rb")
         self.assertEqual(reader.readline(), u"hello žluťoučký\u2028world!\n".encode("utf-8"))
 
-    @mock_s3
+    @moto.mock_s3
     def test_readline_iter(self):
         """Does __iter__ return the correct file content?"""
         s3 = boto3.resource('s3')
@@ -955,7 +955,7 @@ class SmartOpenReadTest(unittest.TestCase):
         self.assertEqual(lines[0], actual_lines[0])
         self.assertEqual(lines[1], actual_lines[1])
 
-    @mock_s3
+    @moto.mock_s3
     def test_readline_eof(self):
         """Does readline() return empty string on EOF?"""
         s3 = boto3.resource('s3')
@@ -970,7 +970,7 @@ class SmartOpenReadTest(unittest.TestCase):
             self.assertEqual(reader.readline(), b"")
             self.assertEqual(reader.readline(), b"")
 
-    @mock_s3
+    @moto.mock_s3
     def test_s3_iter_lines(self):
         """Does s3_iter_lines give correct content?"""
         # create fake bucket and fake key
@@ -1094,7 +1094,7 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object = smart_open.open("webhdfs://127.0.0.1:8440/path/file", 'rb')
         self.assertEqual(smart_open_object.read().decode("utf-8"), "line1\nline2")
 
-    @mock_s3
+    @moto.mock_s3
     def test_s3_iter_moto(self):
         """Are S3 files iterated over correctly?"""
         # a list of strings to test with
@@ -1126,7 +1126,7 @@ class SmartOpenReadTest(unittest.TestCase):
             output = [line.rstrip(b'\n') for line in smart_open_object]
             self.assertEqual(output, expected)
 
-    @mock_s3
+    @moto.mock_s3
     def test_s3_read_moto(self):
         """Are S3 files read correctly?"""
         s3 = boto3.resource('s3')
@@ -1143,7 +1143,7 @@ class SmartOpenReadTest(unittest.TestCase):
 
         self.assertEqual(content[14:], smart_open_object.read())  # read the rest
 
-    @mock_s3
+    @moto.mock_s3
     def test_s3_seek_moto(self):
         """Does seeking in S3 files work correctly?"""
         s3 = boto3.resource('s3')
@@ -1164,7 +1164,7 @@ class SmartOpenReadTest(unittest.TestCase):
         smart_open_object.seek(0)
         self.assertEqual(content, smart_open_object.read(-1))  # same thing
 
-    @mock_s3
+    @moto.mock_s3
     def test_s3_tell(self):
         """Does tell() work when S3 file is opened for text writing? """
         s3 = boto3.resource('s3')
@@ -1357,7 +1357,7 @@ class SmartOpenTest(unittest.TestCase):
             ["hdfs", "dfs", "-put", "-f", "-", "/tmp/test.txt"], stdin=mock_subprocess.PIPE
         )
 
-    @mock_s3
+    @moto.mock_s3
     def test_s3_modes_moto(self):
         """Do s3:// open modes work correctly?"""
         # fake bucket and key
@@ -1376,7 +1376,7 @@ class SmartOpenTest(unittest.TestCase):
 
         self.assertEqual(output, [raw_data])
 
-    @mock_s3
+    @moto.mock_s3
     def test_s3_metadata_write(self):
         # Read local file fixture
         path = os.path.join(CURR_DIR, 'test_data/crime-and-punishment.txt.gz')
@@ -1409,7 +1409,7 @@ class SmartOpenTest(unittest.TestCase):
         self.assertIn('text/plain', key.content_type)
         self.assertEqual(key.content_encoding, 'gzip')
 
-    @mock_s3
+    @moto.mock_s3
     def test_write_bad_encoding_strict(self):
         """Should abort on encoding error."""
         text = u'欲しい気持ちが成長しすぎて'
@@ -1419,7 +1419,7 @@ class SmartOpenTest(unittest.TestCase):
                 with smart_open.open(infile.name, 'w', encoding='koi8-r', errors='strict') as fout:
                     fout.write(text)
 
-    @mock_s3
+    @moto.mock_s3
     def test_write_bad_encoding_replace(self):
         """Should replace characters that failed to encode."""
         text = u'欲しい気持ちが成長しすぎて'
@@ -1649,7 +1649,7 @@ class MultistreamsBZ2Test(unittest.TestCase):
 
 class S3OpenTest(unittest.TestCase):
 
-    @mock_s3
+    @moto.mock_s3
     def test_r(self):
         """Reading a UTF string should work."""
         text = u"физкульт-привет!"
@@ -1670,7 +1670,7 @@ class S3OpenTest(unittest.TestCase):
         uri = smart_open_lib._parse_uri("s3://bucket/key")
         self.assertRaises(NotImplementedError, smart_open.open, uri, "x")
 
-    @mock_s3
+    @moto.mock_s3
     def test_rw_encoding(self):
         """Should read and write text, respecting encodings, etc."""
         s3 = boto3.resource('s3')
@@ -1694,7 +1694,7 @@ class S3OpenTest(unittest.TestCase):
         with smart_open.open(key, "r", encoding="euc-jp", errors="replace") as fin:
             fin.read()
 
-    @mock_s3
+    @moto.mock_s3
     def test_rw_gzip(self):
         """Should read/write gzip files, implicitly and explicitly."""
         s3 = boto3.resource('s3')
@@ -1718,7 +1718,7 @@ class S3OpenTest(unittest.TestCase):
         with smart_open.open(key, "rb") as fin:
             self.assertEqual(fin.read().decode("utf-8"), text)
 
-    @mock_s3
+    @moto.mock_s3
     @mock.patch('smart_open.smart_open_lib._inspect_kwargs', mock.Mock(return_value={}))
     def test_gzip_write_mode(self):
         """Should always open in binary mode when writing through a codec."""
@@ -1729,7 +1729,7 @@ class S3OpenTest(unittest.TestCase):
             smart_open.open("s3://bucket/key.gz", "wb")
             mock_open.assert_called_with('bucket', 'key.gz', 'wb')
 
-    @mock_s3
+    @moto.mock_s3
     @mock.patch('smart_open.smart_open_lib._inspect_kwargs', mock.Mock(return_value={}))
     def test_gzip_read_mode(self):
         """Should always open in binary mode when reading through a codec."""
@@ -1745,7 +1745,7 @@ class S3OpenTest(unittest.TestCase):
             smart_open.open(key, "r")
             mock_open.assert_called_with('bucket', 'key.gz', 'rb')
 
-    @mock_s3
+    @moto.mock_s3
     def test_read_encoding(self):
         """Should open the file with the correct encoding, explicit text read."""
         s3 = boto3.resource('s3')
@@ -1758,7 +1758,7 @@ class S3OpenTest(unittest.TestCase):
             actual = fin.read()
         self.assertEqual(text, actual)
 
-    @mock_s3
+    @moto.mock_s3
     def test_read_encoding_implicit_text(self):
         """Should open the file with the correct encoding, implicit text read."""
         s3 = boto3.resource('s3')
@@ -1771,7 +1771,7 @@ class S3OpenTest(unittest.TestCase):
             actual = fin.read()
         self.assertEqual(text, actual)
 
-    @mock_s3
+    @moto.mock_s3
     def test_write_encoding(self):
         """Should open the file for writing with the correct encoding."""
         s3 = boto3.resource('s3')
@@ -1785,7 +1785,7 @@ class S3OpenTest(unittest.TestCase):
             actual = fin.read()
         self.assertEqual(text, actual)
 
-    @mock_s3
+    @moto.mock_s3
     def test_write_bad_encoding_strict(self):
         """Should open the file for writing with the correct encoding."""
         s3 = boto3.resource('s3')
@@ -1797,7 +1797,7 @@ class S3OpenTest(unittest.TestCase):
             with smart_open.open(key, 'w', encoding='koi8-r', errors='strict') as fout:
                 fout.write(text)
 
-    @mock_s3
+    @moto.mock_s3
     def test_write_bad_encoding_replace(self):
         """Should open the file for writing with the correct encoding."""
         s3 = boto3.resource('s3')
@@ -1812,7 +1812,7 @@ class S3OpenTest(unittest.TestCase):
             actual = fin.read()
         self.assertEqual(expected, actual)
 
-    @mock_s3
+    @moto.mock_s3
     def test_write_text_gzip(self):
         """Should open the file for writing with the correct encoding."""
         s3 = boto3.resource('s3')
@@ -1889,7 +1889,7 @@ def initialize_bucket():
     bucket.Object('bzipped').put(Body=bz2.compress(_DECOMPRESSED_DATA))
 
 
-@mock_s3
+@moto.mock_s3
 @mock.patch('time.time', _MOCK_TIME)
 def test_s3_gzip_compress_sanity():
     """Does our gzip_compress function actually produce gzipped data?"""
@@ -1897,7 +1897,7 @@ def test_s3_gzip_compress_sanity():
     assert gzip.decompress(gzip_compress(_DECOMPRESSED_DATA)) == _DECOMPRESSED_DATA
 
 
-@mock_s3
+@moto.mock_s3
 @mock.patch('time.time', _MOCK_TIME)
 @pytest.mark.parametrize(
     "url,_compression",
@@ -1913,7 +1913,7 @@ def test_s3_read_explicit(url, _compression):
         assert fin.read() == _DECOMPRESSED_DATA
 
 
-@mock_s3
+@moto.mock_s3
 @mock.patch('time.time', _MOCK_TIME)
 @pytest.mark.parametrize(
     "_compression,expected",
@@ -1933,7 +1933,7 @@ def test_s3_write_explicit(_compression, expected):
         assert fin.read() == expected
 
 
-@mock_s3
+@moto.mock_s3
 @mock.patch('time.time', _MOCK_TIME)
 @pytest.mark.parametrize(
     "url,_compression,expected",
@@ -1953,7 +1953,7 @@ def test_s3_write_implicit(url, _compression, expected):
         assert fin.read() == expected
 
 
-@mock_s3
+@moto.mock_s3
 @mock.patch('time.time', _MOCK_TIME)
 @pytest.mark.parametrize(
     "url,_compression,expected",
@@ -2080,6 +2080,17 @@ def test_write_file_descriptor():
 
         with smart_open.open(tmp.name, 'rt') as fin:
             assert fin.read() == "hello world"
+
+
+@moto.mock_s3()
+def test_to_boto3():
+    resource = boto3.resource('s3')
+    resource.create_bucket(Bucket='mybucket')
+    with smart_open.open('s3://mybucket/key.txt', 'wt') as fout:
+        fout.write('я бегу по вызженной земле, гермошлем захлопнув на ходу')
+        obj = fout.to_boto3(resource)
+    assert obj.bucket_name == 'mybucket'
+    assert obj.key == 'key.txt'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix #663

Our text decoding and decompression wrappers were hiding some important methods from the user.

It worked in earlier versions of smart_open because the wrappers were disabled by default (read mode was rb).

Also includes some documentation fixups.