### PR TITLE
[http,azure] Optimize forward seeks within buffered data to avoid redundant requests

### DIFF
--- a/smart_open/azure.py
+++ b/smart_open/azure.py
@@ -284,6 +284,16 @@ class Reader(io.BufferedIOBase):
             new_position = self._position + offset
         else:
             new_position = self._size + offset
+
+        # Check if we can satisfy the seek from buffer (forward seek within buffered data)
+        if (
+            new_position > self._position
+            and new_position - self._position <= len(self._current_part)
+        ):
+            self._current_part.read(new_position - self._position)
+            self._position = new_position
+            return self._position
+
         self._position = new_position
         self._raw_reader.seek(new_position)
         logger.debug('current_pos: %r', self._position)

--- a/smart_open/http.py
+++ b/smart_open/http.py
@@ -264,6 +264,12 @@ class SeekableBufferedInputBase(BufferedInputBase):
         if self._current_pos == new_pos:
             return self._current_pos
 
+        # Check if we can satisfy the seek from buffer (forward seek within buffered data)
+        if new_pos > self._current_pos and new_pos - self._current_pos <= len(self._read_buffer):
+            self._read_buffer.read(new_pos - self._current_pos)
+            self._current_pos = new_pos
+            return self._current_pos
+
         logger.debug("http seeking from current_pos: %d to new_pos: %d", self._current_pos, new_pos)
 
         self._current_pos = new_pos

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -12,6 +12,7 @@ import logging
 import os
 import time
 import unittest
+import unittest.mock
 import uuid
 from collections import OrderedDict
 from typing import Literal
@@ -466,6 +467,31 @@ class ReaderTest(unittest.TestCase):
         seek = fin.seek(-4, whence=smart_open.constants.WHENCE_END)
         self.assertEqual(seek, len(content) - 4)
         self.assertEqual(fin.read(), b'you?')
+
+    def test_seek_forward_within_buffer(self):
+        """Does forward seeking within buffered data avoid additional download_blob requests?"""
+        content = u"hello wořld\nhow are you?".encode('utf8')
+        blob_name = "test_seek_forward_within_buffer_%s" % BLOB_NAME
+        put_to_container(blob_name, contents=content)
+
+        fin = smart_open.azure.Reader(CONTAINER_NAME, blob_name, CLIENT, buffer_size=32)
+        self.assertEqual(fin.read(5), b'hello')
+
+        # Account for the initial download_blob call from the read above.
+        with unittest.mock.patch.object(
+            fin._blob, 'download_blob', wraps=fin._blob.download_blob
+        ) as mock_download:
+            # Forward seek within buffer using WHENCE_CURRENT - no new download
+            seek = fin.seek(1, whence=smart_open.constants.WHENCE_CURRENT)
+            self.assertEqual(seek, 6)
+            self.assertEqual(fin.read(6), u'wořld'.encode('utf-8'))
+
+            # Forward seek within buffer using WHENCE_START - no new download
+            seek = fin.seek(13, whence=smart_open.constants.WHENCE_START)
+            self.assertEqual(seek, 13)
+            self.assertEqual(fin.read(3), b'how')
+
+            mock_download.assert_not_called()
 
     def test_detect_eof(self):
         content = u"hello wořld\nhow are you?".encode('utf8')

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -85,6 +85,27 @@ class HttpTest(unittest.TestCase):
         self.assertEqual(BYTES[30:40], read_bytes)
 
     @responses.activate
+    def test_seek_forward_within_buffer(self):
+        """Does forward seeking within buffered data avoid additional GET requests?"""
+        responses.add_callback(responses.GET, URL, callback=request_callback)
+        reader = smart_open.http.SeekableBufferedInputBase(URL, buffer_size=32)
+
+        self.assertEqual(reader.read(5), BYTES[:5])
+        initial_calls = len(responses.calls)
+
+        # Forward seek within buffer using WHENCE_CURRENT - no new GET request
+        reader.seek(1, whence=smart_open.constants.WHENCE_CURRENT)
+        self.assertEqual(reader.tell(), 6)
+        self.assertEqual(reader.read(5), BYTES[6:11])
+
+        # Forward seek within buffer using WHENCE_START - no new GET request
+        reader.seek(13, whence=smart_open.constants.WHENCE_START)
+        self.assertEqual(reader.tell(), 13)
+        self.assertEqual(reader.read(3), BYTES[13:16])
+
+        self.assertEqual(len(responses.calls), initial_calls)
+
+    @responses.activate
     def test_seek_from_end(self):
         responses.add_callback(responses.GET, URL, callback=request_callback)
         reader = smart_open.http.SeekableBufferedInputBase(URL)


### PR DESCRIPTION
### Motivation

Closes #712.

Follow-up to #892, which added a forward-seek-within-buffer fast path to the S3 reader. This PR ports the same optimization to the remaining transports that maintain their own `ByteBuffer` and still discard it on every seek:

- **HTTP** — `SeekableBufferedInputBase.seek` previously called `_read_buffer.empty()` and issued a fresh ranged GET on every seek, even when the target offset fell within the current buffer.
- **Azure** — `Reader.seek` previously called `_current_part.empty()` and `_raw_reader.seek(...)` on every seek, with the same downside.

Both seeks now check whether the requested forward offset is within `len(buffer)` of the current position, and if so, just advance the buffer cursor without making a new request.

Out of scope (per discussion in #712):
- **GCS** — delegates to `google-cloud-storage`'s `BlobReader`, which invalidates its own buffer on backward seek by design.
- **HDFS / WebHDFS / SSH / FTP** — none rely on smart_open's `ByteBuffer` for seek (HDFS/WebHDFS are not seekable; SSH/FTP delegate to native file objects).

### Tests

Added `test_seek_forward_within_buffer` to both `tests/test_http.py` and `tests/test_azure.py`, mirroring the S3 test from #892:

- HTTP test asserts `len(responses.calls)` does not increase across forward seeks within the buffer.
- Azure test wraps `BlobClient.download_blob` with `unittest.mock` and asserts it is not called during forward seeks within the buffer.

### Checklist

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass