### PR TITLE
Allow passing storage_class via gcs blob_properties

### DIFF
--- a/smart_open/gcs.py
+++ b/smart_open/gcs.py
@@ -408,7 +408,10 @@ class Writer(io.BufferedIOBase):
         if client is None:
             client = google.cloud.storage.Client()
         self._client = client
-        self._blob = self._client.bucket(bucket).blob(blob)  # type: google.cloud.storage.Blob
+        _bucket = self._client.bucket(bucket)
+        if blob_properties and 'storage_class' in blob_properties:
+            _bucket.storage_class = blob_properties.pop('storage_class')
+        self._blob = _bucket.blob(blob)  # type: google.cloud.storage.Blob
         assert min_part_size % _REQUIRED_CHUNK_MULTIPLE == 0, 'min part size must be a multiple of 256KB'
         assert min_part_size >= _MIN_MIN_PART_SIZE, 'min part size must be greater than 256KB'
         self._min_part_size = min_part_size

--- a/smart_open/tests/test_gcs.py
+++ b/smart_open/tests/test_gcs.py
@@ -139,6 +139,7 @@ class FakeBlob(object):
         self._bucket = bucket  # type: FakeBucket
         self._exists = False
         self.__contents = io.BytesIO()
+        self.storage_class = getattr(bucket, 'storage_class', None)
 
         self._create_if_not_exists()
 
@@ -807,12 +808,14 @@ class WriterTest(unittest.TestCase):
         smart_open_write = smart_open.gcs.Writer(BUCKET_NAME, WRITE_BLOB_NAME,
             blob_properties={
                 "content_type": "random/x-test",
-                "content_encoding": "coded"
+                "content_encoding": "coded",
+                "storage_class": "STANDARD_STORAGE_CLASS"
             }
         )
         with smart_open_write as fout:  # noqa
             assert fout._blob.content_type == "random/x-test"
             assert fout._blob.content_encoding == "coded"
+            assert fout._blob.storage_class == "STANDARD_STORAGE_CLASS"
 
     def test_gzip(self):
         expected = u'а не спеть ли мне песню... о любви'.encode('utf-8')


### PR DESCRIPTION
#### Title

Allow passing storage_class via gcs blob_properties

#### Motivation

We want to upload files to gcs with a specific storage_class, [similar](https://github.com/ddelange/pypicloud/blob/6edcc4269f1799bdd7b7a49539aa3ca8037b9ff4/pypicloud/storage/s3.py#L210) to s3.

It turns out you can't set a storage_class to a gcs blob object directly ref https://github.com/stevearc/pypicloud/issues/317.

Luckily, there is a [local-only](https://github.com/googleapis/python-storage/blob/8d5a6c3557c48fb885e7e5966d1d906398edc399/google/cloud/storage/_helpers.py#L254-L255) setter for the bucket. This can be used to set the default storage class temporarily, into which the blob will be uploaded.

#### Tests

If you're fixing a bug, consider [test-driven development](https://en.wikipedia.org/wiki/Test-driven_development):

1. Create a unit test that demonstrates the bug. The test should **fail**.
2. Implement your bug fix.
3. The test you created should now **pass**.

If you're implementing a new feature, include unit tests for it.

Make sure all existing unit tests pass.
You can run them locally using:

    pytest smart_open

If there are any failures, please fix them before creating the PR (or mark it as WIP, see below).

#### Work in progress

If you're still working on your PR, include "WIP" in the title.
We'll skip reviewing it for the time being.
Once you're ready to review, remove the "WIP" from the title, and ping one of the maintainers (e.g. mpenkov).

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass

#### Workflow

Please avoid rebasing and force-pushing to the branch of the PR once a review is in progress.
Rebasing can make your commits look a bit cleaner, but it also makes life more difficult from the reviewer, because they are no longer able to distinguish between code that has already been reviewed, and unreviewed code.
