### PR TITLE
[gcs] Use gcs:// as canonical GCS scheme, keep gs:// as alias

### DIFF
--- a/MIGRATING_FROM_OLDER_VERSIONS.rst
+++ b/MIGRATING_FROM_OLDER_VERSIONS.rst
@@ -132,6 +132,18 @@ Build a boto3 client with the desired ``endpoint_url`` (and credentials) and pas
 For an ``s3u://`` URL (http endpoint), pass ``endpoint_url='http://host:1234'`` to the client.
 The ``s3``, ``s3n``, and ``s3a`` schemes continue to work, as does the ``s3://key:secret@bucket/key`` form for embedding credentials in the URL.
 
+GCS canonical scheme is now ``gcs://``
+--------------------------------------
+
+Tracked in `#598 <https://github.com/piskvorky/smart_open/issues/598>`_.
+Documentation and examples now use ``gcs://bucket/blob`` as the canonical GCS URI form, matching the ``smart_open.gcs`` module name and the ``smart_open[gcs]`` extras.
+The ``gs://`` scheme keeps working as a backwards-compatible alias — no code change required if you are already using it — but prefer ``gcs://`` in new code:
+
+.. code-block:: diff
+
+   - smart_open.open('gs://my_bucket/my_file.txt')
+   + smart_open.open('gcs://my_bucket/my_file.txt')
+
 
 Migrating to the new compression parameter
 ==========================================

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Some examples::
 
     s3://bucket/key
     s3://access_key_id:secret_access_key@bucket/key
-    gs://bucket/blob
+    gcs://bucket/blob
     azure://bucket/blob
     hdfs://host:port/path/file
     ./local/path/file.gz
@@ -204,11 +204,11 @@ For the sake of simplicity, the examples below assume you have all the dependenc
         fout.write(b'here we stand')
 
     # stream from GCS
-    for line in open('gs://my_bucket/my_file.txt'):
+    for line in open('gcs://my_bucket/my_file.txt'):
         print(line)
 
     # stream content *into* GCS (write mode):
-    with open('gs://my_bucket/my_file.txt', 'wb') as fout:
+    with open('gcs://my_bucket/my_file.txt', 'wb') as fout:
         fout.write(b'hello world')
 
     # stream from Azure Blob Storage
@@ -419,7 +419,7 @@ to setting up GCS authentication with a service account.
     from google.cloud.storage import Client
     service_account_path = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
     client = Client.from_service_account_json(service_account_path)
-    fin = open('gs://gcp-public-data-landsat/index.csv.gz', transport_params=dict(client=client))
+    fin = open('gcs://gcp-public-data-landsat/index.csv.gz', transport_params=dict(client=client))
 
 If you need more credential options, you can create an explicit ``google.auth.credentials.Credentials`` object
 and pass it to the Client. To create an API token for use in the example below, refer to the
@@ -433,7 +433,7 @@ and pass it to the Client. To create an API token for use in the example below, 
 	token = os.environ['GOOGLE_API_TOKEN']
 	credentials = Credentials(token=token)
 	client = Client(credentials=credentials)
-	fin = open('gs://gcp-public-data-landsat/index.csv.gz', transport_params={'client': client})
+	fin = open('gcs://gcp-public-data-landsat/index.csv.gz', transport_params={'client': client})
 
 GCS Advanced Usage
 ------------------
@@ -448,7 +448,7 @@ Additional blob properties (`docs <https://cloud.google.com/python/docs/referenc
 
     open_kwargs = {'predefined_acl': 'authenticated-read'}
     properties = {'metadata': {'version': 2}, 'storage_class': 'COLDLINE'}
-    fout = open('gs://bucket/key', 'wb', transport_params={'blob_open_kwargs': open_kwargs, 'blob_properties': properties})
+    fout = open('gcs://bucket/key', 'wb', transport_params={'blob_open_kwargs': open_kwargs, 'blob_properties': properties})
 
 Azure Credentials
 -----------------

--- a/help.txt
+++ b/help.txt
@@ -138,8 +138,8 @@ FUNCTIONS
             Additional parameters for the FTP connection.
             Currently supported parameters: timeout, source_address, encoding.
 
-        gs (smart_open/gcs.py)
-        ~~~~~~~~~~~~~~~~~~~~~~
+        gcs/gs (smart_open/gcs.py)
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~
         Implements file-like objects for reading and writing to/from GCS.
 
         bucket_id: str
@@ -383,6 +383,7 @@ FUNCTIONS
         * file
         * ftp
         * ftps
+        * gcs
         * gs
         * hdfs
         * viewfs

--- a/howto.md
+++ b/howto.md
@@ -426,7 +426,7 @@ for an explanation). To download all files in a directory you can do this:
 >>> bucket_name = "gcp-public-data-landsat"
 >>> prefix = "LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/"
 >>> for blob in client.list_blobs(client.get_bucket(bucket_name), prefix=prefix):
-...      with open(f"gs://{bucket_name}/{blob.name}") as f:
+...      with open(f"gcs://{bucket_name}/{blob.name}") as f:
 ...          print(f.name)
 ...          break # just show the first iteration for the test
 LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt
@@ -442,7 +442,7 @@ If you would like to access GCS without using an account you need to explicitly 
 >>> from google.cloud import storage
 >>> from smart_open import open
 >>> client = storage.Client.create_anonymous_client()
->>> f = open("gs://gcp-public-data-landsat/index.csv.gz", transport_params=dict(client=client))
+>>> f = open("gcs://gcp-public-data-landsat/index.csv.gz", transport_params=dict(client=client))
 >>> f.readline()
 'SCENE_ID,PRODUCT_ID,SPACECRAFT_ID,SENSOR_ID,DATE_ACQUIRED,COLLECTION_NUMBER,COLLECTION_CATEGORY,SENSING_TIME,DATA_TYPE,WRS_PATH,WRS_ROW,CLOUD_COVER,NORTH_LAT,SOUTH_LAT,WEST_LON,EAST_LON,TOTAL_SIZE,BASE_URL\n'
 

--- a/smart_open/gcs.py
+++ b/smart_open/gcs.py
@@ -23,8 +23,8 @@ from smart_open import constants
 
 logger = logging.getLogger(__name__)
 
-SCHEME = "gs"
-"""Supported scheme for GCS"""
+SCHEMES = ("gcs", "gs")
+"""Supported schemes for GCS.  ``gcs`` is canonical; ``gs`` is kept as a backwards-compatible alias."""
 
 _DEFAULT_MIN_PART_SIZE = 50 * 1024**2
 """Default minimum part size for GCS multipart uploads"""
@@ -34,10 +34,10 @@ _DEFAULT_WRITE_OPEN_KWARGS = {'ignore_flush': True}
 
 def parse_uri(uri_as_string):
     sr = smart_open.utils.safe_urlsplit(uri_as_string)
-    assert sr.scheme == SCHEME
+    assert sr.scheme in SCHEMES
     bucket_id = sr.netloc
     blob_id = sr.path.lstrip('/')
-    return dict(scheme=SCHEME, bucket_id=bucket_id, blob_id=blob_id)
+    return dict(scheme=sr.scheme, bucket_id=bucket_id, blob_id=blob_id)
 
 
 def open_uri(uri, mode, transport_params):

--- a/smart_open/utils.py
+++ b/smart_open/utils.py
@@ -17,7 +17,7 @@ import wrapt
 
 logger = logging.getLogger(__name__)
 
-WORKAROUND_SCHEMES = ['s3', 's3n', 's3a', 'gs']
+WORKAROUND_SCHEMES = ['s3', 's3n', 's3a', 'gcs', 'gs']
 QUESTION_MARK_PLACEHOLDER = '///smart_open.utils.QUESTION_MARK_PLACEHOLDER///'
 
 

--- a/tests/test_gcs.py
+++ b/tests/test_gcs.py
@@ -268,7 +268,7 @@ class OpenTest(unittest.TestCase):
 
     def test_round_trip(self):
         test_string = u"ветер по морю гуляет..."
-        url = 'gs://%s/%s' % (BUCKET_NAME, BLOB_NAME)
+        url = 'gcs://%s/%s' % (BUCKET_NAME, BLOB_NAME)
         with smart_open.open(url, "w", encoding='utf-8') as fout:
             fout.write(test_string)
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -24,4 +24,4 @@ class PackageTests(unittest.TestCase):
     @pytest.mark.skipif(skip_tests, reason="requires missing dependencies")
     def test_gcs_raises_helpful_error_with_missing_deps(self):
         with pytest.raises(ImportError, match=r"pip install smart_open\[gcs\]"):
-            open("gs://foo/bar")
+            open("gcs://foo/bar")

--- a/tests/test_smart_open.py
+++ b/tests/test_smart_open.py
@@ -131,7 +131,9 @@ class ParseUriTest(unittest.TestCase):
     def test_scheme(self):
         """Do URIs schemes parse correctly?"""
         # supported schemes
-        for scheme in ("s3", "s3a", "s3n", "hdfs", "file", "http", "https", "gs", "azure"):
+        for scheme in (
+            "s3", "s3a", "s3n", "hdfs", "file", "http", "https", "gcs", "gs", "azure",
+        ):
             parsed_uri = smart_open_lib._parse_uri(scheme + "://mybucket/mykey")
             self.assertEqual(parsed_uri.scheme, scheme)
 
@@ -346,25 +348,32 @@ class ParseUriTest(unittest.TestCase):
         uri = smart_open_lib._parse_uri(as_string)
         self.assertEqual(uri.password, 'some:complex@password$$')
 
-    def test_gs_uri(self):
+    def test_gcs_uri(self):
         """Do GCS URIs parse correctly?"""
         # correct uri without credentials
-        parsed_uri = smart_open_lib._parse_uri("gs://mybucket/myblob")
-        self.assertEqual(parsed_uri.scheme, "gs")
+        parsed_uri = smart_open_lib._parse_uri("gcs://mybucket/myblob")
+        self.assertEqual(parsed_uri.scheme, "gcs")
         self.assertEqual(parsed_uri.bucket_id, "mybucket")
         self.assertEqual(parsed_uri.blob_id, "myblob")
 
-    def test_gs_uri_contains_slash(self):
+    def test_gcs_uri_contains_slash(self):
+        parsed_uri = smart_open_lib._parse_uri("gcs://mybucket/mydir/myblob")
+        self.assertEqual(parsed_uri.scheme, "gcs")
+        self.assertEqual(parsed_uri.bucket_id, "mybucket")
+        self.assertEqual(parsed_uri.blob_id, "mydir/myblob")
+
+    def test_gcs_uri_contains_question_mark(self):
+        parsed_uri = smart_open_lib._parse_uri("gcs://mybucket/mydir/myblob?param")
+        self.assertEqual(parsed_uri.scheme, "gcs")
+        self.assertEqual(parsed_uri.bucket_id, "mybucket")
+        self.assertEqual(parsed_uri.blob_id, "mydir/myblob?param")
+
+    def test_gs_uri_backwards_compat(self):
+        """``gs://`` keeps working as a backwards-compat alias of ``gcs://``."""
         parsed_uri = smart_open_lib._parse_uri("gs://mybucket/mydir/myblob")
         self.assertEqual(parsed_uri.scheme, "gs")
         self.assertEqual(parsed_uri.bucket_id, "mybucket")
         self.assertEqual(parsed_uri.blob_id, "mydir/myblob")
-
-    def test_gs_uri_contains_question_mark(self):
-        parsed_uri = smart_open_lib._parse_uri("gs://mybucket/mydir/myblob?param")
-        self.assertEqual(parsed_uri.scheme, "gs")
-        self.assertEqual(parsed_uri.bucket_id, "mybucket")
-        self.assertEqual(parsed_uri.blob_id, "mydir/myblob?param")
 
     def test_azure_blob_uri(self):
         """Do Azure Blob URIs parse correctly?"""


### PR DESCRIPTION
Resolves #598.

The module is `smart_open.gcs`, the extras are `smart_open[gcs]`, but the URL scheme was `gs://`. This PR aligns the URI scheme with everything else.

## Summary

- `smart_open.gcs.SCHEME = "gs"` → `SCHEMES = ("gcs", "gs")`. `gcs` is canonical; `gs` is kept as a backwards-compatible alias so existing callers keep working.
- `parse_uri` now returns the scheme as parsed (`gcs` or `gs`) rather than hard-coding it.
- `utils.WORKAROUND_SCHEMES` includes `gcs` so the `?versionId` question-mark workaround applies to both.
- Docs (`README.rst`, `howto.md`, `help.txt`) and tests (`test_smart_open.py`, `test_gcs.py`, `test_package.py`) updated to use `gcs://` canonically. Added a `test_gs_uri_backwards_compat` test that pins `gs://` as a working alias.
- Added a `MIGRATING_FROM_OLDER_VERSIONS.rst` section noting that `gs://` is now an alias and `gcs://` is preferred.

No breaking change — `gs://` callers don't need to touch anything.

## Test plan

- [x] `pytest tests/` — 449 passed, 4 skipped (missing-deps/moto-server skips), no failures.
- [ ] CI green on the PR.