### PR TITLE
feat: add type hinting to `s3.open()` and main `open()`

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -53,19 +53,19 @@ FUNCTIONS
         uri: str or object
             The object to open.
         mode: str, optional
-            Mimicks built-in open parameter of the same name.
+            Mimics built-in open parameter of the same name.
         buffering: int, optional
-            Mimicks built-in open parameter of the same name.
+            Mimics built-in open parameter of the same name.
         encoding: str, optional
-            Mimicks built-in open parameter of the same name.
+            Mimics built-in open parameter of the same name.
         errors: str, optional
-            Mimicks built-in open parameter of the same name.
+            Mimics built-in open parameter of the same name.
         newline: str, optional
-            Mimicks built-in open parameter of the same name.
+            Mimics built-in open parameter of the same name.
         closefd: boolean, optional
-            Mimicks built-in open parameter of the same name.  Ignored.
+            Mimics built-in open parameter of the same name.  Ignored.
         opener: object, optional
-            Mimicks built-in open parameter of the same name.  Ignored.
+            Mimics built-in open parameter of the same name.  Ignored.
         compression: str, optional (see smart_open.compression.get_supported_compression_types)
             Explicitly specify the compression/decompression behavior.
         transport_params: dict, optional

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -18,7 +18,6 @@ import warnings
 from math import inf
 
 from typing import (
-    IO,
     BinaryIO,
     Callable,
     List,
@@ -324,7 +323,7 @@ def open(
     defer_seek: bool = False,
     client: object | None = None,
     client_kwargs: dict | None = None,
-    writebuffer: IO[bytes] | None = None,
+    writebuffer: BinaryIO | None = None,
     range_chunk_size: int | None = None,
 ) -> BinaryIO:
     """Open an S3 object for reading or writing.

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -16,9 +16,12 @@ import time
 import warnings
 
 from typing import (
+    IO,
+    BinaryIO,
     Callable,
     List,
     TYPE_CHECKING,
+    Literal,
 )
 
 try:
@@ -309,18 +312,18 @@ def open_uri(uri, mode, transport_params):
 
 
 def open(
-    bucket_id,
-    key_id,
-    mode,
-    version_id=None,
-    buffer_size=DEFAULT_BUFFER_SIZE,
-    min_part_size=DEFAULT_PART_SIZE,
-    multipart_upload=True,
-    defer_seek=False,
-    client=None,
-    client_kwargs=None,
-    writebuffer=None,
-):
+    bucket_id: str,
+    key_id: str,
+    mode: Literal["rb", "wb"],
+    version_id: str | None = None,
+    buffer_size: int = DEFAULT_BUFFER_SIZE,
+    min_part_size: int = DEFAULT_PART_SIZE,
+    multipart_upload: bool = True,
+    defer_seek: bool = False,
+    client: object | None = None,
+    client_kwargs: dict | None = None,
+    writebuffer: IO[bytes] | None = None,
+) -> BinaryIO:
     """Open an S3 object for reading or writing.
 
     Parameters

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -14,6 +14,7 @@ import logging
 import os
 import os.path as P
 import pathlib
+from typing import IO, Any, BinaryIO, Literal, TextIO, overload
 import urllib.parse
 import warnings
 
@@ -90,18 +91,46 @@ _parse_uri = parse_uri
 _builtin_open = open
 
 
+@overload
+def open(  # Text modes: 'r' or 'w'
+    uri: str | pathlib.Path | IO[str],
+    mode: Literal["r", "w", 'a'] = "r",
+    buffering: int = -1,
+    encoding: str | None = ...,
+    errors: str | None = ...,
+    newline: str | None = ...,
+    closefd: bool = ...,
+    opener: object | None = ...,
+    compression: str = ...,
+    transport_params: dict[str, Any] | None = ...,
+) -> TextIO: ...
+@overload
+def open(  # Binary modes: 'rb' or 'wb'
+    uri: str | pathlib.Path | IO[bytes],
+    mode: Literal["rb", "wb", 'ab', 'rb+', 'wb+', 'ab+'] = "rb",
+    buffering: int = -1,
+    encoding: None = ...,
+    errors: None = ...,
+    newline: None = ...,
+    closefd: bool = ...,
+    opener: object | None = ...,
+    compression: str = ...,
+    transport_params: dict[str, Any] | None = ...,
+) -> BinaryIO: ...
+
+
 def open(
-        uri,
-        mode='r',
-        buffering=-1,
-        encoding=None,
-        errors=None,
-        newline=None,
-        closefd=True,
-        opener=None,
-        compression=so_compression.INFER_FROM_EXTENSION,
-        transport_params=None,
-        ):
+    uri: str | pathlib.Path | IO,
+    mode: Literal['r', 'rb', 'w', 'wb', 'a', 'ab', 'rb+', 'wb+', 'ab+'] = 'r',
+    buffering: int = -1,
+    encoding: str | None = None,
+    errors: str | None = None,
+    newline: str | None = None,
+    closefd: bool = True,
+    opener: object | None = None,
+    compression: str = so_compression.INFER_FROM_EXTENSION,
+    transport_params: dict[str, Any] | None = None,
+) -> IO:
     r"""Open the URI object, returning a file-like object.
 
     The URI is usually a string in a variety of formats.
@@ -117,19 +146,19 @@ def open(
     uri: str or object
         The object to open.
     mode: str, optional
-        Mimicks built-in open parameter of the same name.
+        Mimics built-in open parameter of the same name.
     buffering: int, optional
-        Mimicks built-in open parameter of the same name.
+        Mimics built-in open parameter of the same name.
     encoding: str, optional
-        Mimicks built-in open parameter of the same name.
+        Mimics built-in open parameter of the same name.
     errors: str, optional
-        Mimicks built-in open parameter of the same name.
+        Mimics built-in open parameter of the same name.
     newline: str, optional
-        Mimicks built-in open parameter of the same name.
+        Mimics built-in open parameter of the same name.
     closefd: boolean, optional
-        Mimicks built-in open parameter of the same name.  Ignored.
+        Mimics built-in open parameter of the same name.  Ignored.
     opener: object, optional
-        Mimicks built-in open parameter of the same name.  Ignored.
+        Mimics built-in open parameter of the same name.  Ignored.
     compression: str, optional (see smart_open.compression.get_supported_compression_types)
         Explicitly specify the compression/decompression behavior.
     transport_params: dict, optional

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -92,7 +92,8 @@ _builtin_open = open
 
 
 @overload
-def open(  # Text modes: 'r' or 'w'
+def open(
+    # Text modes: 'r' or 'w'
     uri: str | pathlib.Path | IO[str],
     mode: Literal["r", "w", 'a'] = "r",
     buffering: int = -1,
@@ -104,8 +105,11 @@ def open(  # Text modes: 'r' or 'w'
     compression: str = ...,
     transport_params: dict[str, Any] | None = ...,
 ) -> TextIO: ...
+
+
 @overload
-def open(  # Binary modes: 'rb' or 'wb'
+def open(
+    # Binary modes: 'rb' or 'wb'
     uri: str | pathlib.Path | IO[bytes],
     mode: Literal["rb", "wb", 'ab', 'rb+', 'wb+', 'ab+'] = "rb",
     buffering: int = -1,


### PR DESCRIPTION
### Motivation

Related to #518. Not a complete fix, but makes some progress.

### Tests

CI should really get upgraded and have `ruff` for checking and `pyright` for type validations.
