### PR TITLE
Add required import for example to work

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,6 +151,7 @@ For the sake of simplicity, the examples below assume you have all the dependenc
 .. code-block:: python
 
     >>> import os, boto3
+    >>> from smart_open import open
     >>>
     >>> # stream content *into* S3 (write mode) using a custom session
     >>> session = boto3.Session(


### PR DESCRIPTION
If a person were to simply copy this code block it would use the built in `open` and would not work. Adding in the correct import makes this block a bit easier for a simple copy paste.