### PR TITLE
Fix a changed boto3 documentation URL

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -1240,7 +1240,7 @@ def _download_key(key_name, bucket_name=None, retries=3, **session_kwargs):
         raise ValueError('bucket_name may not be None')
 
     #
-    # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html#multithreading-and-multiprocessing
+    # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html#multithreading-or-multiprocessing-with-resources
     #
     session = boto3.session.Session(**session_kwargs)
     s3 = session.resource('s3')


### PR DESCRIPTION
The URL about multiprocessing is now at https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html#multithreading-or-multiprocessing-with-resources

#### Title

A URL to a paragraph in the boto3 docs changed. This PR fixes a mention of that URL in the code comments of `s3.py`.

#### Motivation

As I was debugging performance issues, I came across this, so I figured I would fix it.