### PR TITLE
[s3] Remove deprecated smart_open.s3_iter_bucket shim

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -14,7 +14,6 @@ DESCRIPTION
 
     * `open()`, which opens the given file for reading/writing
     * `parse_uri()`
-    * `s3_iter_bucket()`, which goes over all keys in an S3 bucket in parallel
     * `register_compressor()`, which registers callbacks for transparent compressor handling
 
 PACKAGE CONTENTS
@@ -446,8 +445,5 @@ FUNCTIONS
 
         This is just an example: `lzma` is in the standard library and is registered by default.
 
-    s3_iter_bucket(bucket_name, prefix='', accept_key=None, key_limit=None, workers=16, retries=3, **session_kwargs)
-        Deprecated.  Use smart_open.s3.iter_bucket instead.
-
 DATA
-    __all__ = ['open', 'parse_uri', 'register_compressor', 's3_iter_bucket...
+    __all__ = ['open', 'parse_uri', 'register_compressor']

--- a/smart_open/__init__.py
+++ b/smart_open/__init__.py
@@ -17,7 +17,6 @@ The main functions are:
 
 * `open()`, which opens the given file for reading/writing
 * `parse_uri()`
-* `s3_iter_bucket()`, which goes over all keys in an S3 bucket in parallel
 * `register_compressor()`, which registers callbacks for transparent compressor handling
 
 """
@@ -37,44 +36,8 @@ logger.addHandler(logging.NullHandler())
 from .compression import register_compressor  # noqa: E402
 from .smart_open_lib import open, parse_uri  # noqa: E402
 
-_WARNING = """smart_open.s3_iter_bucket is deprecated and will stop functioning
-in a future version. Please import iter_bucket from the smart_open.s3 module instead:
-
-    from smart_open.s3 import iter_bucket as s3_iter_bucket
-
-"""
-_WARNED = False
-
-
-def s3_iter_bucket(
-        bucket_name,
-        prefix='',
-        accept_key=None,
-        key_limit=None,
-        workers=16,
-        retries=3,
-        **session_kwargs
-):
-    """Deprecated.  Use smart_open.s3.iter_bucket instead."""
-    global _WARNED
-    from .s3 import iter_bucket
-    if not _WARNED:
-        logger.warning(_WARNING)
-        _WARNED = True
-    return iter_bucket(
-        bucket_name=bucket_name,
-        prefix=prefix,
-        accept_key=accept_key,
-        key_limit=key_limit,
-        workers=workers,
-        retries=retries,
-        session_kwargs=session_kwargs
-    )
-
-
 __all__ = [
     'open',
     'parse_uri',
     'register_compressor',
-    's3_iter_bucket',
 ]

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1014,18 +1014,6 @@ class IterBucketTest(unittest.TestCase):
             with pytest.raises(botocore.exceptions.ClientError):
                 list(smart_open.s3.iter_bucket(BUCKET_NAME))
 
-    def test_deprecated_top_level_s3_iter_bucket(self):
-        populate_bucket()
-        with self.assertLogs(smart_open.logger.name, level='WARN') as cm:
-            # invoking once will generate a warning
-            smart_open.s3_iter_bucket(BUCKET_NAME)
-            # invoking again will not (to reduce spam)
-            smart_open.s3_iter_bucket(BUCKET_NAME)
-            # verify only one output
-            assert len(cm.output) == 1
-            # verify the suggested new import is in the warning
-            assert "from smart_open.s3 import iter_bucket as s3_iter_bucket" in cm.output[0]
-
     def test_accepts_boto3_bucket(self):
         populate_bucket()
         bucket = _resource('s3').Bucket(BUCKET_NAME)


### PR DESCRIPTION
Part of #926.

Drops the top-level `smart_open.s3_iter_bucket()` wrapper from `smart_open/__init__.py` along with its `_WARNING`/`_WARNED` globals. The wrapper has been emitting a deprecation warning pointing users at `smart_open.s3.iter_bucket as s3_iter_bucket` for years; v8.0.0 hard-removes it.

Also drops the corresponding `test_deprecated_top_level_s3_iter_bucket` from `tests/test_s3.py`.

## Migration

```diff
- from smart_open import s3_iter_bucket
+ from smart_open.s3 import iter_bucket as s3_iter_bucket
```