### PR TITLE
Avoid overfilling buffer when reading from Azure

### DIFF
--- a/smart_open/azure.py
+++ b/smart_open/azure.py
@@ -306,7 +306,7 @@ class Reader(io.BufferedIOBase):
         if self._position == self._size:
             return self._read_from_buffer()
 
-        self._fill_buffer()
+        self._fill_buffer(size)
         return self._read_from_buffer(size)
 
     def read1(self, size=-1):


### PR DESCRIPTION
#### Title

when read size > chunk size, return read size and not chunk size.

```
bugfix: read(MAX_READ_SIZE) returns read(CHUNK_SIZE) when read size > chunk size
```

#### Motivation

The read function expects to return the maximum size it can read from a stream and not the chunk size. This causes serious bugs when reading with a parameter such as x.read(MAX_READ_SIZE), which does not expect you to re-read the buffer until you get to MAX_READ_SIZE.

This bug does not happen when the read size is not specified.

If you're fixing a bug, link to the issue number like so:

```
- Fixes #{issue_number}
```

If you're adding a new feature, then consider opening a ticket and discussing it with the maintainers before you actually do the hard work.

#### Tests

If you're fixing a bug, consider [test-driven development](https://en.wikipedia.org/wiki/Test-driven_development):

1. Create a unit test that demonstrates the bug. The test should **fail**.
2. Implement your bug fix.
3. The test you created should now **pass**.

If you're implementing a new feature, include unit tests for it.

Make sure all existing unit tests pass.
You can run them locally using:

    pytest smart_open

If there are any failures, please fix them before creating the PR (or mark it as WIP, see below).

#### Work in progress

If you're still working on your PR, include "WIP" in the title.
We'll skip reviewing it for the time being.
Once you're ready to review, remove the "WIP" from the title, and ping one of the maintainers (e.g. mpenkov).

#### Checklist

Before you create the PR, please make sure you have:

- [ ] Picked a concise, informative and complete title
- [ ] Clearly explained the motivation behind the PR
- [ ] Linked to any existing issues that your PR will be solving
- [ ] Included tests for any new functionality
- [ ] Checked that all unit tests pass

#### Workflow

Please avoid rebasing and force-pushing to the branch of the PR once a review is in progress.
Rebasing can make your commits look a bit cleaner, but it also makes life more difficult from the reviewer, because they are no longer able to distinguish between code that has already been reviewed, and unreviewed code.
