### PR TITLE
Remove stale Python 2.7 references in comments and docstrings

### DIFF
--- a/smart_open/bytebuffer.py
+++ b/smart_open/bytebuffer.py
@@ -28,9 +28,6 @@ class ByteBuffer(object):
     Example
     -------
 
-    Note that while this example works in both Python 2 and 3, the doctest only
-    passes in Python 3 due to the bytestring literals in the expected values.
-
     >>> buf = ByteBuffer(chunk_size = 8)
     >>> message_bytes = iter([b'Hello, W', b'orld!'])
     >>> buf.fill(message_bytes)

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -862,7 +862,7 @@ class WriterTest(unittest.TestCase):
     def test_buffered_writer_wrapper_works(self):
         """
         Ensure that we can wrap a smart_open azure stream in a BufferedWriter, which
-        passes a memoryview object to the underlying stream in python >= 2.7
+        passes a memoryview object to the underlying stream.
         """
         expected = u'не думай о секундах свысока'
         blob_name = "test_buffered_writer_wrapper_works_%s" % BLOB_NAME

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -40,8 +40,7 @@ import smart_open.s3
 # we create this bucket once before running these tests and then
 # remove it when we're done.  The bucket has a random name so that we
 # can run multiple instances of this suite in parallel and not have
-# them conflict with one another. Travis, for example, runs the Python
-# 2.7, 3.6, and 3.7 suites concurrently.
+# them conflict with one another.
 BUCKET_NAME = 'test-smartopen'
 KEY_NAME = 'test-key'
 WRITE_KEY_NAME = 'test-write-key'


### PR DESCRIPTION
Part of #926.

Drops stale Python 2.7 mentions from three spots:

- `smart_open/bytebuffer.py` — docstring note that "this example works in both Python 2 and 3"
- `tests/test_s3.py` — comment referencing Travis running the "2.7, 3.6, and 3.7 suites concurrently"
- `tests/test_azure.py` — docstring mentioning behavior "in python >= 2.7"

Code-only cleanup, no behavior change. Historical CHANGELOG entries about Py2 support are intentionally kept.