### PR TITLE
[s3] Pass session_kwargs as a dict to s3.iter_bucket

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -1342,7 +1342,7 @@ def iter_bucket(
     retries=3,
     max_threads_per_fileobj=4,
     client_kwargs=None,
-    **session_kwargs,  # double star notation for backwards compatibility
+    session_kwargs=None,
 ):
     """
     Iterate and download all S3 objects under `s3://bucket_name/prefix`.
@@ -1386,9 +1386,8 @@ def iter_bucket(
 
     Notes
     -----
-    The keys are processed in parallel, using `workers` processes (default: 16),
-    to speed up downloads greatly. If multiprocessing is not available, thus
-    _MULTIPROCESSING is False, this parameter will be ignored.
+    The keys are processed in parallel, using `workers` threads (default: 16),
+    to speed up downloads greatly.
 
     Examples
     --------
@@ -1422,6 +1421,8 @@ def iter_bucket(
 
     # thread-safe client to share across _list_bucket and _download_key calls
     # https://github.com/boto/boto3/blob/1.38.41/docs/source/guide/clients.rst?plain=1#L111
+    if session_kwargs is None:
+        session_kwargs = {}
     session = boto3.session.Session(**session_kwargs)
     if client_kwargs is None:
         client_kwargs = {}

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1065,8 +1065,10 @@ class IterBucketCredentialsTest(unittest.TestCase):
             smart_open.s3.iter_bucket(
                 BUCKET_NAME,
                 workers=1,
-                aws_access_key_id='access_id',
-                aws_secret_access_key='access_secret'
+                session_kwargs={
+                    'aws_access_key_id': 'access_id',
+                    'aws_secret_access_key': 'access_secret',
+                },
             )
         )
         self.assertEqual(len(result), num_keys)


### PR DESCRIPTION
Part of #926.

Replaces the legacy `**session_kwargs` double-star catch-all on `smart_open.s3.iter_bucket()` with a single `session_kwargs=None` dict parameter. Callers must now pass a `dict` instead of arbitrary keyword arguments. The docstring's "multiprocessing" prose is also corrected to "multithreading" — `iter_bucket` runs on a `ThreadPoolExecutor`, not a process pool.

## Migration

```diff
  smart_open.s3.iter_bucket(
      bucket,
-     aws_access_key_id='id',
-     aws_secret_access_key='secret',
+     session_kwargs={
+         'aws_access_key_id': 'id',
+         'aws_secret_access_key': 'secret',
+     },
  )
```