### PR TITLE
Allow passing predefined_acl via gcs blob_properties

### DIFF
--- a/smart_open/tests/test_gcs.py
+++ b/smart_open/tests/test_gcs.py
@@ -142,12 +142,13 @@ class FakeBlob(object):
 
         self._create_if_not_exists()
 
-    def create_resumable_upload_session(self):
+    def create_resumable_upload_session(self, predefined_acl=None):
         resumeable_upload_url = RESUMABLE_SESSION_URI_TEMPLATE % dict(
             bucket=self._bucket.name,
             upload_id=str(uuid.uuid4()),
         )
         upload = FakeBlobUpload(resumeable_upload_url, self)
+        self.acl = predefined_acl
         self._bucket.register_upload(upload)
         return resumeable_upload_url
 
@@ -807,12 +808,14 @@ class WriterTest(unittest.TestCase):
         smart_open_write = smart_open.gcs.Writer(BUCKET_NAME, WRITE_BLOB_NAME,
             blob_properties={
                 "content_type": "random/x-test",
-                "content_encoding": "coded"
+                "content_encoding": "coded",
+                "predefined_acl": "publicRead"
             }
         )
         with smart_open_write as fout:  # noqa
             assert fout._blob.content_type == "random/x-test"
             assert fout._blob.content_encoding == "coded"
+            assert fout._blob.acl == "publicRead"
 
     def test_gzip(self):
         expected = u'а не спеть ли мне песню... о любви'.encode('utf-8')


### PR DESCRIPTION
#### Title

Allow passing predefined_acl via gcs blob_properties

#### Motivation

Similar to #726, it should be possible to set an ACL for gcs uploads, as it is for s3.

It turns out you can't set an ACL to a gcs blob object directly ref https://github.com/stevearc/pypicloud/issues/317.

- Blocked by https://github.com/googleapis/python-storage/pull/878
- Blocked by https://github.com/googleapis/python-storage/pull/838

#### Tests

If you're fixing a bug, consider [test-driven development](https://en.wikipedia.org/wiki/Test-driven_development):

1. Create a unit test that demonstrates the bug. The test should **fail**.
2. Implement your bug fix.
3. The test you created should now **pass**.

If you're implementing a new feature, include unit tests for it.

Make sure all existing unit tests pass.
You can run them locally using:

    pytest smart_open

If there are any failures, please fix them before creating the PR (or mark it as WIP, see below).

#### Work in progress

If you're still working on your PR, include "WIP" in the title.
We'll skip reviewing it for the time being.
Once you're ready to review, remove the "WIP" from the title, and ping one of the maintainers (e.g. mpenkov).

#### Checklist

Before you create the PR, please make sure you have:

- [ ] Picked a concise, informative and complete title
- [ ] Clearly explained the motivation behind the PR
- [ ] Linked to any existing issues that your PR will be solving
- [ ] Included tests for any new functionality
- [ ] Checked that all unit tests pass

#### Workflow

Please avoid rebasing and force-pushing to the branch of the PR once a review is in progress.
Rebasing can make your commits look a bit cleaner, but it also makes life more difficult from the reviewer, because they are no longer able to distinguish between code that has already been reviewed, and unreviewed code.
