### PR TITLE
Read importlib.metadata to find transport / compressor extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         'all': all_deps,
         'http': http_deps,
         'webhdfs': http_deps,
+        ':python_version<"3.8"': ['importlib-metadata'],
     },
     python_requires=">=3.6,<4.0",
 

--- a/smart_open/compression.py
+++ b/smart_open/compression.py
@@ -7,9 +7,9 @@
 #
 """Implements the compression layer of the ``smart_open`` library."""
 import logging
-import importlib
-import importlib.metadata
 import os.path
+
+from smart_open.utils import find_entry_points
 
 logger = logging.getLogger(__name__)
 
@@ -158,5 +158,5 @@ def _register_compressor_entry_point(ep):
         logger.warning("Fail to load smart_open compressor extension: %s (target: %s)", ep.name, ep.value)
 
 
-for ep in importlib.metadata.entry_points().select(group='smart_open_compressor'):
+for ep in find_entry_points('smart_open_compressor'):
     _register_compressor_entry_point(ep)

--- a/smart_open/tests/fixtures/compressor.py
+++ b/smart_open/tests/fixtures/compressor.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""Some no-op compressor"""
+
+
+def handle_foo():
+    ...
+
+
+def handle_bar():
+    ...

--- a/smart_open/tests/test_compression.py
+++ b/smart_open/tests/test_compression.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from importlib.metadata import EntryPoint
 import pytest
 
+from smart_open.utils import importlib_metadata
 from smart_open.compression import _COMPRESSOR_REGISTRY, _register_compressor_entry_point
+
+EntryPoint = importlib_metadata.EntryPoint
 
 
 def unregister_compressor(ext):

--- a/smart_open/tests/test_compression.py
+++ b/smart_open/tests/test_compression.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+from importlib.metadata import EntryPoint
+import pytest
+
+from smart_open.compression import _COMPRESSOR_REGISTRY, _register_compressor_entry_point
+
+
+def unregister_compressor(ext):
+    if ext in _COMPRESSOR_REGISTRY:
+        del _COMPRESSOR_REGISTRY[ext]
+
+
+@pytest.fixture(autouse=True)
+def cleanup_compressor():
+    unregister_compressor(".foo")
+    unregister_compressor(".bar")
+
+
+def test_register_valid_entry_point():
+    assert ".foo" not in _COMPRESSOR_REGISTRY
+    assert ".bar" not in _COMPRESSOR_REGISTRY
+    _register_compressor_entry_point(EntryPoint(
+        "foo",
+        "smart_open.tests.fixtures.compressor:handle_bar",
+        "smart_open_compressor",
+    ))
+    _register_compressor_entry_point(EntryPoint(
+        "bar",
+        "smart_open.tests.fixtures.compressor:handle_bar",
+        "smart_open_compressor",
+    ))
+    assert ".foo" in _COMPRESSOR_REGISTRY
+    assert ".bar" in _COMPRESSOR_REGISTRY
+
+
+def test_register_invalid_entry_point_name_do_not_crash():
+    _register_compressor_entry_point(EntryPoint(
+        "",
+        "smart_open.tests.fixtures.compressor:handle_foo",
+        "smart_open_compressor",
+    ))
+    assert "" not in _COMPRESSOR_REGISTRY
+    assert "." not in _COMPRESSOR_REGISTRY
+
+
+def test_register_invalid_entry_point_value_do_not_crash():
+    _register_compressor_entry_point(EntryPoint(
+        "foo",
+        "smart_open.tests.fixtures.compressor:handle_invalid",
+        "smart_open_compressor",
+    ))
+    assert ".foo" not in _COMPRESSOR_REGISTRY

--- a/smart_open/tests/test_transport.py
+++ b/smart_open/tests/test_transport.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
-from importlib.metadata import EntryPoint
 import pytest
 import unittest
 
 from smart_open.transport import (
     register_transport, get_transport, _REGISTRY, _ERRORS, _register_transport_entry_point
 )
+from smart_open.utils import importlib_metadata
+
+EntryPoint = importlib_metadata.EntryPoint
 
 
 def unregister_transport(x):

--- a/smart_open/tests/test_transport.py
+++ b/smart_open/tests/test_transport.py
@@ -1,15 +1,43 @@
 # -*- coding: utf-8 -*-
+from importlib.metadata import EntryPoint
 import pytest
 import unittest
 
-from smart_open.transport import register_transport, get_transport
+from smart_open.transport import (
+    register_transport, get_transport, _REGISTRY, _ERRORS, _register_transport_entry_point
+)
+
+
+def unregister_transport(x):
+    if x in _REGISTRY:
+        del _REGISTRY[x]
+    if x in _ERRORS:
+        del _ERRORS[x]
+
+
+def assert_transport_not_registered(scheme):
+    with pytest.raises(NotImplementedError):
+        get_transport(scheme)
+
+
+def assert_transport_registered(scheme):
+    transport = get_transport(scheme)
+    assert transport.SCHEME == scheme
 
 
 class TransportTest(unittest.TestCase):
+    def tearDown(self):
+        unregister_transport("foo")
+        unregister_transport("missing")
 
     def test_registry_requires_declared_schemes(self):
         with pytest.raises(ValueError):
             register_transport('smart_open.tests.fixtures.no_schemes_transport')
+
+    def test_registry_valid_transport(self):
+        assert_transport_not_registered("foo")
+        register_transport('smart_open.tests.fixtures.good_transport')
+        assert_transport_registered("foo")
 
     def test_registry_errors_on_double_register_scheme(self):
         register_transport('smart_open.tests.fixtures.good_transport')
@@ -18,5 +46,31 @@ class TransportTest(unittest.TestCase):
 
     def test_registry_errors_get_transport_for_module_with_missing_deps(self):
         register_transport('smart_open.tests.fixtures.missing_deps_transport')
+        with pytest.raises(ImportError):
+            get_transport("missing")
+
+    def test_register_entry_point_valid(self):
+        assert_transport_not_registered("foo")
+        _register_transport_entry_point(EntryPoint(
+            "foo",
+            "smart_open.tests.fixtures.good_transport",
+            "smart_open_transport",
+        ))
+        assert_transport_registered("foo")
+
+    def test_register_entry_point_catch_bad_data(self):
+        _register_transport_entry_point(EntryPoint(
+            "invalid",
+            "smart_open.some_totaly_invalid_module",
+            "smart_open_transport",
+        ))
+
+    def test_register_entry_point_for_module_with_missing_deps(self):
+        assert_transport_not_registered("missing")
+        _register_transport_entry_point(EntryPoint(
+            "missing",
+            "smart_open.tests.fixtures.missing_deps_transport",
+            "smart_open_transport",
+        ))
         with pytest.raises(ImportError):
             get_transport("missing")

--- a/smart_open/tests/test_utils.py
+++ b/smart_open/tests/test_utils.py
@@ -59,3 +59,14 @@ def test_check_kwargs():
 def test_safe_urlsplit(url, expected):
     actual = smart_open.utils.safe_urlsplit(url)
     assert actual == urllib.parse.SplitResult(*expected)
+
+
+def test_find_entry_points():
+    # Installed through setup.py tests requirements
+    eps = smart_open.utils.find_entry_points("pytest11")
+    eps_names = {ep.name for ep in eps}
+    assert "rerunfailures" in eps_names
+
+    # Part of setuptools
+    eps = smart_open.utils.find_entry_points("distutils.commands")
+    assert len(eps) > 0

--- a/smart_open/transport.py
+++ b/smart_open/transport.py
@@ -11,10 +11,10 @@ The main entrypoint is :func:`get_transport`.  See also :file:`extending.md`.
 
 """
 import importlib
-import importlib.metadata
 import logging
 
 import smart_open.local_file
+from smart_open.utils import find_entry_points
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +111,7 @@ def _register_transport_entry_point(ep):
         logger.warning("Fail to load smart_open transport extension: %s (target: %s)", ep.name, ep.value)
 
 
-for ep in importlib.metadata.entry_points().select(group='smart_open_transport'):
+for ep in find_entry_points(group='smart_open_transport'):
     _register_transport_entry_point(ep)
 
 SUPPORTED_SCHEMES = tuple(sorted(_REGISTRY.keys()))

--- a/smart_open/transport.py
+++ b/smart_open/transport.py
@@ -11,6 +11,7 @@ The main entrypoint is :func:`get_transport`.  See also :file:`extending.md`.
 
 """
 import importlib
+import importlib.metadata
 import logging
 
 import smart_open.local_file
@@ -101,6 +102,17 @@ register_transport('smart_open.http')
 register_transport('smart_open.s3')
 register_transport('smart_open.ssh')
 register_transport('smart_open.webhdfs')
+
+
+def _register_transport_entry_point(ep):
+    try:
+        register_transport(ep.value)
+    except Exception:
+        logger.warning("Fail to load smart_open transport extension: %s (target: %s)", ep.name, ep.value)
+
+
+for ep in importlib.metadata.entry_points().select(group='smart_open_transport'):
+    _register_transport_entry_point(ep)
 
 SUPPORTED_SCHEMES = tuple(sorted(_REGISTRY.keys()))
 """The transport schemes that the local installation of ``smart_open`` supports."""

--- a/smart_open/utils.py
+++ b/smart_open/utils.py
@@ -10,7 +10,15 @@
 
 import inspect
 import logging
+import sys
 import urllib.parse
+
+# Library has been added in version 3.8
+# See: https://docs.python.org/3.8/library/importlib.metadata.html#module-importlib.metadata
+if sys.version_info >= (3, 8):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -189,3 +197,30 @@ def safe_urlsplit(url):
 
     path = sr.path.replace(placeholder, '?')
     return urllib.parse.SplitResult(sr.scheme, sr.netloc, path, '', '')
+
+
+def find_entry_points(group):
+    """Search packages entry points and filter value based
+    on their group name.
+
+    Parameters
+    ----------
+    group: str
+        An entry point group name to filter registered entry points.
+
+    Returns
+    -------
+    list[EntryPoint]
+        Valid registered entry points.
+    """
+
+    try:
+        # Try new filter API (python 3.10+ and importlib_metadata 3.6+).
+        #
+        # Check "Compatibility Note" here:
+        # https://docs.python.org/3.10/library/importlib.metadata.html#entry-points
+        return importlib_metadata.entry_points(group=group)
+    except Exception:
+        # Legacy API
+        eps = importlib_metadata.entry_points()
+        return eps.get(group, [])


### PR DESCRIPTION
#### Motivation

For now, if user install a package that provide  new `smart_open` transport mechanism, it cannot be automatically registered.
It would be great if `smart_open` could be extended using [setuptools / entry_points](https://setuptools.pypa.io/en/latest/userguide/entry_point.html#advertising-behavior) capabilities.

Fixes #691 

##### Example use case

**Please note**: schema is not relevant here.

In package `smart_ext_transport` I have following file:

```python
# smart_ext_transport/custom_transport.py
SCHEMA = "custom"
...
```

##### Current situation

The only way to load extension for now are listed bellow:

**Option 1**: using `register_transport` everywhere and every time it might be required :cry:

```python
register_transport("smart_ext_transport.custom_transport")
```

**Option 2**: using `__init__.py` and `import` statement:

Adding:

```python
# smart_ext_transport/__init__.py
register_transport("smart_ext_transport.custom_transport")
```

Then every time `custom` schema might be needed:

```python
import smart_ext_transport
```

##### Improved situation with setuptools

In `setup.py` from `smart_ext_transport` we may add:

```python
from setuptools import setup

setup(
    name="smart_ext_transport",
    packages=["smart_ext_transport"],
    entry_points={"smart_open_transport": [
        "custom = smart_ext_transport.custom_transport"],
    },
)
```

Once package is installed, `smart_open` can automatically load every plugin that is registered using setuptools entry points.
User will no longer have to import package to register extension manually.

This is how pytest / setuptools CLI / flake8 / jupyter nb convert works for example.

Handling correct version of `importlib.metadata` is mainly inspired from `pytest` codebase.

See my issue about this PR: #691 

##### What it may change for the future ?

Future extension to `smart_open` may be moved out of core library.

Example use case may be new extensions libraries like:
- `smart_open_zstd` to add `zstandard` compress
- `smart_open_xxx_cloud` to add new cloud provider without having to implementing it in core library (like AliCloud).

Core library will only have to maintain base / robust API and no longer have to support all possible URI provider / compression standard.

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass
