### PR TITLE
[s3] Optimize forward seeks within buffered data to avoid redundant GET

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -199,7 +199,12 @@ FUNCTIONS
         mode: str
             The mode for opening the object.  Must be either "rb" or "wb".
         buffer_size: int, optional
-            The buffer size to use when performing I/O.
+            Default: 128KB
+            The buffer size in bytes for reading. Controls memory usage. Data is streamed
+            from a S3 network stream in buffer_size chunks. Forward seeks within
+            the current buffer are satisfied without additional GET requests. Backward
+            seeks always open a new GET request. For forward seek-intensive workloads,
+            increase buffer_size to reduce GET requests at the cost of higher memory usage.
         min_part_size: int, optional
             The minimum part size for multipart uploads, in bytes.
             When the writebuffer contains this many bytes, smart_open will upload

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -271,7 +271,7 @@ class ReaderTest(BaseTest):
             fin = smart_open.s3.Reader(BUCKET_NAME, KEY_NAME)
             self.assertEqual(fin.read(5), b'hello')
 
-        with self.assertApiCalls(GetObject=1):
+        with self.assertApiCalls():
             seek = fin.seek(1, whence=smart_open.constants.WHENCE_CURRENT)
             self.assertEqual(seek, 6)
             self.assertEqual(fin.read(6), u'wořld'.encode('utf-8'))
@@ -297,6 +297,22 @@ class ReaderTest(BaseTest):
             fin = smart_open.s3.Reader(BUCKET_NAME, KEY_NAME, defer_seek=True)
             seek = fin.seek(-(body_len + 10), whence=smart_open.constants.WHENCE_END)
             self.assertEqual(seek, 0)  # Should clamp to start of file
+
+    def test_seek_forward_within_buffer(self):
+        """Does forward seeking within buffered data avoid additional GET requests?"""
+        with self.assertApiCalls(GetObject=1):
+            fin = smart_open.s3.Reader(BUCKET_NAME, KEY_NAME, buffer_size=32)
+            self.assertEqual(fin.read(5), b'hello')
+
+            # Forward seek within buffer using WHENCE_CURRENT - should NOT make a new GET request
+            seek = fin.seek(1, whence=smart_open.constants.WHENCE_CURRENT)
+            self.assertEqual(seek, 6)
+            self.assertEqual(fin.read(6), u'wořld'.encode('utf-8'))
+
+            # Forward seek within buffer using WHENCE_START - should NOT make a new GET request
+            seek = fin.seek(13, whence=smart_open.constants.WHENCE_START)
+            self.assertEqual(seek, 13)
+            self.assertEqual(fin.read(3), b'how')
 
     def test_detect_eof(self):
         with self.assertApiCalls(GetObject=1):


### PR DESCRIPTION
> Please **pick a concise, informative and complete title** for your PR.
> 
> The title is important because it will appear in [our change log](https://github.com/RaRe-Technologies/smart_open/blob/master/CHANGELOG.md).

### Motivation

> Please explain the motivation behind this PR.
> 
> If you're fixing a bug, link to the issue using a [supported keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) like "Fixes #{issue_number}".
> 
> If you're adding a new feature, then consider opening a ticket and discussing it with the maintainers before you actually do the hard work.

Ref #712, fix #622, fix #742

Before this change, any seek operation would close the current HTTP  connection and open a new GET request to S3, even when seeking forward  by a small amount within already-buffered data.

This commit adds an optimization to Reader.seek() that checks if a  forward seek can be satisfied from the existing buffer. If the target  position falls within the currently buffered range, the implementation  simply advances the buffer position without making a new S3 request.

Backward seeks and forward seeks beyond the buffer still require new GET requests as before.


### Tests

> If you're fixing a bug, consider [test-driven development](https://en.wikipedia.org/wiki/Test-driven_development):
> 
> 1. Create a unit test that demonstrates the bug. The test should **fail**.
> 2. Implement your bug fix.
> 3. The test you created should now **pass**.
> 
> If you're implementing a new feature, include unit tests for it.
> 
> Make sure all existing unit tests pass.
> You can run them locally using:
> 
>     pytest tests
> 
> If there are any failures, please fix them before creating the PR (or mark it as WIP, see below).

### Work in progress

> If you're still working on your PR, mark the PR as [draft PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request).
> 
> We'll skip reviewing it for the time being.
> 
> Once it's ready, mark the PR as "ready for review", and ping one of the maintainers (e.g. mpenkov).

### Checklist

> Before you mark the PR as "ready for review", please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Run `python update_helptext.py` in case there are API changes
- [ ] Checked that all unit tests pass

### Workflow

> Please avoid rebasing and force-pushing to the branch of the PR once a review is in progress.
> 
> Rebasing can make your commits look a bit cleaner, but it also makes life more difficult from the reviewer, because they are no longer able to distinguish between code that has already been reviewed, and unreviewed code.
