### PR TITLE
Add support for lz4 compression

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,7 @@ You can install one or more of these dependencies explicitly using optional depe
 
 .. code-block:: sh
 
-    pip install 'smart_open[s3,gcs,azure,http,webhdfs,ssh,zst]'
+    pip install 'smart_open[s3,gcs,azure,http,webhdfs,ssh,zst,lz4]'
 
 Or, if you don't mind installing a large number of third party libraries, you can install all dependencies using:
 
@@ -238,6 +238,7 @@ The supported values for this parameter are:
 - ``.gz``
 - ``.xz``
 - ``.zst``
+- ``.lz4``
 
 By default, ``smart_open`` automatically (de)compresses the file if the filename ends with one of these extensions.
 `See also <https://github.com/piskvorky/smart_open/blob/master/smart_open/compression.py>`__

--- a/README.rst
+++ b/README.rst
@@ -236,9 +236,9 @@ The supported values for this parameter are:
 - ``disable``
 - ``.bz2``
 - ``.gz``
+- ``.lz4``
 - ``.xz``
 - ``.zst``
-- ``.lz4``
 
 By default, ``smart_open`` automatically (de)compresses the file if the filename ends with one of these extensions.
 `See also <https://github.com/piskvorky/smart_open/blob/master/smart_open/compression.py>`__

--- a/help.txt
+++ b/help.txt
@@ -346,6 +346,7 @@ FUNCTIONS
 
         * .bz2
         * .gz
+        * .lz4
         * .xz
         * .zst
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ http = ["requests"]
 webhdfs = ["requests"]
 ssh = ["paramiko"]
 zst = ["backports.zstd>=1.0.0;python_version<'3.14'"]
-all = ["smart_open[s3,gcs,azure,http,webhdfs,ssh,zst]"]
+lz4 = ["lz4"]
+all = ["smart_open[s3,gcs,azure,http,webhdfs,ssh,zst,lz4]"]
 test = [
   "smart_open[all]",
   "moto[server]",

--- a/smart_open/compression.py
+++ b/smart_open/compression.py
@@ -134,6 +134,12 @@ def _handle_xz(file_obj, mode):
     return _maybe_wrap_buffered(result, mode)
 
 
+def _handle_lz4(file_obj, mode):
+    import lz4.frame
+    result = lz4.frame.open(file_obj, mode=mode)
+    return _maybe_wrap_buffered(result, mode)
+
+
 def compression_wrapper(file_obj, mode, compression=INFER_FROM_EXTENSION, filename=None):
     """
     Wrap `file_obj` with an appropriate [de]compression mechanism based on its file extension.
@@ -177,3 +183,4 @@ register_compressor('.bz2', _handle_bz2)
 register_compressor('.gz', _handle_gzip)
 register_compressor('.zst', _handle_zstd)
 register_compressor('.xz', _handle_xz)
+register_compressor('.lz4', _handle_lz4)

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -17,6 +17,7 @@ if sys.version_info >= (3, 14):
     from compression import zstd
 else:
     from backports import zstd
+import lz4.frame
 
 import smart_open.compression
 
@@ -52,23 +53,12 @@ def label(thing, name):
         (io.BytesIO(bz2.compress(plain)), 'infer_from_extension', 'file.BZ2'),
         (label(io.BytesIO(bz2.compress(plain)), 'file.bz2'), 'infer_from_extension', ''),
         (io.BytesIO(bz2.compress(plain)), '.bz2', 'file.bz2'),
+        (io.BytesIO(lz4.frame.compress(plain)), 'infer_from_extension', 'file.lz4'),
+        (io.BytesIO(lz4.frame.compress(plain)), 'infer_from_extension', 'file.LZ4'),
+        (label(io.BytesIO(lz4.frame.compress(plain)), 'file.lz4'), 'infer_from_extension', ''),
+        (io.BytesIO(lz4.frame.compress(plain)), '.lz4', 'file.lz4'),
     ]
 )
 def test_compression_wrapper_read(fileobj, compression, filename):
-    wrapped = smart_open.compression.compression_wrapper(fileobj, 'rb', compression, filename)
-    assert wrapped.read() == plain
-
-
-@pytest.mark.parametrize(
-    'compression,filename',
-    [
-        ('infer_from_extension', 'file.lz4'),
-        ('infer_from_extension', 'file.LZ4'),
-        ('.lz4', 'file.lz4'),
-    ]
-)
-def test_compression_wrapper_read_lz4(compression, filename):
-    lz4_frame = pytest.importorskip('lz4.frame')
-    fileobj = io.BytesIO(lz4_frame.compress(plain))
     wrapped = smart_open.compression.compression_wrapper(fileobj, 'rb', compression, filename)
     assert wrapped.read() == plain

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -57,3 +57,18 @@ def label(thing, name):
 def test_compression_wrapper_read(fileobj, compression, filename):
     wrapped = smart_open.compression.compression_wrapper(fileobj, 'rb', compression, filename)
     assert wrapped.read() == plain
+
+
+@pytest.mark.parametrize(
+    'compression,filename',
+    [
+        ('infer_from_extension', 'file.lz4'),
+        ('infer_from_extension', 'file.LZ4'),
+        ('.lz4', 'file.lz4'),
+    ]
+)
+def test_compression_wrapper_read_lz4(compression, filename):
+    lz4_frame = pytest.importorskip('lz4.frame')
+    fileobj = io.BytesIO(lz4_frame.compress(plain))
+    wrapped = smart_open.compression.compression_wrapper(fileobj, 'rb', compression, filename)
+    assert wrapped.read() == plain


### PR DESCRIPTION
### Motivation

A simple change that adds support for lz4 compression, since this format is quite popular.

### Verification
```
.venv/bin/python -m pytest tests/test_compression.py -q
........................                                                                                                                                                                                                                                                            [100%]
24 passed in 0.40s
```

### Checklist

> Before you mark the PR as "ready for review", please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Run `python update_helptext.py` in case there are API changes
- [x] Checked that all unit tests pass
