### PR TITLE
Allow passing additional kwargs for Azure writes

### DIFF
--- a/smart_open/tests/test_azure.py
+++ b/smart_open/tests/test_azure.py
@@ -600,8 +600,12 @@ class WriterTest(unittest.TestCase):
         container_client = CLIENT.get_container_client(CONTAINER_NAME)
         blob_client = container_client.get_blob_client(blob_name)
 
-        with smart_open.azure.Writer(
-            CONTAINER_NAME, blob_name, blob_client, metadata={"name": blob_name}
+        with smart_open.open(
+            "azure://%s/%s" % (CONTAINER_NAME, blob_name),
+            "wb",
+            transport_params={
+                "client": blob_client, "blob_kwargs": {"metadata": {"name": blob_name}}
+            },
         ) as fout:
             fout.write(test_string)
 

--- a/smart_open/tests/test_azure.py
+++ b/smart_open/tests/test_azure.py
@@ -51,10 +51,12 @@ class FakeBlobClient(object):
         self.__contents = io.BytesIO()
         self._staged_contents = {}
 
-    def commit_block_list(self, block_list):
+    def commit_block_list(self, block_list, metadata=None):
         data = b''.join([self._staged_contents[block_blob['id']] for block_blob in block_list])
         self.__contents = io.BytesIO(data)
-        self.set_blob_metadata(dict(size=len(data)))
+        metadata = metadata or {}
+        metadata.update({"size": len(data)})
+        self.set_blob_metadata(metadata)
         self._container_client.register_blob_client(self)
 
     def delete_blob(self):
@@ -589,6 +591,28 @@ class WriterTest(unittest.TestCase):
             transport_params=dict(client=container_client),
         ))
         assert output == [test_string]
+
+    def test_write_blob_client(self):
+        """Does writing into Azure Blob Storage work correctly?"""
+        test_string = u"žluťoučký koníček".encode('utf8')
+        blob_name = "test_write_blob_client_%s" % BLOB_NAME
+
+        container_client = CLIENT.get_container_client(CONTAINER_NAME)
+        blob_client = container_client.get_blob_client(blob_name)
+
+        with smart_open.azure.Writer(
+            CONTAINER_NAME, blob_name, blob_client, metadata={"name": blob_name}
+        ) as fout:
+            fout.write(test_string)
+
+        self.assertEqual(blob_client.get_blob_properties()["name"], blob_name)
+
+        output = list(smart_open.open(
+            "azure://%s/%s" % (CONTAINER_NAME, blob_name),
+            "rb",
+            transport_params=dict(client=CLIENT),
+        ))
+        self.assertEqual(output, [test_string])
 
     def test_incorrect_input(self):
         """Does azure write fail on incorrect input?"""


### PR DESCRIPTION
#### Title

Allow passing additional kwargs for Azure writes

#### Motivation

- Fixes #701 

#### Tests

Tests that `smart_open.azure.Writer` accepts metadata, and retrieving it afterwards (with `FakeBlobClient.get_blob_properties`).

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass

#### Workflow

Please avoid rebasing and force-pushing to the branch of the PR once a review is in progress.
Rebasing can make your commits look a bit cleaner, but it also makes life more difficult from the reviewer, because they are no longer able to distinguish between code that has already been reviewed, and unreviewed code.
