### PR TITLE
[gcs] Remove no-op _blob.terminate shim in Writer

### DIFF
--- a/smart_open/gcs.py
+++ b/smart_open/gcs.py
@@ -170,7 +170,4 @@ def Writer(bucket,
 
     _blob = g_blob.open('wb', **blob_open_kwargs)
 
-    # backwards-compatiblity, was deprecated upstream https://cloud.google.com/storage/docs/resumable-uploads
-    _blob.terminate = lambda: None
-
     return _blob


### PR DESCRIPTION
Part of #926.

Drops the `_blob.terminate = lambda: None` monkey-patch in `smart_open/gcs.py` that kept a no-op `.terminate()` method on the google-cloud-storage blob writer. The shim was kept for backwards compatibility after Google [deprecated resumable-upload termination upstream](https://cloud.google.com/storage/docs/resumable-uploads); v8.0.0 stops papering over the upstream change.

## Migration

If you were calling `.terminate()` on a smart_open GCS writer expecting it to cancel the upload, it has been a silent no-op for some time. Rely on the writer's context manager or `.close()` for normal completion:

```diff
- writer = smart_open.open('gs://bucket/key', 'wb')
- writer.terminate()
+ with smart_open.open('gs://bucket/key', 'wb') as writer:
+     ...  # normal completion via __exit__/close
```