### PR TITLE
Remove deprecated top-level smart_open() function

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -450,7 +450,5 @@ FUNCTIONS
     s3_iter_bucket(bucket_name, prefix='', accept_key=None, key_limit=None, workers=16, retries=3, **session_kwargs)
         Deprecated.  Use smart_open.s3.iter_bucket instead.
 
-    smart_open(uri, mode='rb', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, ignore_extension=False, **kwargs)
-
 DATA
     __all__ = ['open', 'parse_uri', 'register_compressor', 's3_iter_bucket...

--- a/integration-tests/test_184.py
+++ b/integration-tests/test_184.py
@@ -10,7 +10,7 @@ import time
 
 import smart_open
 
-open_fn = smart_open.smart_open
+open_fn = smart_open.open
 # open_fn = open
 
 

--- a/integration-tests/test_207.py
+++ b/integration-tests/test_207.py
@@ -30,7 +30,7 @@ def tofile():
 def test_fromfile():
     try:
         path = tofile()
-        with smart_open.smart_open(path, 'rb') as fin:
+        with smart_open.open(path, 'rb') as fin:
             np.fromfile(fin)
     finally:
         os.unlink(path)

--- a/integration-tests/test_hdfs.py
+++ b/integration-tests/test_hdfs.py
@@ -11,11 +11,11 @@ Requires hadoop to be running on localhost, at the moment.
 """
 import smart_open
 
-with smart_open.smart_open("hdfs://user/root/input/core-site.xml") as fin:
+with smart_open.open("hdfs://user/root/input/core-site.xml") as fin:
     print(fin.read())
 
-with smart_open.smart_open("hdfs://user/root/input/test.txt") as fin:
+with smart_open.open("hdfs://user/root/input/test.txt") as fin:
     print(fin.read())
 
-with smart_open.smart_open("hdfs://user/root/input/test.txt?user.name=root", 'wb') as fout:
+with smart_open.open("hdfs://user/root/input/test.txt?user.name=root", 'wb') as fout:
     fout.write(b'hello world')

--- a/integration-tests/test_http.py
+++ b/integration-tests/test_http.py
@@ -20,28 +20,28 @@ BASE_URL = ('https://raw.githubusercontent.com/RaRe-Technologies/smart_open/'
 class ReadTest(unittest.TestCase):
     def test_read_text(self):
         url = BASE_URL + 'crime-and-punishment.txt'
-        with smart_open.smart_open(url, encoding='utf-8') as fin:
+        with smart_open.open(url, encoding='utf-8') as fin:
             text = fin.read()
         self.assertTrue(text.startswith('В начале июля, в чрезвычайно жаркое время,'))
         self.assertTrue(text.endswith('улизнуть, чтобы никто не видал.\n'))
 
     def test_read_binary(self):
         url = BASE_URL + 'crime-and-punishment.txt'
-        with smart_open.smart_open(url, 'rb') as fin:
+        with smart_open.open(url, 'rb') as fin:
             text = fin.read()
         self.assertTrue(text.startswith('В начале июля, в чрезвычайно'.encode('utf-8')))
         self.assertTrue(text.endswith('улизнуть, чтобы никто не видал.\n'.encode('utf-8')))
 
     def test_read_gzip_text(self):
         url = BASE_URL + 'crime-and-punishment.txt.gz'
-        with smart_open.smart_open(url, encoding='utf-8') as fin:
+        with smart_open.open(url, encoding='utf-8') as fin:
             text = fin.read()
         self.assertTrue(text.startswith('В начале июля, в чрезвычайно жаркое время,'))
         self.assertTrue(text.endswith('улизнуть, чтобы никто не видал.\n'))
 
     def test_read_gzip_binary(self):
         url = BASE_URL + 'crime-and-punishment.txt.gz'
-        with smart_open.smart_open(url, 'rb', ignore_extension=True) as fin:
+        with smart_open.open(url, 'rb', compression='disable') as fin:
             binary = fin.read()
         self.assertTrue(binary.startswith(GZIP_MAGIC))
 

--- a/smart_open/__init__.py
+++ b/smart_open/__init__.py
@@ -34,7 +34,7 @@ with contextlib.suppress(PackageNotFoundError):
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
-from .smart_open_lib import open, parse_uri, smart_open, register_compressor  # noqa: E402
+from .smart_open_lib import open, parse_uri, register_compressor  # noqa: E402
 
 _WARNING = """smart_open.s3_iter_bucket is deprecated and will stop functioning
 in a future version. Please import iter_bucket from the smart_open.s3 module instead:
@@ -76,5 +76,4 @@ __all__ = [
     'parse_uri',
     'register_compressor',
     's3_iter_bucket',
-    'smart_open',
 ]

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -15,7 +15,6 @@ import os
 import os.path as P
 import pathlib
 import urllib.parse
-import warnings
 
 #
 # This module defines a function called smart_open so we cannot use
@@ -466,46 +465,6 @@ def _patch_pathlib(func):
     old_impl = pathlib.Path.open
     pathlib.Path.open = func
     return old_impl
-
-
-def smart_open(
-        uri,
-        mode='rb',
-        buffering=-1,
-        encoding=None,
-        errors=None,
-        newline=None,
-        closefd=True,
-        opener=None,
-        ignore_extension=False,
-        **kwargs
-    ):
-    #
-    # This is a thin wrapper of smart_open.open.  It's here for backward
-    # compatibility.  It works exactly like smart_open.open when the passed
-    # parameters are identical.  Otherwise, it raises a DeprecationWarning.
-    #
-    # For completeness, the main differences of the old smart_open function:
-    #
-    # 1. Default mode was read binary (mode='rb')
-    # 2. compression parameter was called ignore_extension
-    # 3. Transport parameters were passed directly as kwargs
-    #
-    url = 'https://github.com/piskvorky/smart_open/blob/develop/MIGRATING_FROM_OLDER_VERSIONS.rst'
-    if kwargs:
-        raise DeprecationWarning(
-            'The following keyword parameters are not supported: %r. '
-            'See  %s for more information.' % (sorted(kwargs), url)
-        )
-    message = 'This function is deprecated.  See %s for more information' % url
-    warnings.warn(message, category=DeprecationWarning)
-
-    if ignore_extension:
-        compression = so_compression.NO_COMPRESSION
-    else:
-        compression = so_compression.INFER_FROM_EXTENSION
-    del kwargs, url, message, ignore_extension
-    return open(**locals())
 
 
 #

--- a/tests/test_smart_open.py
+++ b/tests/test_smart_open.py
@@ -1221,12 +1221,12 @@ class SmartOpenTest(unittest.TestCase):
 
     def test_incorrect(self):
         # incorrect file mode
-        self.assertRaises(NotImplementedError, smart_open.smart_open, "s3://bucket/key", "x")
+        self.assertRaises(NotImplementedError, smart_open.open, "s3://bucket/key", "x")
 
         # correct write modes, incorrect scheme
-        self.assertRaises(NotImplementedError, smart_open.smart_open, "hdfs:///blah.txt", "wb+")
-        self.assertRaises(NotImplementedError, smart_open.smart_open, "http:///blah.txt", "w")
-        self.assertRaises(NotImplementedError, smart_open.smart_open, "s3://bucket/key", "wb+")
+        self.assertRaises(NotImplementedError, smart_open.open, "hdfs:///blah.txt", "wb+")
+        self.assertRaises(NotImplementedError, smart_open.open, "http:///blah.txt", "w")
+        self.assertRaises(NotImplementedError, smart_open.open, "s3://bucket/key", "wb+")
 
     def test_write_utf8(self):
         # correct write mode, correct file:// URI
@@ -1955,23 +1955,6 @@ def test_get_binary_mode(mode, expected):
 def test_get_binary_mode_bad(mode):
     with pytest.raises(ValueError):
         smart_open.smart_open_lib._get_binary_mode(mode)
-
-
-def test_backwards_compatibility_wrapper():
-    fpath = os.path.join(CURR_DIR, 'test_data/crime-and-punishment.txt')
-    expected = open(fpath, 'rb').readline()
-
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-
-        actual = smart_open.smart_open(fpath).readline()
-        assert expected == actual
-
-        actual = smart_open.smart_open(fpath, ignore_extension=True).readline()
-        assert expected == actual
-
-    with pytest.raises(DeprecationWarning):
-        smart_open.smart_open(fpath, unsupported_keyword_param=123)
 
 
 @pytest.mark.skipif(os.name == "nt", reason="this test does not work on Windows")


### PR DESCRIPTION
Part of #926.

Drops the top-level `smart_open.smart_open()` function from `smart_open/smart_open_lib.py`. It was a thin compatibility wrapper around `smart_open.open()` that emitted a `DeprecationWarning`; v8.0.0 hard-removes it.

Also removes the now-unused `import warnings` in `smart_open_lib.py`, the `test_backwards_compatibility_wrapper` test, updates `test_incorrect` to call `smart_open.open` directly, and updates the `integration-tests/` scripts to use `smart_open.open` instead of the removed wrapper.

## Migration

```diff
- fin = smart_open.smart_open(uri, mode='rb', ignore_extension=True)
+ fin = smart_open.open(uri, mode='rb', compression='disable')
```