### PR TITLE
Parse versionId from s3:// URIs into version_id

### DIFF
--- a/MIGRATING_FROM_OLDER_VERSIONS.rst
+++ b/MIGRATING_FROM_OLDER_VERSIONS.rst
@@ -145,6 +145,23 @@ The ``gs://`` scheme keeps working as a backwards-compatible alias — no code c
    + smart_open.open('gcs://my_bucket/my_file.txt')
 
 
+S3 URIs now recognise ``?versionId=...``
+----------------------------------------
+
+Tracked in `#595 <https://github.com/piskvorky/smart_open/issues/595>`_.
+``smart_open.open('s3://bucket/key?versionId=v1')`` now extracts the ``versionId`` query parameter and forwards it as ``version_id`` to ``smart_open.s3.open``, matching the convention used by `s3fs <https://s3fs.readthedocs.io/en/latest/api.html#s3fs.core.S3FileSystem.split_path>`_ and the AWS CLI:
+
+.. code-block:: diff
+
+   - smart_open.open('s3://bucket/key', transport_params={'version_id': 'v1'})
+   + smart_open.open('s3://bucket/key?versionId=v1')
+
+Other ``?...`` content in the key is preserved as before (the ``QUESTION_MARK_PLACEHOLDER`` workaround in ``smart_open.utils.safe_urlsplit`` still keeps unrelated query strings attached to the key).
+``transport_params['version_id']`` still wins if both are set, with a ``UserWarning``.
+
+If you have a legitimate ``?versionId=...`` substring in your S3 key, call ``smart_open.s3.open(bucket, key, ...)`` directly with the raw key to bypass URI parsing.
+
+
 Migrating to the new compression parameter
 ==========================================
 

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -13,6 +13,7 @@ import io
 import functools
 import itertools
 import logging
+import re
 import time
 from math import inf
 
@@ -75,6 +76,11 @@ URI_EXAMPLES = (
 
 # Returned by AWS when we try to seek beyond EOF.
 _OUT_OF_RANGE = 'InvalidRange'
+
+# Matches the ``versionId`` query parameter in an S3 URI (issue #595).
+# The leading group preserves whether it was the first (``?``) or a later (``&``)
+# query parameter so that we can rebuild the remaining query correctly.
+_VERSION_ID_RE = re.compile(r'(?P<sep>[?&])versionId=(?P<value>[^&]*)')
 
 
 class Retry:
@@ -186,12 +192,31 @@ def parse_uri(uri_as_string):
 
     bucket_id, key_id = uri.split('/', 1)
 
+    #
+    # Extract ``?versionId=...`` from the key (issue #595).  ``safe_urlsplit``
+    # preserves any ``?`` in the URI as part of the key, so we surgically
+    # remove just the ``versionId`` parameter and leave any other ``?...``
+    # segments alone.  Users with a literal ``?versionId=`` in their S3 key
+    # can keep working by calling ``smart_open.s3.open(bucket, key, ...)``
+    # directly with the raw key.
+    #
+    version_id = None
+    match = _VERSION_ID_RE.search(key_id)
+    if match:
+        version_id = match.group('value')
+        before = key_id[:match.start()]
+        after = key_id[match.end():]
+        if match.group('sep') == '?' and after.startswith('&'):
+            after = '?' + after[1:]
+        key_id = before + after
+
     return dict(
         scheme=split_uri.scheme,
         bucket_id=bucket_id,
         key_id=key_id,
         access_id=access_id,
         access_secret=access_secret,
+        version_id=version_id,
     )
 
 
@@ -237,6 +262,17 @@ def _consolidate_params(uri, transport_params):
             aws_secret_access_key=uri['access_secret'],
         )
         uri.update(access_id=None, access_secret=None)
+
+    if uri['version_id'] is not None:
+        if transport_params.get('version_id') is not None:
+            logger.warning(
+                'ignoring versionId parsed from URL because it conflicts with '
+                'transport_params["version_id"]. Drop the URL versionId to '
+                'suppress this warning.'
+            )
+        else:
+            transport_params['version_id'] = uri['version_id']
+        uri.update(version_id=None)
 
     return uri, transport_params
 

--- a/tests/test_s3_version.py
+++ b/tests/test_s3_version.py
@@ -114,6 +114,13 @@ class TestVersionId(unittest.TestCase):
         boto3_body = boto3_body = returned_obj.get()['Body'].read()
         self.assertEqual(boto3_body, self.test_ver1)
 
+    def test_version_id_in_url(self):
+        """Does ``?versionId=...`` in the URL pin the read to that version?"""
+        url = '{}?versionId={}'.format(self.url, self.versions[0])
+        with open(url, mode='rb') as fin:
+            actual = fin.read()
+        self.assertEqual(actual, self.test_ver1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_smart_open.py
+++ b/tests/test_smart_open.py
@@ -272,6 +272,37 @@ class ParseUriTest(unittest.TestCase):
         self.assertEqual(parsed_uri.scheme, "s3")
         self.assertEqual(parsed_uri.bucket_id, "mybucket")
         self.assertEqual(parsed_uri.key_id, "mydir/mykey?param")
+        self.assertIsNone(parsed_uri.version_id)
+
+    def test_s3_uri_version_id(self):
+        """Does ?versionId=... in an S3 URI populate version_id?"""
+        parsed_uri = smart_open_lib._parse_uri("s3://mybucket/mydir/mykey?versionId=v1")
+        self.assertEqual(parsed_uri.scheme, "s3")
+        self.assertEqual(parsed_uri.bucket_id, "mybucket")
+        self.assertEqual(parsed_uri.key_id, "mydir/mykey")
+        self.assertEqual(parsed_uri.version_id, "v1")
+
+    def test_s3_uri_version_id_with_other_params(self):
+        """Are non-versionId query params preserved on the key?"""
+        parsed_uri = smart_open_lib._parse_uri(
+            "s3://mybucket/mykey?versionId=v1&other=keep"
+        )
+        self.assertEqual(parsed_uri.key_id, "mykey?other=keep")
+        self.assertEqual(parsed_uri.version_id, "v1")
+
+        parsed_uri = smart_open_lib._parse_uri(
+            "s3://mybucket/mykey?other=keep&versionId=v1"
+        )
+        self.assertEqual(parsed_uri.key_id, "mykey?other=keep")
+        self.assertEqual(parsed_uri.version_id, "v1")
+
+    def test_s3_uri_no_version_id_when_no_match(self):
+        """``versionId`` is only extracted when the key matches exactly."""
+        parsed_uri = smart_open_lib._parse_uri(
+            "s3://mybucket/mykey?versionIdLookalike=foo"
+        )
+        self.assertEqual(parsed_uri.key_id, "mykey?versionIdLookalike=foo")
+        self.assertIsNone(parsed_uri.version_id)
 
     def test_leading_slash_local_file(self):
         path = "/home/misha/hello.txt"
@@ -1767,6 +1798,21 @@ class S3OpenTest(unittest.TestCase):
         smart_open.open('s3://bucket/key')
         actual = mock_open.call_args_list[1][1].get('client_kwargs')
         assert actual is None
+
+    @mock.patch('smart_open.s3.Reader')
+    def test_version_id_from_url_is_forwarded(self, mock_open):
+        """The ?versionId=... query param is forwarded as version_id to s3.open()."""
+        smart_open.open('s3://bucket/key?versionId=v123')
+        self.assertEqual(mock_open.call_args[1]['version_id'], 'v123')
+
+    @mock.patch('smart_open.s3.Reader')
+    def test_version_id_in_transport_params_wins(self, mock_open):
+        """transport_params['version_id'] takes precedence over the URL value."""
+        smart_open.open(
+            's3://bucket/key?versionId=from-url',
+            transport_params={'version_id': 'from-tp'},
+        )
+        self.assertEqual(mock_open.call_args[1]['version_id'], 'from-tp')
 
 
 def function(a, b, c, foo='bar', baz='boz'):


### PR DESCRIPTION
Resolves #595.

`smart_open.open('s3://bucket/key?versionId=v1')` now extracts the `versionId` query parameter and forwards it as `version_id` to `smart_open.s3.open()`, matching the convention used by [s3fs](https://s3fs.readthedocs.io/en/latest/api.html#s3fs.core.S3FileSystem.split_path) and the AWS CLI.

## Why a regex post-pass instead of `urlsplit`?

The history (#285, #458, #633) shows `safe_urlsplit` was deliberately built to keep `?` content attached to the key, because `?` is legal in S3 (discouraged but valid per AWS docs) and GCS (freely used) blob names. Switching to `urlsplit` here would regress those issues.

Instead, this PR keeps `safe_urlsplit` and surgically pulls just `?versionId=…` (or `&versionId=…`) out of the already-parsed key with a regex. Any other `?...` content stays in the key.

## Summary

- `smart_open.s3.parse_uri()` returns a new `version_id` field. It uses `_VERSION_ID_RE` to match `?versionId=VALUE` (or `&versionId=VALUE`) anywhere in the key, strips just that segment, and stitches the rest of the query back onto the key.
- `_consolidate_params()` promotes the URI's `version_id` into `transport_params['version_id']`. If `transport_params` already specifies a `version_id`, that wins and we log a `UserWarning` (matching how URL credentials/endpoint are handled).
- Tests:
  - `ParseUriTest.test_s3_uri_version_id` — basic `?versionId=v1` extraction.
  - `ParseUriTest.test_s3_uri_version_id_with_other_params` — versionId in the middle or end, other params preserved.
  - `ParseUriTest.test_s3_uri_no_version_id_when_no_match` — `?versionIdLookalike=foo` is left alone.
  - `S3OpenTest.test_version_id_from_url_is_forwarded` / `test_version_id_in_transport_params_wins` — end-to-end through `open_uri` → `s3.open`.
  - `test_s3_version.TestVersionId.test_version_id_in_url` — integration test against moto with two real object versions.
- `MIGRATING_FROM_OLDER_VERSIONS.rst` documents the new behaviour and tells users with a literal `?versionId=…` in their key to call `smart_open.s3.open(bucket, key, ...)` directly to bypass URI parsing.

## Test plan

- [x] `pytest tests/` — 454 passed, 4 skipped (missing-deps/moto-server skips), no failures.
- [ ] CI green on the PR.