### PR TITLE
[hdfs] Make CliRawOutputBase.write return number of bytes written

### DIFF
--- a/smart_open/hdfs.py
+++ b/smart_open/hdfs.py
@@ -151,7 +151,17 @@ class CliRawOutputBase(io.RawIOBase):
         return False
 
     def write(self, b):
-        self._sub.stdin.write(b)
+        """Write the given buffer to the underlying raw stream.
+
+        Returns the number of bytes written, as required by
+        :class:`io.RawIOBase`. Without this return value, callers that wrap
+        this stream and rely on the documented ``write`` contract (for
+        example, ``ray._private.external_storage._write_multiple_objects``,
+        which asserts ``written_bytes == payload_len``) fail with an
+        ``AssertionError`` because ``write`` would otherwise implicitly
+        return ``None``.
+        """
+        return self._sub.stdin.write(b)
 
     #
     # io.IOBase methods.

--- a/tests/test_hdfs.py
+++ b/tests/test_hdfs.py
@@ -110,9 +110,15 @@ def test_write(schema):
     expected = 'мы в ответе за тех, кого приручили'
     mocked_cat = cat()
 
+    payload = expected.encode('utf-8')
     with mock.patch('subprocess.Popen', return_value=mocked_cat):
         with smart_open.hdfs.CliRawOutputBase(f'{schema}://dummy/url') as fout:
-            fout.write(expected.encode('utf-8'))
+            written = fout.write(payload)
+
+    # CliRawOutputBase implements io.RawIOBase, whose write() contract is to
+    # return the number of bytes written. Returning None breaks callers like
+    # ray._private.external_storage that assert on the return value.
+    assert written == len(payload)
 
     actual = mocked_cat.stdout.read().decode('utf-8')
     assert actual == expected


### PR DESCRIPTION
## Motivation

`smart_open.hdfs.CliRawOutputBase` extends `io.RawIOBase`. Per the
[Python `io.RawIOBase.write` contract](https://docs.python.org/3/library/io.html#io.RawIOBase.write),
`write(b)` must return the number of bytes written. The current
implementation forwards to `self._sub.stdin.write(b)` but **drops the
return value**, so `write()` implicitly returns `None`.

This breaks every caller that relies on the documented contract. A
concrete real-world example is Ray's object spilling layer
([`ray._private.external_storage._write_multiple_objects`](https://github.com/ray-project/ray/blob/master/python/ray/_private/external_storage.py)),
which spills plasma objects to HDFS via smart_open and asserts:

```python
written_bytes = f.write(payload)
assert written_bytes == payload_len
```

For users who configure Ray to spill to HDFS via smart_open:

```python
ray.init(_system_config={
    "object_spilling_config": json.dumps({
        "type": "smart_open",
        "params": {"uri": "hdfs:///user/.../object_spilling"},
    }),
})
```

every spill fails immediately with:

```
ERROR -- An unexpected internal error occurred while the IO worker was spilling objects:
Traceback (most recent call last):
  ...
  File ".../ray/_private/external_storage.py", line 176, in _write_multiple_objects
    assert written_bytes == payload_len
AssertionError
```

The S3 writers (`MultipartWriter` / `SinglepartWriter`) correctly return
the byte count, which is why this has not been widely reported — only
HDFS users are affected.

## Fix

Propagate the return value from the underlying buffered
`subprocess.PIPE` (`BufferedWriter`, whose `write()` returns the byte
count). Extend `test_write` to assert on the return value so we do not
regress.

## Verification

Without the fix, the new assertion in `test_write` reproduces the same
`AssertionError: assert None == <int>` failure pattern as Ray's
traceback. With the fix, all 14 tests in `tests/test_hdfs.py` pass:

```
tests/test_hdfs.py::test_write[schema0] PASSED
tests/test_hdfs.py::test_write[schema1] PASSED
...
======================== 14 passed in 9.05s ========================
```
