### PR TITLE
pass additional client_kwargs from the top level transport_params["client_kwargs"]

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -822,6 +822,7 @@ multipart upload may fail")
                 Bucket=self._bucket,
                 Key=self._key,
                 Body=b'',
+                **self._client.kwargs
             )
             logger.debug('%s: wrote 0 bytes to imitate multipart upload', self)
         self._upload_id = None
@@ -1004,6 +1005,7 @@ class SinglepartWriter(io.BufferedIOBase):
                 Bucket=self._bucket,
                 Key=self._key,
                 Body=self._buf,
+                **self._client.kwargs
             )
         except botocore.client.ClientError as e:
             raise ValueError(

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -761,6 +761,7 @@ multipart upload may fail")
                 self._client.create_multipart_upload,
                 Bucket=bucket,
                 Key=key,
+                **self._client.kwargs,
             )
             self._upload_id = _retry_if_failed(partial)['UploadId']
         except botocore.client.ClientError as error:


### PR DESCRIPTION
In #705 , it says the feature is already there. however, it is not implemented yet 

#### Summary

Based on the [source code](https://github.com/RaRe-Technologies/smart_open/blob/develop/smart_open/s3.py#L1003), the ``client_kwargs`` is declared but not actually used in the low level API.

Basically I just changed this:

```python
self._client.put_object(
      Bucket=self._bucket,
      Key=self._key,
      Body=self._buf,
  )
```

to this

```python
self._client.put_object(
      Bucket=self._bucket,
      Key=self._key,
      Body=self._buf,
      **self._client.kwargs
)
```

#### Motivation

See discussion in #705 
