### PR TITLE
[s3] Drop host/port from S3 URIs, drop s3u scheme

### DIFF
--- a/MIGRATING_FROM_OLDER_VERSIONS.rst
+++ b/MIGRATING_FROM_OLDER_VERSIONS.rst
@@ -110,6 +110,28 @@ Tracked in `#937 <https://github.com/piskvorky/smart_open/pull/937>`_.
 The ``UserWarning`` that ``smart_open.s3.open_uri`` emitted for the legacy resource-API transport parameters (``multipart_upload_kwargs``, ``object_kwargs``, ``resource``, ``resource_kwargs``, ``session``, ``singlepart_upload_kwargs``) is gone.
 These parameters had already been unsupported since v5.0.0 — see `Migrating to the new client-based S3 API`_ below for the actual translation recipes.
 
+S3 URIs no longer accept embedded ``host[:port]`` or the ``s3u`` scheme
+----------------------------------------------------------------------
+
+Tracked in `#385 <https://github.com/piskvorky/smart_open/issues/385>`_.
+The non-standard ``s3://key:secret@host:port@bucket/key`` form (and its ``s3u://`` http variant) is no longer parsed.
+It broke `RFC 3986 <https://www.rfc-editor.org/rfc/rfc3986>`_ by stuffing two ``@`` separators into the authority, made S3 URI parsing the most fiddly code in the library, and was rarely used in practice.
+Build a boto3 client with the desired ``endpoint_url`` (and credentials) and pass it via ``transport_params['client']`` instead:
+
+.. code-block:: diff
+
+   - smart_open.open('s3://key:secret@host:1234@bucket/key')
+   + client = boto3.client(
+   +     's3',
+   +     endpoint_url='https://host:1234',
+   +     aws_access_key_id='key',
+   +     aws_secret_access_key='secret',
+   + )
+   + smart_open.open('s3://bucket/key', transport_params={'client': client})
+
+For an ``s3u://`` URL (http endpoint), pass ``endpoint_url='http://host:1234'`` to the client.
+The ``s3``, ``s3n``, and ``s3a`` schemes continue to work, as does the ``s3://key:secret@bucket/key`` form for embedding credentials in the URL.
+
 
 Migrating to the new compression parameter
 ==========================================

--- a/README.rst
+++ b/README.rst
@@ -192,7 +192,8 @@ For the sake of simplicity, the examples below assume you have all the dependenc
         fout.write(b'hello world')
 
     # stream from a completely custom s3 server, like s3proxy:
-    for line in open('s3u://user:secret@host:port@mybucket/mykey.txt'):
+    client = boto3.client('s3', endpoint_url='http://host:port', aws_access_key_id='user', aws_secret_access_key='secret')
+    for line in open('s3://mybucket/mykey.txt', transport_params={'client': client}):
         print(line)
 
     # Stream to Digital Ocean Spaces bucket providing credentials from boto3 profile

--- a/help.txt
+++ b/help.txt
@@ -191,8 +191,8 @@ FUNCTIONS
         buffer_size: int, optional
             The buffer size to use when performing I/O.
 
-        s3/s3n/s3u/s3a (smart_open/s3.py)
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        s3/s3n/s3a (smart_open/s3.py)
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Implements file-like objects for reading and writing from/to AWS S3.
 
         bucket_id: str
@@ -390,7 +390,6 @@ FUNCTIONS
         * https
         * s3
         * s3n
-        * s3u
         * s3a
         * ssh
         * scp
@@ -418,7 +417,6 @@ FUNCTIONS
         * viewfs://host/path/file
         * s3://my_bucket/my_key
         * s3://my_key:my_secret@my_bucket/my_key
-        * s3://my_key:my_secret@my_server:my_port@my_bucket/my_key
         * ssh://username@host/path/file
         * ssh://username@host//path/file
         * scp://username@host/path/file

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -64,16 +64,13 @@ DEFAULT_PART_SIZE = 50 * 1024**2
 MAX_PART_SIZE = 5 * 1024 ** 3
 """The absolute maximum permitted by Amazon."""
 
-SCHEMES = ("s3", "s3n", 's3u', "s3a")
-DEFAULT_PORT = 443
-DEFAULT_HOST = 's3.amazonaws.com'
+SCHEMES = ("s3", "s3n", "s3a")
 
 DEFAULT_BUFFER_SIZE = 128 * 1024
 
 URI_EXAMPLES = (
     's3://my_bucket/my_key',
     's3://my_key:my_secret@my_bucket/my_key',
-    's3://my_key:my_secret@my_server:my_port@my_bucket/my_key',
 )
 
 # Returned by AWS when we try to seek beyond EOF.
@@ -159,16 +156,13 @@ def parse_uri(uri_as_string):
     split_uri = smart_open.utils.safe_urlsplit(uri_as_string)
     assert split_uri.scheme in SCHEMES
 
-    port = DEFAULT_PORT
-    host = DEFAULT_HOST
-    ordinary_calling_format = False
     #
     # These defaults tell boto3 to look for credentials elsewhere
     #
     access_id, access_secret = None, None
 
     #
-    # Common URI template [secret:key@][host[:port]@]bucket/object
+    # Common URI template [secret:key@]bucket/object
     #
     # The urlparse function doesn't handle the above schema, so we have to do
     # it ourselves.
@@ -190,25 +184,12 @@ def parse_uri(uri_as_string):
                 access_id, access_secret = maybe_id, maybe_secret
                 uri = rest
 
-    head, key_id = uri.split('/', 1)
-    if '@' in head and ':' in head:
-        ordinary_calling_format = True
-        host_port, bucket_id = head.split('@')
-        host, port = host_port.split(':', 1)
-        port = int(port)
-    elif '@' in head:
-        ordinary_calling_format = True
-        host, bucket_id = head.split('@')
-    else:
-        bucket_id = head
+    bucket_id, key_id = uri.split('/', 1)
 
     return dict(
         scheme=split_uri.scheme,
         bucket_id=bucket_id,
         key_id=key_id,
-        port=port,
-        host=host,
-        ordinary_calling_format=ordinary_calling_format,
         access_id=access_id,
         access_secret=access_secret,
     )
@@ -256,21 +237,6 @@ def _consolidate_params(uri, transport_params):
             aws_secret_access_key=uri['access_secret'],
         )
         uri.update(access_id=None, access_secret=None)
-
-    if client is not None and uri['host'] != DEFAULT_HOST:
-        logger.warning(
-            'ignoring endpoint_url parsed from URL because they conflict with '
-            'transport_params["client"]. Set transport_params["client"] to None '
-            'to suppress this warning.'
-        )
-        uri.update(host=None)
-    elif uri['host'] != DEFAULT_HOST:
-        if uri['scheme'] == 's3u':
-            scheme = 'http'
-        else:
-            scheme = 'https'
-        inject(endpoint_url=scheme + '://%(host)s:%(port)d' % uri)
-        uri.update(host=None)
 
     return uri, transport_params
 

--- a/smart_open/utils.py
+++ b/smart_open/utils.py
@@ -17,7 +17,7 @@ import wrapt
 
 logger = logging.getLogger(__name__)
 
-WORKAROUND_SCHEMES = ['s3', 's3n', 's3u', 's3a', 'gs']
+WORKAROUND_SCHEMES = ['s3', 's3n', 's3a', 'gs']
 QUESTION_MARK_PLACEHOLDER = '///smart_open.utils.QUESTION_MARK_PLACEHOLDER///'
 
 

--- a/tests/test_smart_open.py
+++ b/tests/test_smart_open.py
@@ -195,28 +195,6 @@ class ParseUriTest(unittest.TestCase):
         self.assertEqual(parsed_uri.access_id, "accessid")
         self.assertEqual(parsed_uri.access_secret, "access/secret:totally")
 
-    def test_s3_uri_has_atmark_in_key_name2(self):
-        parsed_uri = smart_open_lib._parse_uri(
-            "s3://accessid:access/secret@hostname:1234@mybucket/dir/my@ke@y"
-        )
-        self.assertEqual(parsed_uri.scheme, "s3")
-        self.assertEqual(parsed_uri.bucket_id, "mybucket")
-        self.assertEqual(parsed_uri.key_id, "dir/my@ke@y")
-        self.assertEqual(parsed_uri.access_id, "accessid")
-        self.assertEqual(parsed_uri.access_secret, "access/secret")
-        self.assertEqual(parsed_uri.host, "hostname")
-        self.assertEqual(parsed_uri.port, 1234)
-
-    def test_s3_uri_has_atmark_in_key_name3(self):
-        parsed_uri = smart_open_lib._parse_uri("s3://accessid:access/secret@hostname@mybucket/dir/my@ke@y")
-        self.assertEqual(parsed_uri.scheme, "s3")
-        self.assertEqual(parsed_uri.bucket_id, "mybucket")
-        self.assertEqual(parsed_uri.key_id, "dir/my@ke@y")
-        self.assertEqual(parsed_uri.access_id, "accessid")
-        self.assertEqual(parsed_uri.access_secret, "access/secret")
-        self.assertEqual(parsed_uri.host, "hostname")
-        self.assertEqual(parsed_uri.port, 443)
-
     def test_s3_handles_fragments(self):
         uri_str = 's3://bucket-name/folder/picture #1.jpg'
         parsed_uri = smart_open_lib._parse_uri(uri_str)
@@ -226,18 +204,6 @@ class ParseUriTest(unittest.TestCase):
         uri_str = 's3://bucket-name/folder/picture1.jpg?bar'
         parsed_uri = smart_open_lib._parse_uri(uri_str)
         self.assertEqual(parsed_uri.key_id, "folder/picture1.jpg?bar")
-
-    def test_s3_invalid_url_atmark_in_bucket_name(self):
-        self.assertRaises(
-            ValueError, smart_open_lib._parse_uri,
-            "s3://access_id:access_secret@my@bucket@port/mykey",
-        )
-
-    def test_s3_invalid_uri_missing_colon(self):
-        self.assertRaises(
-            ValueError, smart_open_lib._parse_uri,
-            "s3://access_id@access_secret@mybucket@port/mykey",
-        )
 
     def test_webhdfs_uri_to_http(self):
         parsed_uri = smart_open_lib._parse_uri("webhdfs://host:14000/path/file")
@@ -304,25 +270,6 @@ class ParseUriTest(unittest.TestCase):
         self.assertEqual(parsed_uri.scheme, "s3")
         self.assertEqual(parsed_uri.bucket_id, "mybucket")
         self.assertEqual(parsed_uri.key_id, "mydir/mykey?param")
-
-    def test_host_and_port(self):
-        as_string = 's3u://user:secret@host:1234@mybucket/mykey.txt'
-        uri = smart_open_lib._parse_uri(as_string)
-        self.assertEqual(uri.scheme, "s3u")
-        self.assertEqual(uri.bucket_id, "mybucket")
-        self.assertEqual(uri.key_id, "mykey.txt")
-        self.assertEqual(uri.access_id, "user")
-        self.assertEqual(uri.access_secret, "secret")
-        self.assertEqual(uri.host, "host")
-        self.assertEqual(uri.port, 1234)
-
-    def test_invalid_port(self):
-        as_string = 's3u://user:secret@host:port@mybucket/mykey.txt'
-        self.assertRaises(ValueError, smart_open_lib._parse_uri, as_string)
-
-    def test_invalid_port2(self):
-        as_string = 's3u://user:secret@host:port:foo@mybucket/mykey.txt'
-        self.assertRaises(ValueError, smart_open_lib._parse_uri, as_string)
 
     def test_leading_slash_local_file(self):
         path = "/home/misha/hello.txt"
@@ -1798,13 +1745,12 @@ class S3OpenTest(unittest.TestCase):
 
     @mock.patch('smart_open.s3.Reader')
     def test_transport_params_is_not_mutable(self, mock_open):
-        smart_open.open('s3://access_key:secret_key@host@bucket/key')
+        smart_open.open('s3://access_key:secret_key@bucket/key')
         actual = mock_open.call_args_list[0][1]['client_kwargs']
         expected = {
             'S3.Client': {
                 'aws_access_key_id': 'access_key',
                 'aws_secret_access_key': 'secret_key',
-                'endpoint_url': 'https://host:443',
             }
         }
         assert actual == expected
@@ -1812,30 +1758,6 @@ class S3OpenTest(unittest.TestCase):
         smart_open.open('s3://bucket/key')
         actual = mock_open.call_args_list[1][1].get('client_kwargs')
         assert actual is None
-
-    @mock.patch('smart_open.s3.Reader')
-    def test_respects_endpoint_url_read(self, mock_open):
-        url = 's3://key_id:secret_key@play.min.io:9000@smart-open-test/README.rst'
-        smart_open.open(url)
-
-        expected = {
-            'aws_access_key_id': 'key_id',
-            'aws_secret_access_key': 'secret_key',
-            'endpoint_url': 'https://play.min.io:9000',
-        }
-        self.assertEqual(mock_open.call_args[1]['client_kwargs']['S3.Client'], expected)
-
-    @mock.patch('smart_open.s3.MultipartWriter')
-    def test_respects_endpoint_url_write(self, mock_open):
-        url = 's3://key_id:secret_key@play.min.io:9000@smart-open-test/README.rst'
-        smart_open.open(url, 'wb')
-
-        expected = {
-            'aws_access_key_id': 'key_id',
-            'aws_secret_access_key': 'secret_key',
-            'endpoint_url': 'https://play.min.io:9000',
-        }
-        self.assertEqual(mock_open.call_args[1]['client_kwargs']['S3.Client'], expected)
 
 
 def function(a, b, c, foo='bar', baz='boz'):


### PR DESCRIPTION
Resolves #385.

## Summary

- Removes the non-standard `s3://key:secret@host:port@bucket/key` parsing path from `smart_open.s3.parse_uri` / `_consolidate_params`. The form violated RFC 3986 (two `@` separators in the authority) and made `parse_uri` the most fiddly code in the library.
- Drops the `s3u` scheme. Its only behaviour was selecting `http://` instead of `https://` for the embedded endpoint — meaningless once host/port embedding is gone.
- Drops `DEFAULT_HOST` / `DEFAULT_PORT` from `smart_open.s3` and removes `'s3u'` from `utils.WORKAROUND_SCHEMES`.
- Removes the now-dead host/port tests in `tests/test_smart_open.py` (`test_host_and_port`, `test_invalid_port`, `test_invalid_port2`, `test_s3_uri_has_atmark_in_key_name2/3`, `test_s3_invalid_url_atmark_in_bucket_name`, `test_s3_invalid_uri_missing_colon`, and the host-bearing variants of `test_respects_endpoint_url_*`).
- Updates `README.rst` and `help.txt` so the s3proxy-style example uses `transport_params={'client': boto3.client('s3', endpoint_url=...)}`.
- Adds a `MIGRATING_FROM_OLDER_VERSIONS.rst` section explaining the translation from the in-URL form to a boto3 client with `endpoint_url`.

The `s3`, `s3n`, and `s3a` schemes continue to work, as does `s3://key:secret@bucket/key` for embedding credentials in the URL.

## Test plan

- [x] `pytest tests/test_smart_open.py tests/test_s3.py` — all green locally (one moto-server skip).
- [ ] CI green on the PR.