### PR TITLE
Run tests on py3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,10 +6,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup up Python 3.10
+      - name: Setup up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Update pip
         run: python -m pip install -U pip
@@ -26,15 +26,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - {python: '3.7', os: ubuntu-20.04}
           - {python: '3.8', os: ubuntu-20.04}
           - {python: '3.9', os: ubuntu-20.04}
           - {python: '3.10', os: ubuntu-20.04}
+          - {python: '3.11', os: ubuntu-20.04}
 
-          - {python: '3.7', os: windows-2019}
           - {python: '3.8', os: windows-2019}
           - {python: '3.9', os: windows-2019}
           - {python: '3.10', os: windows-2019}
+          - {python: '3.11', os: windows-2019}
     steps:
       - uses: actions/checkout@v2
 
@@ -63,10 +63,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - {python: '3.7', os: ubuntu-20.04}
           - {python: '3.8', os: ubuntu-20.04}
           - {python: '3.9', os: ubuntu-20.04}
           - {python: '3.10', os: ubuntu-20.04}
+          - {python: '3.11', os: ubuntu-20.04}
 
           #
           # Some of the doctests don't pass on Windows because of Windows-specific
@@ -105,10 +105,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - {python: '3.7', os: ubuntu-20.04, moto_server: true}
           - {python: '3.8', os: ubuntu-20.04}
           - {python: '3.9', os: ubuntu-20.04}
           - {python: '3.10', os: ubuntu-20.04}
+          - {python: '3.11', os: ubuntu-20.04}
 
           # Not sure why we exclude these, perhaps for historical reasons?
           #
@@ -159,10 +159,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - {python: '3.7', os: ubuntu-20.04}
           - {python: '3.8', os: ubuntu-20.04}
           - {python: '3.9', os: ubuntu-20.04}
           - {python: '3.10', os: ubuntu-20.04}
+          - {python: '3.11', os: ubuntu-20.04}
 
           # - {python: '3.7', os: windows-2019}
           # - {python: '3.8', os: windows-2019}


### PR DESCRIPTION
relates to https://github.com/RaRe-Technologies/smart_open/issues/770

removes py3.7 tests too as that version is out of support: https://endoflife.date/python