### PR TITLE
Remove deprecated concurrency.create_pool and ConcurrentFuturesPool

### DIFF
--- a/smart_open/concurrency.py
+++ b/smart_open/concurrency.py
@@ -6,10 +6,12 @@
 # from the MIT License (MIT).
 #
 
-"""Common functionality for concurrent processing. The main entry point is :func:`create_pool`."""
+"""Common functionality for concurrent processing.
 
-import concurrent.futures
-import contextlib
+The main entry point is :class:`ThreadPoolExecutor`, which extends the
+standard library executor with a lazy ``imap`` method.
+"""
+
 import logging
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor as _ThreadPoolExecutor
@@ -59,29 +61,3 @@ class ThreadPoolExecutor(_ThreadPoolExecutor):
 
         while futures:
             yield get()
-
-
-# ConcurrentFuturesPool and create_pool were once used in smart_open.s3.iter_bucket.
-# Left here for backwards compatibility.
-
-
-class ConcurrentFuturesPool(object):
-    """A class that mimics multiprocessing.pool.Pool but uses concurrent futures instead of processes."""
-    def __init__(self, max_workers):
-        self.executor = ThreadPoolExecutor(max_workers=max_workers)
-
-    def imap_unordered(self, function, items):
-        futures = [self.executor.submit(function, item) for item in items]
-        for future in concurrent.futures.as_completed(futures):
-            yield future.result()
-
-    def terminate(self):
-        self.executor.shutdown(wait=True)
-
-
-@contextlib.contextmanager
-def create_pool(processes=1):  # arg is called processes due to historical reasons
-    logger.info("creating concurrent futures pool with %i workers", processes)
-    pool = ConcurrentFuturesPool(max_workers=processes)
-    yield pool
-    pool.terminate()


### PR DESCRIPTION
Part of #926.

Drops `smart_open.concurrency.create_pool()` and `ConcurrentFuturesPool` — both kept only for backwards compatibility after `smart_open.s3.iter_bucket` switched to using `smart_open.concurrency.ThreadPoolExecutor` directly (no internal callers remain). Also drops the now-unused `concurrent.futures` and `contextlib` imports.

The public `smart_open.concurrency.ThreadPoolExecutor` (subclass of `concurrent.futures.ThreadPoolExecutor` with a lazy `imap` method) is unchanged.

## Migration

```diff
- with smart_open.concurrency.create_pool(processes=8) as pool:
-     for result in pool.imap_unordered(fn, items):
-         ...
+ with smart_open.concurrency.ThreadPoolExecutor(max_workers=8) as pool:
+     for result in pool.imap(fn, items):
+         ...
```