### PR TITLE
[s3] Add ability to set endpoint_url from AWS_ENDPOINT_URL env variable

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -13,6 +13,8 @@ import logging
 import time
 import warnings
 
+from os import getenv
+
 try:
     import boto3
     import botocore.client
@@ -89,8 +91,11 @@ def parse_uri(uri_as_string):
     split_uri = smart_open.utils.safe_urlsplit(uri_as_string)
     assert split_uri.scheme in SCHEMES
 
-    port = DEFAULT_PORT
-    host = DEFAULT_HOST
+    custom_endpoint_url = getenv('AWS_ENDPOINT_URL', '')
+    split_custom_endpoint_url = smart_open.utils.safe_urlsplit(custom_endpoint_url)
+
+    port = split_custom_endpoint_url.port or DEFAULT_PORT
+    host = split_custom_endpoint_url.hostname or DEFAULT_HOST
     ordinary_calling_format = False
     #
     # These defaults tell boto3 to look for credentials elsewhere

--- a/smart_open/tests/test_smart_open.py
+++ b/smart_open/tests/test_smart_open.py
@@ -1206,6 +1206,15 @@ class SmartOpenTest(unittest.TestCase):
         smart_open.open("s3://mybucket/mykey", "w", transport_params=transport_params)
         mock_client.assert_called_with('s3', endpoint_url='http://s3.amazonaws.com')
 
+    @mock.patch("boto3.client")
+    @mock.patch.dict(os.environ, {"AWS_ENDPOINT_URL": "https://my-endpoit.com:443", }, clear=True,)
+    def test_s3_endpoint_from_env_var(self, mock_client):
+        """Are s3:// open modes passed correctly with endpoint from environment variables?"""
+
+        smart_open.open("s3://mybucket/mykey", "w")
+
+        mock_client.assert_called_with("s3", endpoint_url="https://my-endpoit.com:443")
+
     @mock.patch('smart_open.hdfs.subprocess')
     def test_hdfs(self, mock_subprocess):
         """Is HDFS write called correctly"""


### PR DESCRIPTION
#### Title

[s3] Add ability to set endpoint_url from AWS_ENDPOINT_URL env variable

#### Motivation

The reason for this modification is that the addition of this functionality to the "smart-open" library addresses [a longstanding PR in the "boto3" library](https://github.com/aws/aws-sdk/issues/229). For years, there has been a lack of progress in implementing this feature directly in "boto3". However, "boto3" allows for the configuration of certain parameters, such as the aws_secret_access_key or aws_access_key_id, through environment variables. By extending the "smart-open" library to support the "AWS_ENDPOINT_URL" environment variable, users can leverage a more flexible approach to configuring the custom endpoint URL for S3 connections. This modification provides a workaround for the limitation in "boto3" and enables users to easily configure the S3 endpoint URL without relying solely on changes to the "boto3" library itself.

The addition of this functionality to the "smart-open" library is valuable as it allows for easy configuration of different S3 connections without the need to modify code paths, providing convenience and flexibility when working with multiple environments


#### Tests

Added test_smart_open::SmartOpenTest::test_s3_endpoint_from_env_var