### PR TITLE
fix(s3): handle "already in progress" InternalError on multipart upload completion

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -1040,7 +1040,37 @@ class MultipartWriter(io.BufferedIOBase):
                 UploadId=self._upload_id,
                 MultipartUpload={'Parts': self._parts},
             )
-            RETRY._do(partial)
+            try:
+                RETRY._do(partial)
+            except botocore.exceptions.ClientError as err:
+                err_code = err.response.get('Error', {}).get('Code', '')
+                err_msg = err.response.get('Error', {}).get('Message', '')
+
+                # Check for S3-compatible 'multipart completion is already in progress'
+                if (
+                    err_code == 'InternalError'
+                    and 'multipart completion is already in progress'
+                    in err_msg.lower()
+                ):
+                    logger.info('%s: Multipart completion is already in progress on the S3 backend.', self)
+
+                    # Poll S3 to verify the object is successfully uploaded
+                    for _ in range(12):
+                        try:
+                            self._client.head_object(Bucket=self._bucket, Key=self._key)
+                            break
+                        except botocore.exceptions.ClientError as head_err:
+                            head_code = head_err.response.get('Error', {}).get('Code', '')
+                            # 404/Not Found usually from Ceph/S3-compatible; NoSuchKey from standard AWS S3
+                            if head_code in ('NoSuchKey', '404') or 'NoSuchKey' in str(head_err):
+                                time.sleep(5)
+                            else:
+                                raise head_err
+                    else:
+                        logger.error('%s: Timed out waiting for multipart completion verification.', self)
+                        raise err
+                else:
+                    raise
             logger.debug('%s: completed multipart upload', self)
         elif self._upload_id:
             #

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -527,6 +527,7 @@ class MultipartWriterTest(unittest.TestCase):
     def setUp(self):
         ignore_resource_warnings()
 
+        self.client = boto3.client('s3')
         _resource('s3').create_bucket(Bucket=BUCKET_NAME).wait_until_exists()
 
     def test_write_01(self):
@@ -798,6 +799,55 @@ class MultipartWriterTest(unittest.TestCase):
             smart_open.s3.open(BUCKET_NAME, WRITE_KEY_NAME, 'rb')
 
         assert 'The specified key does not exist.' in cm.exception.args[0]
+
+    @mock.patch('time.sleep')
+    def test_close_multipart_already_in_progress(self, mock_sleep):
+        """
+        Test that an `InternalError` during `CompleteMultipartUpload` triggers a
+        polling loop using `HeadObject`, and recovers successfully.
+        """
+        client_error = botocore.exceptions.ClientError(
+            dict(
+                Error=dict(
+                    Code='InternalError',
+                    Message='This multipart completion is already in progress'
+                )
+            ),
+            'CompleteMultipartUpload',
+        )
+
+        head_error = botocore.exceptions.ClientError(
+            dict(
+                Error=dict(
+                    Code='NoSuchKey',
+                    Message='The specified key does not exist.'
+                )
+            ),
+            'HeadObject',
+        )
+
+        with mock.patch.object(self.client, 'complete_multipart_upload') as mock_complete, \
+             mock.patch.object(self.client, 'head_object') as mock_head:
+
+            # Force the complete call to fail with the specific ClientError
+            mock_complete.side_effect = client_error
+            # Force the polling loop to fail once (NoSuchKey), then succeed (Return metadata)
+            mock_head.side_effect = [
+                head_error,
+                {'ContentLength': 15, 'ContentType': 'application/octet-stream'}
+            ]
+
+            with smart_open.open(
+                f's3://{BUCKET_NAME}/{WRITE_KEY_NAME}',
+                mode="wb",
+                transport_params={"client": self.client}
+            ) as fout:
+                fout.write(b"test")
+
+            # Assertions to verify the polling mechanism worked exactly as intended
+            mock_complete.assert_called_once()
+            self.assertEqual(mock_head.call_count, 2)
+            mock_sleep.assert_called_once_with(5)
 
 
 @mock_s3


### PR DESCRIPTION
### Motivation:
When uploading to S3-compatible backends (like Object Storage by Hetzner), completing a multipart upload can occasionally fail with an InternalError: This multipart completion is already in progress. This typically happens due to eventual consistency delays: if botocore experiences a timeout or delay, it automatically retries the CompleteMultipartUpload request while the backend is already processing the initial request.

Previously, this resulted in an unhandled `ClientError` that crashed the pipeline, even though the file was successfully uploaded on the backend.


```sh
Traceback (most recent call last):
  File "/home/runner/actions-runner/_work/repo/repo/common/data_integration/transports/s3.py", line 225, in upload
    with open(
         ^^^^^
  File "/home/runner/actions-runner/_work/repo/repo/venv/lib64/python3.12/site-packages/smart_open/utils.py", line 222, in __exit__
    self.__inner.__exit__(*args, **kwargs)
  File "/home/runner/actions-runner/_work/repo/repo/venv/lib64/python3.12/site-packages/smart_open/s3.py", line 1101, in __exit__
    self.close()
  File "/home/runner/actions-runner/_work/repo/repo/venv/lib64/python3.12/site-packages/smart_open/s3.py", line 946, in close
    RETRY._do(partial)
  File "/home/runner/actions-runner/_work/repo/repo/venv/lib64/python3.12/site-packages/smart_open/s3.py", line 92, in _do
    return fn()
           ^^^^
  File "/home/runner/actions-runner/_work/repo/repo/venv/lib64/python3.12/site-packages/botocore/client.py", line 569, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/actions-runner/_work/repo/repo/venv/lib64/python3.12/site-packages/botocore/client.py", line 1023, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InternalError) when calling the CompleteMultipartUpload operation (reached max retries: 4): This multipart completion is already in progress
```

### The Fix:
This PR catches this specific InternalError and implements a lightweight polling mechanism. It uses [`HeadObject`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html) to verify that the file exists on the backend, waiting up to 60 seconds (handling both AWS standard `NoSuchKey` and Ceph-specific `404` missing object errors). Once verified, it closes gracefully. I have also included a unit test using a mocked boto3 client to ensure this retry logic is covered.


### Tests:
 
- [x] 1. Create a unit test that demonstrates the bug. The test should **fail**.
- [x] 2. Implement your bug fix.
- [x] 3. The test you created should now **pass**.

### Checklist:

> Before you mark the PR as "ready for review", please make sure you have:

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [ ] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [ ] Run `python update_helptext.py` in case there are API changes
- [x] Checked that all unit tests pass