### PR TITLE
Add compression_kwargs parameter to smart_open.open()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -271,6 +271,21 @@ To specify the algorithm explicitly (e.g. for non-standard file extensions):
     ...     print(fin.read(32))
     It was a bright cold day in Apri
 
+To forward per-call options to the compression library (e.g. lower gzip's
+default ``compresslevel`` of 9 for faster writes), pass ``compression_kwargs``:
+
+.. code-block:: python
+
+    >>> import tempfile
+    >>> from smart_open import open
+    >>> with tempfile.NamedTemporaryFile(suffix='.gz') as tmp:
+    ...     with open(tmp.name, 'wb', compression_kwargs={'compresslevel': 6}) as fout:
+    ...         _ = fout.write(b'hello world')
+
+The dict is forwarded as-is; spell each option using the underlying library's
+own kwarg name (``compresslevel`` for gzip/bz2, ``preset`` for xz, ``level`` for zstd,
+``compression_level`` for lz4).
+
 You can also easily add support for other file extensions and compression formats.
 For example, to open xz-compressed files:
 
@@ -279,8 +294,8 @@ For example, to open xz-compressed files:
     >>> import lzma, os
     >>> from smart_open import open, register_compressor
 
-    >>> def _handle_xz(file_obj, mode):
-    ...      return lzma.LZMAFile(filename=file_obj, mode=mode)
+    >>> def _handle_xz(file_obj, mode, **kwargs):
+    ...      return lzma.open(filename=file_obj, mode=mode, **kwargs)
 
     >>> register_compressor('.xz', _handle_xz)
 

--- a/help.txt
+++ b/help.txt
@@ -36,7 +36,7 @@ PACKAGE CONTENTS
     webhdfs
 
 FUNCTIONS
-    open(uri, mode='r', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, compression='infer_from_extension', transport_params=None)
+    open(uri, mode='r', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, compression='infer_from_extension', compression_kwargs=None, transport_params=None)
         Open the URI object, returning a file-like object.
 
         The URI is usually a string in a variety of formats.
@@ -67,6 +67,12 @@ FUNCTIONS
             Mimicks built-in open parameter of the same name.  Ignored.
         compression: str, optional (see smart_open.compression.get_supported_compression_types)
             Explicitly specify the compression/decompression behavior.
+        compression_kwargs: dict, optional
+            Keyword arguments forwarded to the registered compressor callback. Examples
+            of each library's max-compression option: {'compresslevel': 9} for
+            .gz/.bz2, {'preset': 9} for .xz, {'level': 22} for .zst,
+            {'compression_level': 12} for .lz4. Ignored when compression is 'disable'
+            or the URI's extension doesn't match a registered compressor.
         transport_params: dict, optional
             Additional parameters for the transport layer (see notes below).
 
@@ -427,9 +433,12 @@ FUNCTIONS
         ext: str
             The extension.  Must include the leading period, e.g. `.gz`.
         callback: callable
-            The callback.  It must accept two position arguments, file_obj and mode.
-            This function will be called when `smart_open` is opening a file with
-            the specified extension.
+            The callback.  It must accept two positional arguments, file_obj and mode,
+            and is recommended to also accept **kwargs so that whatever the caller passes
+            via smart_open.open(..., compression_kwargs={...}) reaches the underlying
+            library unchanged.  Callbacks with the legacy (file_obj, mode) signature still
+            work, but will raise TypeError if the caller supplies compression_kwargs
+            that the callback doesn't declare.
 
         Examples
         --------
@@ -437,9 +446,9 @@ FUNCTIONS
         Instruct smart_open to use the `lzma` module whenever opening a file
         with a .xz extension (see README.rst for the complete example showing I/O):
 
-        >>> def _handle_xz(file_obj, mode):
+        >>> def _handle_xz(file_obj, mode, **kwargs):
         ...     import lzma
-        ...     return lzma.LZMAFile(filename=file_obj, mode=mode)
+        ...     return lzma.open(filename=file_obj, mode=mode, **kwargs)
         >>>
         >>> register_compressor('.xz', _handle_xz)
 

--- a/smart_open/compression.py
+++ b/smart_open/compression.py
@@ -44,9 +44,12 @@ def register_compressor(ext, callback):
     ext: str
         The extension.  Must include the leading period, e.g. `.gz`.
     callback: callable
-        The callback.  It must accept two position arguments, file_obj and mode.
-        This function will be called when `smart_open` is opening a file with
-        the specified extension.
+        The callback.  It must accept two positional arguments, file_obj and mode,
+        and is recommended to also accept **kwargs so that whatever the caller passes
+        via smart_open.open(..., compression_kwargs={...}) reaches the underlying
+        library unchanged.  Callbacks with the legacy (file_obj, mode) signature still
+        work, but will raise TypeError if the caller supplies compression_kwargs
+        that the callback doesn't declare.
 
     Examples
     --------
@@ -54,9 +57,9 @@ def register_compressor(ext, callback):
     Instruct smart_open to use the `lzma` module whenever opening a file
     with a .xz extension (see README.rst for the complete example showing I/O):
 
-    >>> def _handle_xz(file_obj, mode):
+    >>> def _handle_xz(file_obj, mode, **kwargs):
     ...     import lzma
-    ...     return lzma.LZMAFile(filename=file_obj, mode=mode)
+    ...     return lzma.open(filename=file_obj, mode=mode, **kwargs)
     >>>
     >>> register_compressor('.xz', _handle_xz)
 
@@ -81,41 +84,47 @@ def _maybe_wrap_buffered(file_obj, mode):
     return result
 
 
-def _handle_bz2(file_obj, mode):
+def _handle_bz2(file_obj, mode, **kwargs):
     import bz2
-    result = bz2.open(filename=file_obj, mode=mode)
+    result = bz2.open(filename=file_obj, mode=mode, **kwargs)
     return _maybe_wrap_buffered(result, mode)
 
 
-def _handle_gzip(file_obj, mode):
+def _handle_gzip(file_obj, mode, **kwargs):
     import gzip
-    result = gzip.open(filename=file_obj, mode=mode)
+    result = gzip.open(filename=file_obj, mode=mode, **kwargs)
     return _maybe_wrap_buffered(result, mode)
 
 
-def _handle_zstd(file_obj, mode):
+def _handle_zstd(file_obj, mode, **kwargs):
     import sys
     if sys.version_info >= (3, 14):
         from compression import zstd
     else:
         from backports import zstd
-    result = zstd.open(file_obj, mode=mode)
+    result = zstd.open(file_obj, mode=mode, **kwargs)
     return _maybe_wrap_buffered(result, mode)
 
 
-def _handle_xz(file_obj, mode):
+def _handle_xz(file_obj, mode, **kwargs):
     import lzma
-    result = lzma.open(filename=file_obj, mode=mode)
+    result = lzma.open(filename=file_obj, mode=mode, **kwargs)
     return _maybe_wrap_buffered(result, mode)
 
 
-def _handle_lz4(file_obj, mode):
+def _handle_lz4(file_obj, mode, **kwargs):
     import lz4.frame
-    result = lz4.frame.open(file_obj, mode=mode)
+    result = lz4.frame.open(file_obj, mode=mode, **kwargs)
     return _maybe_wrap_buffered(result, mode)
 
 
-def compression_wrapper(file_obj, mode, compression=INFER_FROM_EXTENSION, filename=None):
+def compression_wrapper(
+    file_obj,
+    mode,
+    compression=INFER_FROM_EXTENSION,
+    filename=None,
+    compression_kwargs=None,
+):
     """
     Wrap `file_obj` with an appropriate [de]compression mechanism based on its file extension.
 
@@ -125,6 +134,9 @@ def compression_wrapper(file_obj, mode, compression=INFER_FROM_EXTENSION, filena
 
     If `filename` is specified, it will be used to extract the extension.
     If not, the `file_obj.name` attribute is used as the filename.
+
+    If `compression_kwargs` is specified, its contents are forwarded as keyword
+    arguments to the registered compressor callback.
 
     """
     if compression == NO_COMPRESSION:
@@ -147,8 +159,8 @@ def compression_wrapper(file_obj, mode, compression=INFER_FROM_EXTENSION, filena
         callback = _COMPRESSOR_REGISTRY[compression]
     except KeyError:
         return file_obj
-    else:
-        return callback(file_obj, mode)
+
+    return callback(file_obj, mode, **(compression_kwargs or {}))
 
 
 #

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -92,6 +92,7 @@ def open(
         closefd=True,
         opener=None,
         compression=so_compression.INFER_FROM_EXTENSION,
+        compression_kwargs=None,
         transport_params=None,
         ):
     r"""Open the URI object, returning a file-like object.
@@ -124,6 +125,12 @@ def open(
         Mimicks built-in open parameter of the same name.  Ignored.
     compression: str, optional (see smart_open.compression.get_supported_compression_types)
         Explicitly specify the compression/decompression behavior.
+    compression_kwargs: dict, optional
+        Keyword arguments forwarded to the registered compressor callback. Examples
+        of each library's max-compression option: {'compresslevel': 9} for
+        .gz/.bz2, {'preset': 9} for .xz, {'level': 22} for .zst,
+        {'compression_level': 12} for .lz4. Ignored when compression is 'disable'
+        or the URI's extension doesn't match a registered compressor.
     transport_params: dict, optional
         Additional parameters for the transport layer (see notes below).
 
@@ -219,6 +226,7 @@ def open(
         binary_mode,
         compression,
         filename=filename,
+        compression_kwargs=compression_kwargs,
     )
 
     if 'b' not in mode or explicit_encoding is not None:

--- a/tests/test_smart_open.py
+++ b/tests/test_smart_open.py
@@ -78,6 +78,18 @@ def named_temporary_file(mode='w+b', prefix=None, suffix=None, delete=True):
             logger.error(e)
 
 
+def test_compression_kwargs_changes_gzip_output_size():
+    """Confirm compression_kwargs is forwarded: compresslevel=1 must be larger than =9 for .gz."""
+    payload = b"hello world " * 10_000
+    with named_temporary_file(suffix=".gz") as low_tmp, \
+         named_temporary_file(suffix=".gz") as high_tmp:
+        with smart_open.open(low_tmp.name, "wb", compression_kwargs={"compresslevel": 1}) as fout:
+            fout.write(payload)
+        with smart_open.open(high_tmp.name, "wb", compression_kwargs={"compresslevel": 9}) as fout:
+            fout.write(payload)
+        assert os.path.getsize(low_tmp.name) > os.path.getsize(high_tmp.name)
+
+
 def test_compression_extensions():
     for extension in smart_open.compression.get_supported_extensions():
         with named_temporary_file(suffix=extension) as tmp:


### PR DESCRIPTION
Closes #882.

Adds a top-level `compression_kwargs: dict | None = None` argument to `smart_open.open()` that is forwarded as-is (via `**compression_kwargs`) to the registered compressor callback. `None` keeps the previous behaviour, so the change is backwards compatible.

```diff
- with smart_open.open('s3://bucket/key.gz', 'wb') as fout:
+ with smart_open.open('s3://bucket/key.gz', 'wb', compression_kwargs={'compresslevel': 6}) as fout:  # faster
      fout.write(payload)
```

Spell each option using whatever name the underlying library expects:

| Extension | Underlying call | Kwarg the caller writes |
|---|---|---|
| `.gz` | `gzip.open` | `compresslevel` |
| `.bz2` | `bz2.open` | `compresslevel` |
| `.xz` | `lzma.open` | `preset` |
| `.zst` | `compression.zstd.open` / `backports.zstd.open` | `level` |
| `.lz4` | `lz4.frame.open` | `compression_level` |

Built-in handlers become trivial passthroughs (`def _handle_xxx(file_obj, mode, **kwargs): lib.open(..., **kwargs)`) — no translation table, no introspection, no warning path. Other per-library options (e.g. `lzma`'s `format`/`check`, `zstd`'s `options`/`zstd_dict`, `lz4`'s `block_size`, `gzip`'s `mtime`) work for free.

## Custom compressor callbacks

`register_compressor`'s docstring now recommends the `(file_obj, mode, **kwargs)` signature so any per-call options reach the callback without code changes:

```diff
  def my_handler(file_obj, mode):                       # legacy: still works when no compression_kwargs is passed
      ...

+ def my_handler(file_obj, mode, **kwargs):             # recommended: receives whatever compression_kwargs contains
+     ...
```

If a caller does pass `compression_kwargs` to a legacy `(file_obj, mode)` callback, Python raises a normal `TypeError` for the unexpected kwarg — same as it would for any direct call to a function that doesn't accept that name.

## Docs

- `smart_open.open()` docstring documents `compression_kwargs` with each library's max-compression example dict.
- README.rst "Compression Handling" section gets a worked example (`compression_kwargs={'compresslevel': 6}` framed as "lower gzip's default `compresslevel` of 9 for faster writes").
- The adjacent custom `_handle_xz` README doctest is bumped to `lzma.open(..., **kwargs)` and the recommended `(file_obj, mode, **kwargs)` signature, mirroring the real built-in handler and the docstring example.
- `help.txt` regenerated.

## Alternatives considered

| Approach | Verdict | Why |
|---|---|---|
| `compresslevel: int \| None = None` (#882 spec) | rejected | needs a per-handler rename table (`preset`/`level`/`compression_level`) and `inspect.signature` introspection of callbacks + a warning path — and only covers compression level. Every additional per-library option (`mtime`, `format`, `check`, …) would need a new code change. |
| `compression: str \| dict` (pandas-style) | rejected | folds algorithm + options into one type-poly parameter; needs `isinstance` dispatch + `method`-key validation at the `open()` boundary, more error cases to document. |
| **`compression_kwargs: dict \| None = None` (this PR)** | **chosen** | **straight `**kwargs` passthrough, mirrors `transport_params`, no rename/introspection/warning subsystem, future-proof for any library option.** |

The only loss vs. `compresslevel=N` is format-portability — anyone who wants "max compression regardless of extension" can `os.path.splitext()` in user code; we don't bake that into the core in exchange for a permanent rename subsystem.

## Test plan

- [x] `pytest tests/test_smart_open.py tests/test_utils.py tests/test_bytebuffer.py` → 205 passed locally
- [x] `.gz` `compresslevel=1` produces a larger file than `compresslevel=9` on a compressible payload (`test_compression_kwargs_changes_gzip_output_size`)
- [x] `test_compression_extensions` (unchanged) continues to cover the per-extension round-trip with the default `compression_kwargs=None`