### PR TITLE
Fix avoidable S3 race condition (#693)

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -1193,7 +1193,7 @@ def iter_bucket(
         while True:
             try:
                 (key, content) = result_iterator.__next__()
-                if True or key_no % 1000 == 0:
+                if key_no % 1000 == 0:
                     logger.info(
                         "yielding key #%i: %s, size %i (total %.1fMB)",
                         key_no, key, len(content), total_size / 1024.0 ** 2
@@ -1204,7 +1204,11 @@ def iter_bucket(
                     # we were asked to output only a limited number of keys => we're done
                     break
             except botocore.exceptions.ClientError as err:
-                # ignore 404 not found errors
+                #
+                # ignore 404 not found errors: they mean the object was deleted
+                # after we listed the contents of the bucket, but before we
+                # downloaded the object.
+                #
                 if not ('Error' in err.response and err.response['Error'].get('Code') == '404'):
                     raise err
             except StopIteration:


### PR DESCRIPTION
#### Motivation

Fixes #693 

As proposed by @ronkorving, it may be common for the s3 `iter_bucket` function to encounter `404 not found` errors due to the s3 `list bucket` command sometimes returning recently deleted keys. So a workaround of this problem is to surpress 404 errors for `iter_bucket`, and instead log them as warnings for the user to assess.

#### Tests

All existing tests related to `iter_bucket` within `s3.py` pass. I also added two new tests: `test_iter_bucket_404` and `test_iter_bucket_non_404`. The first test simulates the scenario with `iter_bucket` for a key throws a 404 error, and expects that error to be suppressed and for computation to carry on for the rest of the keys. The latter test simulates the scenario where a non 404 error occurs, in which case it should not be suppressed. 
