### PR TITLE
Add cert parameter to http transport params

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -124,6 +124,8 @@ FUNCTIONS
             The username for authenticating over HTTP
         password: str, optional
             The password for authenticating over HTTP
+        cert: str/tuple, optional
+            If String, path to ssl client cert file (.pem). If Tuple, (‘cert’, ‘key’)
         headers: dict, optional
             Any headers to send in the request. If ``None``, the default headers are sent:
             ``{'Accept-Encoding': 'identity'}``. To use no headers at all,

--- a/smart_open/http.py
+++ b/smart_open/http.py
@@ -49,7 +49,7 @@ def open_uri(uri, mode, transport_params):
     return open(uri, mode, **kwargs)
 
 
-def open(uri, mode, kerberos=False, user=None, password=None, headers=None, timeout=None):
+def open(uri, mode, kerberos=False, user=None, password=None, cert= None, headers=None, timeout=None):
     """Implement streamed reader from a web site.
 
     Supports Kerberos and Basic HTTP authentication.
@@ -66,6 +66,8 @@ def open(uri, mode, kerberos=False, user=None, password=None, headers=None, time
         The username for authenticating over HTTP
     password: str, optional
         The password for authenticating over HTTP
+    cert: str/tuple, optional
+        if String, path to ssl client cert file (.pem). If Tuple, (‘cert’, ‘key’)
     headers: dict, optional
         Any headers to send in the request. If ``None``, the default headers are sent:
         ``{'Accept-Encoding': 'identity'}``. To use no headers at all,
@@ -80,7 +82,8 @@ def open(uri, mode, kerberos=False, user=None, password=None, headers=None, time
     if mode == constants.READ_BINARY:
         fobj = SeekableBufferedInputBase(
             uri, mode, kerberos=kerberos,
-            user=user, password=password, headers=headers, timeout=timeout,
+            user=user, password=password, cert=cert, 
+            headers=headers, timeout=timeout,
         )
         fobj.name = os.path.basename(urllib.parse.urlparse(uri).path)
         return fobj
@@ -90,7 +93,8 @@ def open(uri, mode, kerberos=False, user=None, password=None, headers=None, time
 
 class BufferedInputBase(io.BufferedIOBase):
     def __init__(self, url, mode='r', buffer_size=DEFAULT_BUFFER_SIZE,
-                 kerberos=False, user=None, password=None, headers=None, timeout=None):
+                 kerberos=False, user=None, password=None, cert=None, 
+                 headers=None, timeout=None):
         if kerberos:
             import requests_kerberos
             auth = requests_kerberos.HTTPKerberosAuth()
@@ -112,6 +116,7 @@ class BufferedInputBase(io.BufferedIOBase):
         self.response = requests.get(
             url,
             auth=auth,
+            cert=cert,
             stream=True,
             headers=self.headers,
             timeout=self.timeout,
@@ -204,13 +209,15 @@ class BufferedInputBase(io.BufferedIOBase):
 class SeekableBufferedInputBase(BufferedInputBase):
     """
     Implement seekable streamed reader from a web site.
-    Supports Kerberos and Basic HTTP authentication.
+    Supports Kerberos, client certificate and Basic HTTP authentication.
     """
 
     def __init__(self, url, mode='r', buffer_size=DEFAULT_BUFFER_SIZE,
-                 kerberos=False, user=None, password=None, headers=None, timeout=None):
+                 kerberos=False, user=None, password=None, cert=None, 
+                 headers=None, timeout=None):
         """
         If Kerberos is True, will attempt to use the local Kerberos credentials.
+        If cert is set, will try to use a client certificate
         Otherwise, will try to use "basic" HTTP authentication via username/password.
 
         If none of those are set, will connect unauthenticated.
@@ -230,6 +237,7 @@ class SeekableBufferedInputBase(BufferedInputBase):
         else:
             self.headers = headers
 
+        self.cert = cert
         self.timeout = timeout
 
         self.buffer_size = buffer_size
@@ -325,6 +333,7 @@ class SeekableBufferedInputBase(BufferedInputBase):
             self.url,
             auth=self.auth,
             stream=True,
+            cert=self.cert,
             headers=self.headers,
             timeout=self.timeout,
         )

--- a/smart_open/http.py
+++ b/smart_open/http.py
@@ -49,7 +49,8 @@ def open_uri(uri, mode, transport_params):
     return open(uri, mode, **kwargs)
 
 
-def open(uri, mode, kerberos=False, user=None, password=None, cert= None, headers=None, timeout=None):
+def open(uri, mode, kerberos=False, user=None, password=None, cert= None,
+         headers=None, timeout=None):
     """Implement streamed reader from a web site.
 
     Supports Kerberos and Basic HTTP authentication.
@@ -82,7 +83,7 @@ def open(uri, mode, kerberos=False, user=None, password=None, cert= None, header
     if mode == constants.READ_BINARY:
         fobj = SeekableBufferedInputBase(
             uri, mode, kerberos=kerberos,
-            user=user, password=password, cert=cert, 
+            user=user, password=password, cert=cert,
             headers=headers, timeout=timeout,
         )
         fobj.name = os.path.basename(urllib.parse.urlparse(uri).path)
@@ -93,7 +94,7 @@ def open(uri, mode, kerberos=False, user=None, password=None, cert= None, header
 
 class BufferedInputBase(io.BufferedIOBase):
     def __init__(self, url, mode='r', buffer_size=DEFAULT_BUFFER_SIZE,
-                 kerberos=False, user=None, password=None, cert=None, 
+                 kerberos=False, user=None, password=None, cert=None,
                  headers=None, timeout=None):
         if kerberos:
             import requests_kerberos
@@ -213,7 +214,7 @@ class SeekableBufferedInputBase(BufferedInputBase):
     """
 
     def __init__(self, url, mode='r', buffer_size=DEFAULT_BUFFER_SIZE,
-                 kerberos=False, user=None, password=None, cert=None, 
+                 kerberos=False, user=None, password=None, cert=None,
                  headers=None, timeout=None):
         """
         If Kerberos is True, will attempt to use the local Kerberos credentials.

--- a/smart_open/http.py
+++ b/smart_open/http.py
@@ -49,7 +49,7 @@ def open_uri(uri, mode, transport_params):
     return open(uri, mode, **kwargs)
 
 
-def open(uri, mode, kerberos=False, user=None, password=None, cert= None,
+def open(uri, mode, kerberos=False, user=None, password=None, cert=None,
          headers=None, timeout=None):
     """Implement streamed reader from a web site.
 

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -449,6 +449,18 @@ class SmartOpenHttpTest(unittest.TestCase):
         self.assertTrue(actual_request.headers['Authorization'].startswith('Basic '))
 
     @responses.activate
+    def test_http_cert(self):
+        """Does http authentication work correctly"""
+        responses.add(responses.GET, "http://127.0.0.1/index.html",
+                      body='line1\nline2', stream=True)
+        cert_path = '/path/to/my/cert.pem'
+        tp = dict(cert=cert_path)
+        smart_open.open("http://127.0.0.1/index.html", transport_params=tp)
+        self.assertEqual(len(responses.calls), 1)
+        actual_request = responses.calls[0].request
+        self.assertEqual(cert_path, actual_request.req_kwargs['cert'])
+
+    @responses.activate
     def _test_compressed_http(self, suffix, query):
         """Can open <suffix> via http?"""
         assert suffix in ('.gz', '.bz2')

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -450,7 +450,7 @@ class SmartOpenHttpTest(unittest.TestCase):
 
     @responses.activate
     def test_http_cert(self):
-        """Does http authentication work correctly"""
+        """Does cert parameter get passed to requests"""
         responses.add(responses.GET, "http://127.0.0.1/index.html",
                       body='line1\nline2', stream=True)
         cert_path = '/path/to/my/cert.pem'


### PR DESCRIPTION
#### Allow client certificate authentication for http

#### Motivation

Although it seems to be a simple case of adding http transport parameters and passing them  to `requests`, there is no support for client certificate authentication for http

#### Tests

Added `test_smart_open::SmartOpenHttpTest::test_http_cert`

