### PR TITLE
Fixes KeyError when retrieving empty but existing object from S3

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -324,10 +324,13 @@ def open(
 
 def _get(client, bucket, key, version, range_string):
     try:
+        params = dict(Bucket=bucket, Key=key)
         if version:
-            return client.get_object(Bucket=bucket, Key=key, VersionId=version, Range=range_string)
-        else:
-            return client.get_object(Bucket=bucket, Key=key, Range=range_string)
+            params["VersionId"] = version
+        if range_string:
+            params["Range"] = range_string
+
+        return client.get_object(**params)
     except botocore.client.ClientError as error:
         wrapped_error = IOError(
             'unable to access bucket: %r key: %r version: %r error: %s' % (
@@ -447,8 +450,19 @@ class _SeekableRawReader(object):
             error_response = _unwrap_ioerror(ioe)
             if error_response is None or error_response.get('Code') != _OUT_OF_RANGE:
                 raise
-            self._position = self._content_length = int(error_response['ActualObjectSize'])
-            self._body = io.BytesIO()
+            try:
+                self._position = self._content_length = int(error_response['ActualObjectSize'])
+                self._body = io.BytesIO()
+            except KeyError:
+                response = _get(
+                    self._client,
+                    self._bucket,
+                    self._key,
+                    self._version_id,
+                    None,
+                )
+                self._position = self._content_length = response["ContentLength"]
+                self._body = response["Body"]
         else:
             #
             # Keep track of how many times boto3's built-in retry mechanism
@@ -461,7 +475,7 @@ class _SeekableRawReader(object):
                 self,
                 response['ResponseMetadata']['RetryAttempts'],
             )
-            units, start, stop, length = smart_open.utils.parse_content_range(response['ContentRange'])
+            _, start, stop, length = smart_open.utils.parse_content_range(response['ContentRange'])
             self._content_length = length
             self._position = start
             self._body = response['Body']


### PR DESCRIPTION
#### Title

Attempt to fix the `KeyError` we have when reading an empty file from S3

#### Motivation

When we try to retrieve an empty file from S3 we may have the following error

```
...
File "/home/user/.local/lib/python3.8/site-packages/smart_open/s3.py", line 450, in _open_body
    self._position = self._content_length = int(error_response['ActualObjectSize'])
KeyError: 'ActualObjectSize'
```

This PR catches the `KeyError` and send a `get_object` query without any range to retrieve the data as suggested in the issue

- Fixes #667


#### Tests

I added a test, but it seems that the Moto lib provide the value `ActualObjectSize` even for empty objects so the code won't be tested...
