### PR TITLE
Fix quadratic time ByteBuffer operations

### DIFF
--- a/benchmark/bytebuffer_bench.py
+++ b/benchmark/bytebuffer_bench.py
@@ -1,0 +1,9 @@
+import time
+from smart_open.bytebuffer import ByteBuffer
+
+buffer = ByteBuffer()
+
+start = time.time()
+for _ in range(1000):
+    assert buffer.fill([b"X" * 1000]) == 1000
+print(time.time() - start)

--- a/benchmark/bytebuffer_bench.py
+++ b/benchmark/bytebuffer_bench.py
@@ -1,9 +1,34 @@
 import time
+import sys
+
+import smart_open
 from smart_open.bytebuffer import ByteBuffer
 
-buffer = ByteBuffer()
 
-start = time.time()
-for _ in range(1000):
-    assert buffer.fill([b"X" * 1000]) == 1000
-print(time.time() - start)
+def raw_bytebuffer_benchmark():
+    buffer = ByteBuffer()
+
+    start = time.time()
+    for _ in range(10_000):
+        assert buffer.fill([b"X" * 1000]) == 1000
+    return time.time() - start
+
+
+def file_read_benchmark(filename):
+    file = smart_open.open(filename, mode="rb")
+
+    start = time.time()
+    read = file.read(100_000_000)
+    end = time.time()
+
+    if len(read) < 100_000_000:
+        print("File smaller than 100MB")
+
+    return end - start
+
+
+print("Raw ByteBuffer benchmark:", raw_bytebuffer_benchmark())
+
+if len(sys.argv) > 1:
+    bench_result = file_read_benchmark(sys.argv[1])
+    print("File read benchmark", bench_result)

--- a/smart_open/bytebuffer.py
+++ b/smart_open/bytebuffer.py
@@ -105,12 +105,12 @@ class ByteBuffer(object):
         if size < 0 or size > len(self):
             size = len(self)
 
-        part = self._bytes[self._pos:self._pos+size]
+        part = bytes(self._bytes[self._pos:self._pos+size])
         return part
 
     def empty(self):
         """Remove all bytes from the buffer"""
-        self._bytes = b''
+        self._bytes = bytearray()
         self._pos = 0
 
     def fill(self, source, size=-1):
@@ -151,7 +151,7 @@ class ByteBuffer(object):
         if hasattr(source, 'read'):
             new_bytes = source.read(size)
         else:
-            new_bytes = b''
+            new_bytes = bytearray()
             for more_bytes in source:
                 new_bytes += more_bytes
                 if len(new_bytes) >= size:


### PR DESCRIPTION
`bytes` is immutable, so repeated appends is quadratic-time.

`bytearray` is the mutable version of `bytes`.