### PR TITLE
Remove smart_open_lib backwards-compat re-exports

### DIFF
--- a/smart_open/__init__.py
+++ b/smart_open/__init__.py
@@ -34,7 +34,8 @@ with contextlib.suppress(PackageNotFoundError):
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
-from .smart_open_lib import open, parse_uri, register_compressor  # noqa: E402
+from .compression import register_compressor  # noqa: E402
+from .smart_open_lib import open, parse_uri  # noqa: E402
 
 _WARNING = """smart_open.s3_iter_bucket is deprecated and will stop functioning
 in a future version. Please import iter_bucket from the smart_open.s3 module instead:

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -27,13 +27,6 @@ import smart_open.utils as so_utils
 from smart_open import doctools
 from smart_open import transport
 
-#
-# For backwards compatibility and keeping old unit tests happy.
-#
-from smart_open.compression import register_compressor  # noqa: F401
-from smart_open.utils import check_kwargs as _check_kwargs  # noqa: F401
-from smart_open.utils import inspect_kwargs as _inspect_kwargs  # noqa: F401
-
 logger = logging.getLogger(__name__)
 
 DEFAULT_ENCODING = locale.getpreferredencoding(do_setlocale=False)

--- a/tests/test_smart_open.py
+++ b/tests/test_smart_open.py
@@ -1662,7 +1662,7 @@ class S3OpenTest(unittest.TestCase):
             self.assertEqual(fin.read().decode("utf-8"), text)
 
     @mock_s3
-    @mock.patch('smart_open.smart_open_lib._inspect_kwargs', mock.Mock(return_value={}))
+    @mock.patch('smart_open.utils.inspect_kwargs', mock.Mock(return_value={}))
     def test_gzip_write_mode(self):
         """Should always open in binary mode when writing through a codec."""
         s3 = _resource('s3')
@@ -1673,7 +1673,7 @@ class S3OpenTest(unittest.TestCase):
             mock_open.assert_called_with('bucket', 'key.gz', 'wb')
 
     @mock_s3
-    @mock.patch('smart_open.smart_open_lib._inspect_kwargs', mock.Mock(return_value={}))
+    @mock.patch('smart_open.utils.inspect_kwargs', mock.Mock(return_value={}))
     def test_gzip_read_mode(self):
         """Should always open in binary mode when reading through a codec."""
         s3 = _resource('s3')
@@ -1819,7 +1819,7 @@ class CheckKwargsTest(unittest.TestCase):
     def test(self):
         kwargs = {'foo': 123, 'bad': False}
         expected = {'foo': 123}
-        actual = smart_open.smart_open_lib._check_kwargs(function, kwargs)
+        actual = smart_open.utils.check_kwargs(function, kwargs)
         self.assertEqual(expected, actual)
 
 


### PR DESCRIPTION
Part of #926.

Drops three backwards-compat re-exports from `smart_open/smart_open_lib.py`:

- `register_compressor` (re-exported from `smart_open.compression`)
- `_check_kwargs` (alias for `smart_open.utils.check_kwargs`)
- `_inspect_kwargs` (alias for `smart_open.utils.inspect_kwargs`)

`smart_open/__init__.py` now imports `register_compressor` directly from `smart_open.compression` (the public `smart_open.register_compressor` API is unchanged). Two test mocks that referenced `smart_open.smart_open_lib._inspect_kwargs` / `_check_kwargs` are repointed at `smart_open.utils.inspect_kwargs` / `check_kwargs`.

## Migration

If you import the underscored aliases directly, switch to the canonical module:

```diff
- from smart_open.smart_open_lib import _check_kwargs, _inspect_kwargs
+ from smart_open.utils import check_kwargs, inspect_kwargs
```