### PR TITLE
fix: S3 ignore seek requests to the current position

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -663,9 +663,10 @@ class Reader(io.BufferedIOBase):
             whence = constants.WHENCE_START
             offset += self._current_pos
 
-        self._current_pos = self._raw_reader.seek(offset, whence)
+        if not (whence == constants.WHENCE_START and offset == self._current_pos):
+            self._current_pos = self._raw_reader.seek(offset, whence)
+            self._buffer.empty()
 
-        self._buffer.empty()
         self._eof = self._current_pos == self._raw_reader._content_length
         return self._current_pos
 

--- a/smart_open/tests/test_s3_version.py
+++ b/smart_open/tests/test_s3_version.py
@@ -70,8 +70,10 @@ class TestVersionId(unittest.TestCase):
     def test_bad_id(self):
         """Does passing an invalid version_id exception into the s3 submodule get handled correctly?"""
         params = {'version_id': 'bad-version-does-not-exist'}
-        with self.assertRaises(IOError):
-            open(self.url, 'rb', transport_params=params)
+        with open(self.url, 'rb', transport_params=params) as fin:
+            with self.assertRaises(IOError):
+                fin.read()
+
 
     def test_bad_mode(self):
         """Do we correctly handle non-None version when writing?"""


### PR DESCRIPTION
#### Motivation

When callers perform a `seek()` on a S3 backed file handle that seek can be ignored if it is to the current position.  Python's ZipFile module often seeks to the current position causing performance to be quite slow when reading zip files from S3.  

This change compares the current position vs the destination position and preserves the buffer if possible while still populating the EOF flag.

This addresses: #742 
