### PR TITLE
added buffer_size parameter to http module

### DIFF
--- a/smart_open/http.py
+++ b/smart_open/http.py
@@ -50,7 +50,7 @@ def open_uri(uri, mode, transport_params):
 
 
 def open(uri, mode, kerberos=False, user=None, password=None, cert=None,
-         headers=None, timeout=None):
+         headers=None, timeout=None, buffer_size=DEFAULT_BUFFER_SIZE):
     """Implement streamed reader from a web site.
 
     Supports Kerberos and Basic HTTP authentication.
@@ -73,6 +73,8 @@ def open(uri, mode, kerberos=False, user=None, password=None, cert=None,
         Any headers to send in the request. If ``None``, the default headers are sent:
         ``{'Accept-Encoding': 'identity'}``. To use no headers at all,
         set this variable to an empty dict, ``{}``.
+    buffer_size: int, optional
+        The buffer size to use when performing I/O.
 
     Note
     ----
@@ -82,7 +84,7 @@ def open(uri, mode, kerberos=False, user=None, password=None, cert=None,
     """
     if mode == constants.READ_BINARY:
         fobj = SeekableBufferedInputBase(
-            uri, mode, kerberos=kerberos,
+            uri, mode, buffer_size=buffer_size, kerberos=kerberos,
             user=user, password=password, cert=cert,
             headers=headers, timeout=timeout,
         )


### PR DESCRIPTION
#### Motivation

Added the buffer_size parameter to the http module. This provides more functionality to the http module and is more consistent with the other modules that support it already. The base code for the buffer_size was already there, it was just set to a default buffer size without the option for user input.

Sorry it took so long for me to get to this...

- Fixes #700 

#### Tests

The pytest for test_http.py ran successfully (locally).

#### Checklist

Before you create the PR, please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [ ] Included tests for any new functionality
- [x] Checked that all unit tests pass
