### PR TITLE
[azure] Mark Writer/AppendWriter closed even when close() raises

### DIFF
--- a/smart_open/azure.py
+++ b/smart_open/azure.py
@@ -453,11 +453,13 @@ class Writer(io.BufferedIOBase):
         logger.debug("close: called")
         if not self.closed:
             logger.debug('%s: completing multipart upload', self)
-            if self._current_part.tell() > 0:
-                self._upload_part()
-            self._blob.commit_block_list(self._block_list, **self._blob_kwargs)
-            self._block_list = []
-            self._blob = None
+            try:
+                if self._current_part.tell() > 0:
+                    self._upload_part()
+                self._blob.commit_block_list(self._block_list, **self._blob_kwargs)
+            finally:
+                self._block_list = []
+                self._blob = None
             logger.debug('%s: completed multipart upload', self)
 
     @property
@@ -596,9 +598,11 @@ class AppendWriter(io.BufferedIOBase):
     def close(self):
         """No action needed here, as the AppendBlob is automatically committed"""
         if not self.closed:
-            if self._current_part.tell() > 0:
-                self._upload_part()
-            self._blob = None
+            try:
+                if self._current_part.tell() > 0:
+                    self._upload_part()
+            finally:
+                self._blob = None
 
     @property
     def closed(self):

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -914,6 +914,19 @@ class WriterTest(unittest.TestCase):
         fout.flush()
         fout.close()
 
+    def test_close_marks_closed_on_error(self):
+        """If close() raises during upload, the writer must still mark itself closed.
+
+        Otherwise __del__ would retry the upload and surface an unraisable exception.
+        """
+        text = u'там за туманами, вечными, пьяными'.encode('utf-8')
+        fout = smart_open.azure.Writer(CONTAINER_NAME, 'key', CLIENT)
+        fout.write(text)
+        with unittest.mock.patch.object(fout, '_upload_part', side_effect=RuntimeError('boom')):
+            with self.assertRaises(RuntimeError):
+                fout.close()
+        self.assertTrue(fout.closed)
+
 
 class AppendWriterTest(unittest.TestCase):
     """Test appending into Azure Blob files."""
@@ -966,11 +979,15 @@ class AppendWriterTest(unittest.TestCase):
         with smart_open.azure.Writer(CONTAINER_NAME, blob_name, CLIENT) as fout:
             fout.write(test_string)
 
+        fout = smart_open.azure.AppendWriter(CONTAINER_NAME, blob_name, CLIENT)
+        fout.write(test_string)
         with self.assertRaises(
             azure.core.exceptions.ResourceExistsError, msg="The blob type is invalid for this operation."
         ):
-            with smart_open.azure.AppendWriter(CONTAINER_NAME, blob_name, CLIENT) as fout:
-                fout.write(test_string)
+            fout.close()
+        # close() raised, but the writer must still mark itself closed so that
+        # __del__ does not retry the upload and trigger an unraisable exception.
+        self.assertTrue(fout.closed)
 
     def test_append_on_error(self):
         """


### PR DESCRIPTION
### Motivation

Surfaced by the CI warning observed on #923:

```
PytestUnraisableExceptionWarning: Exception ignored while finalizing file
AppendWriter(container='...', blob='test_append_existing_write_blob_test-blob'):
azure.core.exceptions.ResourceExistsError: The blob type is invalid for this operation.
```

In `Writer.close()` (`smart_open/azure.py:452`) and `AppendWriter.close()` (`smart_open/azure.py:596`), `self._blob = None` runs *after* the upload calls. If the upload raises (e.g. `commit_block_list` failing, or `upload_blob` rejecting an AppendBlob upload on an existing BlockBlob), `self._blob` is never cleared, so `closed` still reports `False`. `io.IOBase.__del__` then calls `close()` again during garbage collection, which retries the failing upload — and Python surfaces the resulting exception as an unraisable warning (promoted to `PytestUnraisableExceptionWarning` by pytest 8+ under Python 3.14).

This PR wraps the upload calls in `try/finally` so both writers always mark themselves closed, regardless of whether the upload succeeded.

### Tests

- `WriterTest.test_close_marks_closed_on_error` — patches `_upload_part` to raise and asserts `closed` becomes `True`.
- `AppendWriterTest.test_append_existing_write_blob` — refactored to invoke `close()` explicitly and assert `closed` is `True` after the `ResourceExistsError`. Without the fix, the test fails on the new `assertTrue(fout.closed)`.

Both tests pass with `-W error::pytest.PytestUnraisableExceptionWarning` after the fix; without the fix, both fail.

### Checklist

- [x] Picked a concise, informative and complete title
- [x] Clearly explained the motivation behind the PR
- [x] Linked to any existing issues that your PR will be solving
- [x] Included tests for any new functionality
- [x] Checked that all unit tests pass