### PR TITLE
Refresh stale RaRe-Technologies URLs and boto wording

### DIFF
--- a/MIGRATING_FROM_OLDER_VERSIONS.rst
+++ b/MIGRATING_FROM_OLDER_VERSIONS.rst
@@ -129,7 +129,7 @@ Smart_open has grown over the years to cover a lot of different storages, each w
 * smart_open < 3.0.0: All dependencies were installed by default. No way to select just a subset during installation.
 * smart_open >= 3.0.0: No dependencies installed by default. Install the ones you need with e.g. ``pip install smart_open[s3]`` (only AWS), or ``smart_open[all]`` (install everything = same behaviour as < 3.0.0; use this for backward compatibility). 
 
-You can read more about the motivation and internal discussions for this change  `here <https://github.com/RaRe-Technologies/smart_open/issues/443>`_.
+You can read more about the motivation and internal discussions for this change  `here <https://github.com/piskvorky/smart_open/issues/443>`_.
 
 Migrating to the new ``open`` function
 ======================================
@@ -230,7 +230,7 @@ After:
   'first line\nsecond line\nthird lin'
 
 See ``help("smart_open.open")`` for the full list of acceptable parameter names,
-or view the help online `here <https://github.com/RaRe-Technologies/smart_open/blob/master/help.txt>`__.
+or view the help online `here <https://github.com/piskvorky/smart_open/blob/master/help.txt>`__.
 
 If you pass an invalid parameter name, the ``smart_open.open`` function will warn you about it.
 Keep an eye on your logs for WARNING messages from ``smart_open``.

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -462,7 +462,7 @@ def _get(client, bucket, key, version, range_string):
 
 
 def _unwrap_ioerror(ioe):
-    """Given an IOError from _get, return the 'Error' dictionary from boto."""
+    """Given an IOError from _get, return the 'Error' dictionary from botocore."""
     try:
         return ioe.backend_error.response['Error']
     except (AttributeError, KeyError):


### PR DESCRIPTION
Part of #926.

Mops up a few stale references in the same spirit as the Python 2.7 cleanup in #932:

- `MIGRATING_FROM_OLDER_VERSIONS.rst` — two stale `RaRe-Technologies/smart_open` URLs (the link to discussion issue #443 and the link to ``help.txt``) updated to the current `piskvorky/smart_open` URLs (GitHub redirects on org rename, so these would work either way, but the canonical URL is preferable).
- `smart_open/s3.py` — `_unwrap_ioerror` docstring said the returned ``'Error'`` dict comes "from boto", but smart_open has been on boto3/botocore for years; corrected to "from botocore".

The README Coveralls badge/link URLs are intentionally **left** on the `RaRe-Technologies/smart_open` path because Coveralls itself does not redirect on org rename.

Pure docstring/URL cleanup, no behaviour change.