### PR TITLE
Add FTPS support (#33)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -138,7 +138,9 @@ jobs:
       - run: bash ci_helpers/helpers.sh enable_moto_server
         if: ${{ matrix.moto_server }}
       
-      - run: sudo apt-get install vsftpd ; bash ci_helpers/helpers.sh create_ftp_ftps_servers
+      - run: |
+          sudo apt-get install vsftpd
+          sudo bash ci_helpers/helpers.sh create_ftp_ftps_servers
         env:
           HOME_DIR: /home/user
           USER: user
@@ -155,7 +157,7 @@ jobs:
       - run: bash ci_helpers/helpers.sh disable_moto_server
         if: ${{ matrix.moto_server }}
       
-      - run: bash ci_helpers/helpers.sh delete_ftp_ftps_servers
+      - run: sudo bash ci_helpers/helpers.sh delete_ftp_ftps_servers
 
   benchmarks:
     needs: [linters,unit_tests]

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -138,7 +138,13 @@ jobs:
       - run: bash ci_helpers/helpers.sh enable_moto_server
         if: ${{ matrix.moto_server }}
       
-      - run: bash ci_helpers/helpers.sh create_ftp_server
+      - run: sudo apt-get install vsftpd ; bash ci_helpers/helpers.sh create_ftp_ftps_servers
+        env:
+          HOME_DIR: /home/user
+          USER: user
+          PASS: 123
+          FTP_PORT: 21
+          FTPS_PORT: 90
 
       - name: Run integration tests
         run: python ci_helpers/run_integration_tests.py
@@ -149,7 +155,7 @@ jobs:
       - run: bash ci_helpers/helpers.sh disable_moto_server
         if: ${{ matrix.moto_server }}
       
-      - run: bash ci_helpers/helpers.sh delete_ftp_server
+      - run: bash ci_helpers/helpers.sh delete_ftp_ftps_servers
 
   benchmarks:
     needs: [linters,unit_tests]

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -141,12 +141,6 @@ jobs:
       - run: |
           sudo apt-get install vsftpd
           sudo bash ci_helpers/helpers.sh create_ftp_ftps_servers
-        env:
-          HOME_DIR: /home/user
-          USER: user
-          PASS: 123
-          FTP_PORT: 21
-          FTPS_PORT: 90
 
       - name: Run integration tests
         run: python ci_helpers/run_integration_tests.py

--- a/ci_helpers/helpers.sh
+++ b/ci_helpers/helpers.sh
@@ -11,6 +11,7 @@ create_ftp_ftps_servers(){
   #
   # Must be run as root
   #
+  HOME_DIR=/home/user
   mkdir $HOME_DIR
   useradd -p $(echo $PASS | openssl passwd -1 -stdin) -d $HOME_DIR $USER
   chown $USER:$USER $HOME_DIR

--- a/ci_helpers/helpers.sh
+++ b/ci_helpers/helpers.sh
@@ -8,9 +8,12 @@ enable_moto_server(){
 }
 
 create_ftp_ftps_servers(){
-  sudo mkdir $HOME_DIR
-  sudo useradd -p $(echo $PASS | openssl passwd -1 -stdin) -d $HOME_DIR $USER
-  sudo chown $USER:$USER $HOME_DIR
+  #
+  # Must be run as root
+  #
+  mkdir $HOME_DIR
+  useradd -p $(echo $PASS | openssl passwd -1 -stdin) -d $HOME_DIR $USER
+  chown $USER:$USER $HOME_DIR
 
   server_setup='''
 listen=YES
@@ -30,12 +33,12 @@ force_local_logins_ssl=NO
 require_ssl_reuse=NO
 '''
 
-  sudo cp /etc/vsftpd.conf /etc/vsftpd-ssl.conf
-  echo -e "$server_setup\nlisten_port=${FTP_PORT}" | sudo tee -a /etc/vsftpd.conf
-  echo -e "$server_setup\nlisten_port=${FTPS_PORT}\n$additional_ssl_setup" | sudo tee -a /etc/vsftpd-ssl.conf
+  cp /etc/vsftpd.conf /etc/vsftpd-ssl.conf
+  echo -e "$server_setup\nlisten_port=${FTP_PORT}" >> /etc/vsftpd.conf
+  echo -e "$server_setup\nlisten_port=${FTPS_PORT}\n$additional_ssl_setup" >> /etc/vsftpd-ssl.conf
 
-  sudo service vsftpd restart
-  sudo vsftpd /etc/vsftpd-ssl.conf &
+  service vsftpd restart
+  vsftpd /etc/vsftpd-ssl.conf &
 }
 
 disable_moto_server(){
@@ -43,7 +46,7 @@ disable_moto_server(){
 }
 
 delete_ftp_ftps_servers(){
-  sudo service vsftpd stop
+  service vsftpd stop
 }
 
 "$@"

--- a/ci_helpers/helpers.sh
+++ b/ci_helpers/helpers.sh
@@ -11,10 +11,15 @@ create_ftp_ftps_servers(){
   #
   # Must be run as root
   #
-  HOME_DIR=/home/user
-  mkdir $HOME_DIR
-  useradd -p $(echo $PASS | openssl passwd -1 -stdin) -d $HOME_DIR $USER
-  chown $USER:$USER $HOME_DIR
+  home_dir=/home/user
+  user=user
+  pass=123
+  ftp_port=21
+  ftps_port=90
+
+  mkdir $home_dir
+  useradd -p $(echo $pass | openssl passwd -1 -stdin) -d $home_dir $user
+  chown $user:$user $home_dir
 
   server_setup='''
 listen=YES
@@ -35,8 +40,8 @@ require_ssl_reuse=NO
 '''
 
   cp /etc/vsftpd.conf /etc/vsftpd-ssl.conf
-  echo -e "$server_setup\nlisten_port=${FTP_PORT}" >> /etc/vsftpd.conf
-  echo -e "$server_setup\nlisten_port=${FTPS_PORT}\n$additional_ssl_setup" >> /etc/vsftpd-ssl.conf
+  echo -e "$server_setup\nlisten_port=${ftp_port}" >> /etc/vsftpd.conf
+  echo -e "$server_setup\nlisten_port=${ftps_port}\n$additional_ssl_setup" >> /etc/vsftpd-ssl.conf
 
   service vsftpd restart
   vsftpd /etc/vsftpd-ssl.conf &

--- a/ci_helpers/helpers.sh
+++ b/ci_helpers/helpers.sh
@@ -7,17 +7,43 @@ enable_moto_server(){
   moto_server -p5000 2>/dev/null&
 }
 
-create_ftp_server(){
-  docker run -d -p 21:21 -p 21000-21010:21000-21010 -e USERS="user|123|/home/user/dir" -e ADDRESS=localhost --name my-ftp-server delfer/alpine-ftp-server 
+create_ftp_ftps_servers(){
+  sudo mkdir $HOME_DIR
+  sudo useradd -p $(echo $PASS | openssl passwd -1 -stdin) -d $HOME_DIR $USER
+  sudo chown $USER:$USER $HOME_DIR
+
+  server_setup='''
+listen=YES
+listen_ipv6=NO
+write_enable=YES
+pasv_enable=YES
+pasv_min_port=40000
+pasv_max_port=40009
+chroot_local_user=YES
+allow_writeable_chroot=YES'''
+
+  additional_ssl_setup='''
+ssl_enable=YES
+allow_anon_ssl=NO
+force_local_data_ssl=NO
+force_local_logins_ssl=NO
+require_ssl_reuse=NO
+'''
+
+  sudo cp /etc/vsftpd.conf /etc/vsftpd-ssl.conf
+  echo -e "$server_setup\nlisten_port=${FTP_PORT}" | sudo tee -a /etc/vsftpd.conf
+  echo -e "$server_setup\nlisten_port=${FTPS_PORT}\n$additional_ssl_setup" | sudo tee -a /etc/vsftpd-ssl.conf
+
+  sudo service vsftpd restart
+  sudo vsftpd /etc/vsftpd-ssl.conf &
 }
 
 disable_moto_server(){
   lsof -i tcp:5000 | tail -n1 | cut -f2 -d" " | xargs kill -9
 }
 
-delete_ftp_server(){
-  docker kill my-ftp-server
-  docker rm my-ftp-server
+delete_ftp_ftps_servers(){
+  sudo service vsftpd stop
 }
 
 "$@"

--- a/integration-tests/test_ftp.py
+++ b/integration-tests/test_ftp.py
@@ -1,71 +1,84 @@
 from __future__ import unicode_literals
-
+import pytest
 from smart_open import open
 
-def test_nonbinary():
+
+@pytest.fixture(params=[("ftp", 21), ("ftps", 90)])
+def server_info(request):
+    return request.param
+
+def test_nonbinary(server_info):
+    server_type = server_info[0]
+    port_num = server_info[1]
     file_contents = "Test Test \n new test \n another tests"
     appended_content1 = "Added \n to end"
 
-    with open("ftp://user:123@localhost:21/home/user/dir/file", "w") as f:
+    with open(f"{server_type}://user:123@localhost:{port_num}/file", "w") as f:
         f.write(file_contents)
 
-    with open("ftp://user:123@localhost:21/home/user/dir/file", "r") as f:
+    with open(f"{server_type}://user:123@localhost:{port_num}/file", "r") as f:
         read_contents = f.read()
         assert read_contents == file_contents
     
-    with open("ftp://user:123@localhost:21/home/user/dir/file", "a") as f:
+    with open(f"{server_type}://user:123@localhost:{port_num}/file", "a") as f:
         f.write(appended_content1)
     
-    with open("ftp://user:123@localhost:21/home/user/dir/file", "r") as f:
+    with open(f"{server_type}://user:123@localhost:{port_num}/file", "r") as f:
         read_contents = f.read()
         assert read_contents == file_contents + appended_content1
 
-def test_binary():
+def test_binary(server_info):
+    server_type = server_info[0]
+    port_num = server_info[1]
     file_contents = b"Test Test \n new test \n another tests"
     appended_content1 = b"Added \n to end"
 
-    with open("ftp://user:123@localhost:21/home/user/dir/file2", "wb") as f:
+    with open(f"{server_type}://user:123@localhost:{port_num}/file2", "wb") as f:
         f.write(file_contents)
 
-    with open("ftp://user:123@localhost:21/home/user/dir/file2", "rb") as f:
+    with open(f"{server_type}://user:123@localhost:{port_num}/file2", "rb") as f:
         read_contents = f.read()
         assert read_contents == file_contents
     
-    with open("ftp://user:123@localhost:21/home/user/dir/file2", "ab") as f:
+    with open(f"{server_type}://user:123@localhost:{port_num}/file2", "ab") as f:
         f.write(appended_content1)
     
-    with open("ftp://user:123@localhost:21/home/user/dir/file2", "rb") as f:
+    with open(f"{server_type}://user:123@localhost:{port_num}/file2", "rb") as f:
         read_contents = f.read()
         assert read_contents == file_contents + appended_content1
 
-def test_line_endings_non_binary():
+def test_line_endings_non_binary(server_info):
+    server_type = server_info[0]
+    port_num = server_info[1]
     B_CLRF = b'\r\n'
     CLRF = '\r\n'
     file_contents = f"Test Test {CLRF} new test {CLRF} another tests{CLRF}"
 
-    with open("ftp://user:123@localhost:21/home/user/dir/file3", "w") as f:
+    with open(f"{server_type}://user:123@localhost:{port_num}/file3", "w") as f:
         f.write(file_contents)
 
-    with open("ftp://user:123@localhost:21/home/user/dir/file3", "r") as f:    
+    with open(f"{server_type}://user:123@localhost:{port_num}/file3", "r") as f:    
         for line in f:
             assert not CLRF in line
     
-    with open("ftp://user:123@localhost:21/home/user/dir/file3", "rb") as f:    
+    with open(f"{server_type}://user:123@localhost:{port_num}/file3", "rb") as f:    
         for line in f:
             assert B_CLRF in line
 
-def test_line_endings_binary():
+def test_line_endings_binary(server_info):
+    server_type = server_info[0]
+    port_num = server_info[1]
     B_CLRF = b'\r\n'
     CLRF = '\r\n'
     file_contents = f"Test Test {CLRF} new test {CLRF} another tests{CLRF}".encode('utf-8')
 
-    with open("ftp://user:123@localhost:21/home/user/dir/file4", "wb") as f:
+    with open(f"{server_type}://user:123@localhost:{port_num}/file4", "wb") as f:
         f.write(file_contents)
 
-    with open("ftp://user:123@localhost:21/home/user/dir/file4", "r") as f:    
+    with open(f"{server_type}://user:123@localhost:{port_num}/file4", "r") as f:    
         for line in f:
             assert not CLRF in line
     
-    with open("ftp://user:123@localhost:21/home/user/dir/file4", "rb") as f:    
+    with open(f"{server_type}://user:123@localhost:{port_num}/file4", "rb") as f:    
         for line in f:
             assert B_CLRF in line

--- a/smart_open/ftp.py
+++ b/smart_open/ftp.py
@@ -97,7 +97,6 @@ def _connect(hostname, username, port, password, secure_connection, transport_pa
     return ftp
 
 
-# transport paramaters can include any extra parameters that you want to be passed into FTP_TLS
 def open(
     path,
     mode="r",
@@ -108,6 +107,28 @@ def open(
     secure_connection=False,
     transport_params=None,
 ):
+    """Open a file for reading or writing via FTP/FTPS.
+
+    Parameters
+    ----------
+    path: str
+        The path on the remote server
+    mode: str
+        Must be "rb" or "wb"
+    host: str
+        The host to connect to
+    user: str
+        The username to use for the connection
+    password: str
+        The password for the specified username
+    port: int
+        The port to connect to
+    secure_connection: bool
+        True for FTPS, False for FTP
+    transport_params: dict
+        Additional parameters for the FTP connection.
+        Currently supported parameters: timeout, source_address, encoding.
+    """
     if not host:
         raise ValueError("you must specify the host to connect to")
     if not user:
@@ -116,12 +137,8 @@ def open(
         transport_params = {}
     conn = _connect(host, user, port, password, secure_connection, transport_params)
     mode_to_ftp_cmds = {
-        "r": ("RETR", "r"),
         "rb": ("RETR", "rb"),
-        "w": ("STOR", "w"),
         "wb": ("STOR", "wb"),
-        "a": ("APPE", "w"),
-        "ab": ("APPE", "wb")
     }
     try:
         ftp_mode, file_obj_mode = mode_to_ftp_cmds[mode]

--- a/smart_open/ftp.py
+++ b/smart_open/ftp.py
@@ -139,6 +139,7 @@ def open(
     mode_to_ftp_cmds = {
         "rb": ("RETR", "rb"),
         "wb": ("STOR", "wb"),
+        "ab": ("APPE", "wb"),
     }
     try:
         ftp_mode, file_obj_mode = mode_to_ftp_cmds[mode]


### PR DESCRIPTION
#### Title
Support for reading and writing files directly to/from ftps (ftp with tls)
#### Motivation

I have [previously](https://github.com/RaRe-Technologies/smart_open/pull/723) added support ftp servers (without tls encryption). Now, to add more complete ftp functionality, I have added support for ftp+tls servers. 

```python
from smart_open import open
with open('ftps://user:password@host:port/dir1/dir2/file') as fin:
     for line in fin:
          print(line)
```

#### Tests
I have edited the ftp integration tests to run an ftp and ftps server on different ports and then test reading, writing, and appending to each of them. (specific integration test [here](https://github.com/RachitSharma2001/smart_open/blob/ftps/integration-tests/test_ftp.py), pull up ftp and ftps servers [here](https://github.com/RachitSharma2001/smart_open/blob/ftps/ci_helpers/helpers.sh)).
