### PR TITLE
[s3] Remove deprecated transport params from open_uri

### DIFF
--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -14,7 +14,6 @@ import functools
 import itertools
 import logging
 import time
-import warnings
 from math import inf
 
 from typing import (
@@ -277,33 +276,6 @@ def _consolidate_params(uri, transport_params):
 
 
 def open_uri(uri, mode, transport_params):
-    deprecated = (
-        'multipart_upload_kwargs',
-        'object_kwargs',
-        'resource',
-        'resource_kwargs',
-        'session',
-        'singlepart_upload_kwargs',
-    )
-    detected = [k for k in deprecated if k in transport_params]
-    if detected:
-        doc_url = (
-            'https://github.com/piskvorky/smart_open/blob/develop/'
-            'MIGRATING_FROM_OLDER_VERSIONS.rst'
-        )
-        #
-        # We use warnings.warn /w UserWarning instead of logger.warn here because
-        #
-        # 1) Not everyone has logging enabled; and
-        # 2) check_kwargs (below) already uses logger.warn with a similar message
-        #
-        # https://github.com/piskvorky/smart_open/issues/614
-        #
-        message = (
-            'ignoring the following deprecated transport parameters: %r. '
-            'See <%s> for details' % (detected, doc_url)
-        )
-        warnings.warn(message, UserWarning)
     parsed_uri = parse_uri(uri)
     parsed_uri, transport_params = _consolidate_params(parsed_uri, transport_params)
     kwargs = smart_open.utils.check_kwargs(open, transport_params)


### PR DESCRIPTION
Part of #926.

Drops the deprecated transport-parameter detection in `smart_open.s3.open_uri`:

- `multipart_upload_kwargs`
- `object_kwargs`
- `resource`
- `resource_kwargs`
- `session`
- `singlepart_upload_kwargs`

These names were left over from when smart_open used the boto3 *resource* API. v5.0.0 already removed support for the parameters themselves — only a `UserWarning` for setting them remained. v8.0.0 drops the warning too. Also removes the now-unused `import warnings`.

## Migration

Migration recipes for these parameters are documented in [`MIGRATING_FROM_OLDER_VERSIONS.rst`](https://github.com/piskvorky/smart_open/blob/develop/MIGRATING_FROM_OLDER_VERSIONS.rst) under "Migrating to the new client-based S3 API" (the v5.0.0 section). Example for `session`:

```diff
- smart_open.open('s3://bucket/key', transport_params={'session': session})
+ smart_open.open('s3://bucket/key', transport_params={'client': session.client('s3')})
```