### PR TITLE
Add flake8 config globally

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,9 @@
+[flake8]
+# E121: Continuation line under-indented for hanging indent
+# E123: Continuation line missing indentation or outdented
+# E125:	Continuation line with same indent as next logical line
+# E128: Continuation line under-indented for visual indent
+# E226: Missing whitespace around arithmetic operator
+# W503: Line break occurred before a binary operator
+ignore=E121,E123,E125,E128,E226,W503
+max-line-length=110

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
         run: python -m pip install flake8
 
       - name: Run flake8 linter (source)
-        run: flake8 --ignore E12,E226,W503 --max-line-length 110 --show-source smart_open
+        run: flake8 --show-source smart_open
 
   unit_tests:
     needs: [linters]

--- a/integration-tests/test_s3.py
+++ b/integration-tests/test_s3.py
@@ -11,7 +11,6 @@ import contextlib
 import io
 import os
 import random
-import subprocess
 import string
 
 import boto3


### PR DESCRIPTION
When making a PR on the project I got caught out by the `flake8` linter and the build failed. Equally, I wasnt sure which formatter was in use by the project.

By configuring flake8 globally this it makes it possible to not get caught out by the CI linting step and ensure the code is formatted correctly on first commit. I guess this is somewhat similar to the changes in #718  but we worried about different aspects of contributing. Both cover different aspects that could be helpful.

I have made the list of errors that are faliling slightly more explicit to just the ones that are failing but equally happy to relax that again if prefered.