### PR TITLE
Add type annotations and ty type checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,12 @@ repos:
     args: [--preview]
     types_or: [markdown]
 
+- repo: https://github.com/astral-sh/ty-pre-commit
+  rev: v0.0.55
+  hooks:
+  - id: ty
+    args: [--isolated, --all-extras]
+
 # should be replaced in the future ref https://github.com/astral-sh/ruff/issues/12434
 - repo: https://github.com/jsh9/pydoclint
   rev: 0.8.7

--- a/help.txt
+++ b/help.txt
@@ -17,6 +17,7 @@ DESCRIPTION
     * `register_compressor()`, which registers callbacks for transparent compressor handling
 
 PACKAGE CONTENTS
+    _typing
     azure
     bytebuffer
     compression
@@ -36,7 +37,7 @@ PACKAGE CONTENTS
     webhdfs
 
 FUNCTIONS
-    open(uri, mode='r', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, compression='infer_from_extension', compression_kwargs=None, transport_params=None)
+    open(uri: 'Uri', mode: 'str' = 'r', buffering: 'int' = -1, encoding: 'str | None' = None, errors: 'str | None' = None, newline: 'str | None' = None, closefd: 'bool' = True, opener: 'Callable[[str, int], int] | None' = None, compression: 'str' = 'infer_from_extension', compression_kwargs: 'CompressionKwargs | None' = None, transport_params: 'TransportParams | None' = None) -> 'IO[Any]'
         Open the URI object, returning a file-like object.
 
         The URI is usually a string in a variety of formats.
@@ -373,7 +374,7 @@ FUNCTIONS
             - `smart_open README.md
               <https://github.com/piskvorky/smart_open/blob/master/README.md>`__
 
-    parse_uri(uri_as_string)
+    parse_uri(uri_as_string: 'str') -> 'tuple[Any, ...]'
         Parse the given URI from a string.
 
         Args:
@@ -429,7 +430,7 @@ FUNCTIONS
             * sftp://username@host/path/file
             * webhdfs://host:port/path/file
 
-    register_compressor(ext, callback)
+    register_compressor(ext: 'str', callback: 'Compressor') -> 'None'
         Register a callback for transparently decompressing files with a specific extension.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,14 +48,18 @@ dev = [
   "pytest-xdist[psutil]",
   "awscli",
   "pyopenssl",
-  "numpy"
+  "numpy",
+  # type-checking only: boto3 ships no inline types, and we use typing_extensions
+  # (Buffer/Self) under TYPE_CHECKING; needed so `ty`/pyright resolve them
+  "boto3-stubs[s3]",
+  "typing_extensions"
 ]
 webhdfs = ["requests"]
 zst = ["backports.zstd>=1.0.0;python_version<'3.14'"]
 
 [tool.pydoclint]
 arg-type-hints-in-docstring = false
-arg-type-hints-in-signature = false
+check-class-attributes = false # we document constructor Args, not class attributes
 check-return-types = false
 check-yield-types = false
 style = "google"
@@ -84,7 +88,9 @@ docstring-code-line-length = "dynamic"
 
 [tool.ruff.lint]
 ignore = [
-  "ANN", # we don't enforce type hints
+  "ANN002", # don't force annotating *args
+  "ANN003", # don't force annotating **kwargs
+  "ANN401", # Any is necessary for transport_params, **kwargs and optional-dependency objects
   "D107", # we have pydoclint with class docstring
   "D203", # there is D211
   "D213", # there is D212
@@ -101,6 +107,7 @@ select = ["ALL"]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "{tests,integration-tests,benchmark,ci_helpers,release}/**/*.py" = [
+  "ANN", # tests and scripts don't need type annotations
   "D100", # not a package
   "D104", # modules don't need docstrings
   "INP001", # not a namespace package
@@ -117,8 +124,14 @@ known-first-party = ["smart_open", "tests"]
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
+[tool.setuptools.package-data]
+smart_open = ["py.typed"]
+
 [tool.setuptools.packages.find]
 include = ["smart_open"]
 
 [tool.setuptools_scm]
 fallback_version = "0.1.dev0+gitnotfound"
+
+[tool.ty.src]
+include = ["smart_open"]

--- a/smart_open/_typing.py
+++ b/smart_open/_typing.py
@@ -1,0 +1,33 @@
+#
+# Copyright (C) 2026 Radim Rehurek <me@radimrehurek.com>
+#
+# This code is distributed under the terms and conditions
+# from the MIT License (MIT).
+#
+
+"""Shared type aliases for ``smart_open``'s public and internal APIs.
+
+For internal use only.  These aliases keep the type annotations consistent
+across the transport, compression and top-level modules.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from typing import IO, Any, TypeAlias
+
+FileObj: TypeAlias = IO[Any]
+"""A binary or text file-like object, as returned by :func:`smart_open.open`."""
+
+Uri: TypeAlias = str | os.PathLike[str] | int | IO[bytes]
+"""Anything :func:`smart_open.open` accepts as its first argument."""
+
+TransportParams: TypeAlias = dict[str, Any]
+"""Per-transport keyword arguments forwarded by :func:`smart_open.open`."""
+
+CompressionKwargs: TypeAlias = dict[str, Any]
+"""Keyword arguments forwarded to a registered compressor callback."""
+
+Compressor: TypeAlias = Callable[..., IO[Any]]
+"""A compressor callback registered via :func:`smart_open.register_compressor`."""

--- a/smart_open/azure.py
+++ b/smart_open/azure.py
@@ -7,18 +7,37 @@
 #
 """Implements file-like objects for reading and writing to/from Azure Blob Storage."""
 
+from __future__ import annotations
+
 import base64
 import io
 import logging
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 import smart_open.bytebuffer
 import smart_open.constants
+import smart_open.utils
 
 try:
     import azure.core.exceptions
     import azure.storage.blob
 except ImportError:
     MISSING_DEPS = True
+
+if TYPE_CHECKING:
+    from types import TracebackType
+    from typing import IO
+
+    from _typeshed import ReadableBuffer, WriteableBuffer
+    from typing_extensions import Self
+
+    from smart_open._typing import TransportParams
+
+    _AzureClient = (
+        azure.storage.blob.BlobServiceClient
+        | azure.storage.blob.ContainerClient
+        | azure.storage.blob.BlobClient
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +59,13 @@ DEFAULT_MAX_CONCURRENCY = 1
 """Default number of parallel connections with which to download."""
 
 
-def parse_uri(uri_as_string):
+class _AzureUri(TypedDict):
+    scheme: str
+    container_id: str
+    blob_id: str
+
+
+def parse_uri(uri_as_string: str) -> _AzureUri:
     """Parse an ``azure://`` URI into its container and blob components."""
     sr = smart_open.utils.safe_urlsplit(uri_as_string)
     assert sr.scheme == SCHEME  # noqa: S101  # internal precondition; misuse should crash loudly
@@ -58,7 +83,7 @@ def parse_uri(uri_as_string):
     return {"scheme": SCHEME, "container_id": container_id, "blob_id": blob_id}
 
 
-def open_uri(uri, mode, transport_params):
+def open_uri(uri: str, mode: str, transport_params: TransportParams) -> io.BufferedIOBase:
     """Open an Azure Blob Storage URI using the given mode and transport params."""
     parsed_uri = parse_uri(uri)
     kwargs = smart_open.utils.check_kwargs(open, transport_params)
@@ -66,15 +91,15 @@ def open_uri(uri, mode, transport_params):
 
 
 def open(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
-    container_id,
-    blob_id,
-    mode,
-    client=None,  # type: Union[azure.storage.blob.BlobServiceClient, azure.storage.blob.ContainerClient, azure.storage.blob.BlobClient]
-    blob_kwargs=None,
-    buffer_size=DEFAULT_BUFFER_SIZE,
-    min_part_size=_DEFAULT_MIN_PART_SIZE,
-    max_concurrency=DEFAULT_MAX_CONCURRENCY,
-):
+    container_id: str,
+    blob_id: str,
+    mode: str,
+    client: _AzureClient | None = None,
+    blob_kwargs: dict[str, Any] | None = None,
+    buffer_size: int = DEFAULT_BUFFER_SIZE,
+    min_part_size: int = _DEFAULT_MIN_PART_SIZE,
+    max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+) -> io.BufferedIOBase:
     """Open an Azure Blob Storage blob for reading or writing.
 
     Args:
@@ -123,33 +148,36 @@ def open(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
     raise NotImplementedError(msg)
 
 
-def _get_blob_client(client, container, blob):
-    # type: (Union[azure.storage.blob.BlobServiceClient, azure.storage.blob.ContainerClient, azure.storage.blob.BlobClient], str, str) -> azure.storage.blob.BlobClient
+def _get_blob_client(
+    client: _AzureClient,
+    container: str,
+    blob: str,
+) -> azure.storage.blob.BlobClient:
     """Return an Azure BlobClient for the given container and blob."""
-    if hasattr(client, "get_container_client"):
-        client = client.get_container_client(container)
+    obj: Any = client
+    if hasattr(obj, "get_container_client"):
+        obj = obj.get_container_client(container)
 
-    if hasattr(client, "container_name") and client.container_name != container:
-        msg = f"Client for {client.container_name!r} doesn't match container {container!r}"
+    if hasattr(obj, "container_name") and obj.container_name != container:
+        msg = f"Client for {obj.container_name!r} doesn't match container {container!r}"
         raise ValueError(msg)
 
-    if hasattr(client, "get_blob_client"):
-        client = client.get_blob_client(blob)
+    if hasattr(obj, "get_blob_client"):
+        obj = obj.get_blob_client(blob)
 
-    return client
+    return cast("azure.storage.blob.BlobClient", obj)
 
 
 class _RawReader:
     """Read an Azure Blob Storage file."""
 
-    def __init__(self, blob, size, concurrency):
-        # type: (azure.storage.blob.BlobClient, int, int) -> None
+    def __init__(self, blob: azure.storage.blob.BlobClient, size: int, concurrency: int) -> None:
         self._blob = blob
         self._size = size
         self._position = 0
         self._concurrency = concurrency
 
-    def seek(self, position):
+    def seek(self, position: int) -> int:
         """Seek to the specified position (byte offset) in the Azure Blob Storage blob.
 
         Args:
@@ -161,14 +189,14 @@ class _RawReader:
         self._position = position
         return self._position
 
-    def read(self, size=-1):
+    def read(self, size: int = -1) -> bytes:
         if self._position >= self._size:
             return b""
         binary = self._download_blob_chunk(size)
         self._position += len(binary)
         return binary
 
-    def _download_blob_chunk(self, size):
+    def _download_blob_chunk(self, size: int) -> bytes:
         if self._size == self._position:
             #
             # When reading, we can't seek to the first byte of an empty file.
@@ -186,7 +214,7 @@ class _RawReader:
             binary = stream.readall()
         else:
             binary = stream.read()
-        return binary
+        return cast("bytes", binary)
 
 
 class Reader(io.BufferedIOBase):
@@ -209,21 +237,22 @@ class Reader(io.BufferedIOBase):
             from does not exist.
     """
 
-    _blob = None  # so `closed` property works in case __init__ fails and __del__ is called
+    name: str
+    _blob: azure.storage.blob.BlobClient | None = None  # so `closed` works if __init__ fails and __del__ runs
 
     def __init__(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
         self,
-        container,
-        blob,
-        client,  # type: Union[azure.storage.blob.BlobServiceClient, azure.storage.blob.ContainerClient, azure.storage.blob.BlobClient]
-        buffer_size=DEFAULT_BUFFER_SIZE,
-        line_terminator=smart_open.constants.BINARY_NEWLINE,
-        max_concurrency=DEFAULT_MAX_CONCURRENCY,
-    ):
+        container: str,
+        blob: str,
+        client: _AzureClient,
+        buffer_size: int = DEFAULT_BUFFER_SIZE,
+        line_terminator: bytes = smart_open.constants.BINARY_NEWLINE,
+        max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+    ) -> None:
         self._container_name = container
         self._blob_name = blob
 
-        self._blob: azure.storage.blob.BlobClient = _get_blob_client(client, container, blob)
+        self._blob = _get_blob_client(client, container, blob)
 
         if self._blob is None:
             msg = f"blob {blob} not found in {container}"
@@ -233,7 +262,7 @@ class Reader(io.BufferedIOBase):
         except KeyError:
             self._size = 0
 
-        self._raw_reader = _RawReader(self._blob, self._size, max_concurrency)
+        self._raw_reader: _RawReader | None = _RawReader(self._blob, self._size, max_concurrency)
         self._position = 0
         self._current_part = smart_open.bytebuffer.ByteBuffer(buffer_size)
         self._line_terminator = line_terminator
@@ -241,7 +270,7 @@ class Reader(io.BufferedIOBase):
     #
     # Override some methods from io.IOBase.
     #
-    def close(self):
+    def close(self) -> None:
         """Flush and close this stream."""
         logger.debug("close: called")
         if not self.closed:
@@ -249,26 +278,26 @@ class Reader(io.BufferedIOBase):
             self._raw_reader = None
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         """Return True if the stream is closed."""
         return self._blob is None
 
-    def readable(self):
+    def readable(self) -> bool:
         """Return True if the stream can be read from."""
         return True
 
-    def seekable(self):
+    def seekable(self) -> bool:
         """Return True; we support `seek` but not `truncate`."""
         return True
 
     #
     # io.BufferedIOBase methods.
     #
-    def detach(self):
+    def detach(self) -> io.RawIOBase:
         """Unsupported."""
         raise io.UnsupportedOperation
 
-    def seek(self, offset, whence=smart_open.constants.WHENCE_START):
+    def seek(self, offset: int, whence: int = smart_open.constants.WHENCE_START) -> int:
         """Seek to the specified position.
 
         Args:
@@ -299,28 +328,35 @@ class Reader(io.BufferedIOBase):
             self._position = new_position
             return self._position
 
+        raw_reader = self._raw_reader
+        assert raw_reader is not None  # noqa: S101  # set in __init__, cleared only on close
+
         self._position = new_position
-        self._raw_reader.seek(new_position)
+        raw_reader.seek(new_position)
         logger.debug("current_pos: %r", self._position)
 
         self._current_part.empty()
         return self._position
 
-    def tell(self):
+    def tell(self) -> int:
         """Return the current position within the file."""
         return self._position
 
-    def truncate(self, size=None):
+    def truncate(self, size: int | None = None) -> int:
         """Unsupported."""
         raise io.UnsupportedOperation
 
-    def read(self, size=-1):
+    def read(self, size: int | None = -1) -> bytes:
         """Read up to size bytes from the object and return them."""
+        if size is None:
+            size = -1
+        raw_reader = self._raw_reader
+        assert raw_reader is not None  # noqa: S101  # set in __init__, cleared only on close
         if size == 0:
             return b""
         if size < 0:
             self._position = self._size
-            return self._read_from_buffer() + self._raw_reader.read()
+            return self._read_from_buffer() + raw_reader.read()
 
         #
         # Return unused data first
@@ -334,20 +370,23 @@ class Reader(io.BufferedIOBase):
         self._fill_buffer(size)
         return self._read_from_buffer(size)
 
-    def read1(self, size=-1):
+    def read1(self, size: int | None = -1) -> bytes:
         """This is the same as read()."""
         return self.read(size=size)
 
-    def readinto(self, b):
+    def readinto(self, b: WriteableBuffer) -> int:
         """Read up to len(b) bytes into b, and return the number of bytes read."""
-        data = self.read(len(b))
+        mv = memoryview(b).cast("B")
+        data = self.read(len(mv))
         if not data:
             return 0
-        b[: len(data)] = data
+        mv[: len(data)] = data
         return len(data)
 
-    def readline(self, limit=-1):
+    def readline(self, limit: int | None = -1) -> bytes:
         """Read up to and including the next newline.  Returns the bytes read."""
+        if limit is None:
+            limit = -1
         if limit != -1:
             msg = "limits other than -1 not implemented yet"
             raise NotImplementedError(msg)
@@ -370,35 +409,43 @@ class Reader(io.BufferedIOBase):
     #
     # Internal methods.
     #
-    def _read_from_buffer(self, size=-1):
+    def _read_from_buffer(self, size: int = -1) -> bytes:
         """Remove at most size bytes from our buffer and return them."""
         size = size if size >= 0 else len(self._current_part)
         part = self._current_part.read(size)
         self._position += len(part)
         return part
 
-    def _fill_buffer(self, size=-1):
+    def _fill_buffer(self, size: int = -1) -> bool | None:
+        raw_reader = self._raw_reader
+        assert raw_reader is not None  # noqa: S101  # set in __init__, cleared only on close
         size = max(size, self._current_part._chunk_size)  # noqa: SLF001  # intra-package coupling
         while len(self._current_part) < size and self._position != self._size:
-            bytes_read = self._current_part.fill(self._raw_reader)
+            # _RawReader has a compatible ``read`` method but is not nominally IO[bytes].
+            bytes_read = self._current_part.fill(cast("IO[bytes]", raw_reader))
             if bytes_read == 0:
                 logger.debug("reached EOF while filling buffer")
                 return True
         return None
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         """Enter the reader context manager."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Close the reader on context exit."""
         self.close()
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return a short human-readable description of the reader."""
         return f"({self.__class__.__name__}, {self._container_name!r}, {self._blob_name!r})"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return an unambiguous representation of the reader."""
         return f"{self.__class__.__name__}(container={self._container_name!r}, blob={self._blob_name!r})"
 
@@ -409,16 +456,17 @@ class Writer(io.BufferedIOBase):
     Implements the io.BufferedIOBase interface of the standard library.
     """
 
-    _blob = None  # so `closed` property works in case __init__ fails and __del__ is called
+    name: str
+    _blob: azure.storage.blob.BlobClient | None = None  # so `closed` works if __init__ fails and __del__ runs
 
     def __init__(
         self,
-        container,
-        blob,
-        client,  # type: Union[azure.storage.blob.BlobServiceClient, azure.storage.blob.ContainerClient, azure.storage.blob.BlobClient]
-        blob_kwargs=None,
-        min_part_size=_DEFAULT_MIN_PART_SIZE,
-    ):
+        container: str,
+        blob: str,
+        client: _AzureClient,
+        blob_kwargs: dict[str, Any] | None = None,
+        min_part_size: int = _DEFAULT_MIN_PART_SIZE,
+    ) -> None:
         self._container_name = container
         self._blob_name = blob
         self._blob_kwargs = blob_kwargs or {}
@@ -427,14 +475,14 @@ class Writer(io.BufferedIOBase):
         self._total_parts = 0
         self._bytes_uploaded = 0
         self._current_part = io.BytesIO()
-        self._block_list = []
+        self._block_list: list[azure.storage.blob.BlobBlock] = []
 
-        self._blob: azure.storage.blob.BlobClient = _get_blob_client(client, container, blob)
+        self._blob = _get_blob_client(client, container, blob)
 
-    def flush(self):
+    def flush(self) -> None:
         """No-op flush; data is buffered until `close` or `_upload_part`."""
 
-    def terminate(self):
+    def terminate(self) -> None:
         """Do not commit block list on abort.
 
         Uploaded (uncommitted) blocks will be garbage collected after 7 days.
@@ -450,54 +498,56 @@ class Writer(io.BufferedIOBase):
     #
     # Override some methods from io.IOBase.
     #
-    def close(self):
+    def close(self) -> None:
         """Commit the buffered block list and close the stream."""
         logger.debug("close: called")
         if not self.closed:
+            blob = self._blob
+            assert blob is not None  # noqa: S101  # not closed implies blob is set
             logger.debug("%s: completing multipart upload", self)
             try:
                 if self._current_part.tell() > 0:
                     self._upload_part()
-                self._blob.commit_block_list(self._block_list, **self._blob_kwargs)
+                blob.commit_block_list(self._block_list, **self._blob_kwargs)
             finally:
                 self._block_list = []
                 self._blob = None
             logger.debug("%s: completed multipart upload", self)
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         """Return True if the stream is closed."""
         return self._blob is None
 
-    def writable(self):
+    def writable(self) -> bool:
         """Return True if the stream supports writing."""
         return True
 
-    def seekable(self):
+    def seekable(self) -> bool:
         """Return True; we support `tell` but not `seek` or `truncate`."""
         return True
 
-    def seek(self, offset, whence=smart_open.constants.WHENCE_START):
+    def seek(self, offset: int, whence: int = smart_open.constants.WHENCE_START) -> int:
         """Unsupported."""
         raise io.UnsupportedOperation
 
-    def truncate(self, size=None):
+    def truncate(self, size: int | None = None) -> int:
         """Unsupported."""
         raise io.UnsupportedOperation
 
-    def tell(self):
+    def tell(self) -> int:
         """Return the current stream position."""
         return self._total_size
 
     #
     # io.BufferedIOBase methods.
     #
-    def detach(self):
+    def detach(self) -> io.RawIOBase:
         """Unsupported."""
         msg = "detach() not supported"
         raise io.UnsupportedOperation(msg)
 
-    def write(self, b):
+    def write(self, b: ReadableBuffer) -> int:
         """Write the given bytes (binary string) to the Azure Blob Storage file.
 
         There's buffering happening under the covers, so this may not actually
@@ -507,15 +557,18 @@ class Writer(io.BufferedIOBase):
             msg = f"input must be one of {_BINARY_TYPES!r}, got: {type(b)!r}"
             raise TypeError(msg)
 
+        length = len(memoryview(b))
         self._current_part.write(b)
-        self._total_size += len(b)
+        self._total_size += length
 
         if self._current_part.tell() >= self._min_part_size:
             self._upload_part()
 
-        return len(b)
+        return length
 
-    def _upload_part(self):
+    def _upload_part(self) -> None:
+        blob = self._blob
+        assert blob is not None  # noqa: S101  # _upload_part is only called while the writer is open
         part_num = self._total_parts + 1
         content_length = self._current_part.tell()
         range_stop = self._bytes_uploaded + content_length - 1
@@ -526,8 +579,11 @@ class Writer(io.BufferedIOBase):
         zero_padded_part_num = str(part_num).zfill(64 // 2)
         block_id = base64.b64encode(zero_padded_part_num.encode())
         self._current_part.seek(0)
-        self._blob.stage_block(block_id, self._current_part.read(content_length))
-        self._block_list.append(azure.storage.blob.BlobBlock(block_id=block_id))
+        # the SDK accepts bytes block IDs at runtime even though its stubs say str
+        blob.stage_block(block_id, self._current_part.read(content_length))  # ty: ignore[invalid-argument-type]
+        self._block_list.append(
+            azure.storage.blob.BlobBlock(block_id=block_id),  # ty: ignore[invalid-argument-type]
+        )
 
         logger.info(
             "uploading part #%i, %i bytes (total %.3fGB)",
@@ -541,22 +597,27 @@ class Writer(io.BufferedIOBase):
         self._current_part = io.BytesIO(self._current_part.read())
         self._current_part.seek(0, io.SEEK_END)
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         """Enter the writer context manager."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Close or terminate the writer on context exit."""
         if exc_type is not None:
             self.terminate()
         else:
             self.close()
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return a short human-readable description of the writer."""
         return f"({self.__class__.__name__}, {self._container_name!r}, {self._blob_name!r})"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return an unambiguous representation of the writer."""
         return f"{self.__class__.__name__}(container={self._container_name!r}, blob={self._blob_name!r}, min_part_size={self._min_part_size!r})"
 
@@ -567,16 +628,17 @@ class AppendWriter(io.BufferedIOBase):
     Implements the io.BufferedIOBase interface of the standard library.
     """
 
-    _blob = None  # so `closed` property works in case __init__ fails and __del__ is called
+    name: str
+    _blob: azure.storage.blob.BlobClient | None = None  # so `closed` works if __init__ fails and __del__ runs
 
     def __init__(
         self,
-        container,
-        blob,
-        client,  # type: Union[azure.storage.blob.BlobServiceClient, azure.storage.blob.ContainerClient, azure.storage.blob.BlobClient]
-        blob_kwargs=None,
-        min_part_size=_DEFAULT_MIN_PART_SIZE,
-    ):
+        container: str,
+        blob: str,
+        client: _AzureClient,
+        blob_kwargs: dict[str, Any] | None = None,
+        min_part_size: int = _DEFAULT_MIN_PART_SIZE,
+    ) -> None:
         self._container_name = container
         self._blob_name = blob
         self._blob_kwargs = blob_kwargs or {}
@@ -584,18 +646,18 @@ class AppendWriter(io.BufferedIOBase):
         self._total_size = 0
         self._current_part = io.BytesIO()
 
-        self._blob: azure.storage.blob.BlobClient = _get_blob_client(client, container, blob)
+        self._blob = _get_blob_client(client, container, blob)
 
-    def flush(self):
+    def flush(self) -> None:
         """No-op flush; data is buffered until `close` or `_upload_part`."""
 
-    def terminate(self):
+    def terminate(self) -> None:
         """AppendBlob cannot be aborted, so we do nothing here."""
         if not self.closed:
             self._current_part = io.BytesIO()
             self._blob = None
 
-    def close(self):
+    def close(self) -> None:
         """No action needed here, as the AppendBlob is automatically committed."""
         if not self.closed:
             try:
@@ -605,49 +667,52 @@ class AppendWriter(io.BufferedIOBase):
                 self._blob = None
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         """Return True if the stream is closed."""
         return self._blob is None
 
-    def writable(self):
+    def writable(self) -> bool:
         """Return True if the stream supports writing."""
         return True
 
-    def seekable(self):
+    def seekable(self) -> bool:
         """Return True; we support `tell` but not `seek` or `truncate`."""
         return True
 
-    def seek(self, offset, whence=smart_open.constants.WHENCE_START):
+    def seek(self, offset: int, whence: int = smart_open.constants.WHENCE_START) -> int:
         """Unsupported."""
         raise io.UnsupportedOperation
 
-    def truncate(self, size=None):
+    def truncate(self, size: int | None = None) -> int:
         """Unsupported."""
         raise io.UnsupportedOperation
 
-    def tell(self):
+    def tell(self) -> int:
         """Return the current stream position."""
         return self._total_size
 
-    def detach(self):
+    def detach(self) -> io.RawIOBase:
         """Unsupported."""
         msg = "detach() not supported"
         raise io.UnsupportedOperation(msg)
 
-    def write(self, b):
+    def write(self, b: ReadableBuffer) -> int:
         """Append `b` to the AppendBlob, buffering until ``min_part_size``."""
         if not isinstance(b, _BINARY_TYPES):
             msg = f"input must be one of {_BINARY_TYPES!r}, got: {type(b)!r}"
             raise TypeError(msg)
+        length = len(memoryview(b))
         self._current_part.write(b)
-        self._total_size += len(b)
+        self._total_size += length
         if self._current_part.tell() >= self._min_part_size:
             self._upload_part()
-        return len(b)
+        return length
 
-    def _upload_part(self):
+    def _upload_part(self) -> None:
+        blob = self._blob
+        assert blob is not None  # noqa: S101  # _upload_part is only called while the writer is open
         data = self._current_part.getvalue()
-        self._blob.upload_blob(
+        blob.upload_blob(
             data=data,
             blob_type=azure.storage.blob.BlobType.APPENDBLOB,
             overwrite=False,
@@ -655,21 +720,26 @@ class AppendWriter(io.BufferedIOBase):
         )
         self._current_part = io.BytesIO()
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         """Enter the append writer context manager."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Close or terminate the append writer on context exit."""
         if exc_type is not None:
             self.terminate()
         else:
             self.close()
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return a short human-readable description of the append writer."""
         return f"({self.__class__.__name__}, {self._container_name!r}, {self._blob_name!r})"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return an unambiguous representation of the append writer."""
         return f"{self.__class__.__name__}(container={self._container_name!r}, blob={self._blob_name!r})"

--- a/smart_open/bytebuffer.py
+++ b/smart_open/bytebuffer.py
@@ -6,7 +6,13 @@
 #
 """Implements ByteBuffer class for amortizing network transfer overhead."""
 
+from __future__ import annotations
+
 import io
+from typing import IO, TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class ByteBuffer:
@@ -51,15 +57,15 @@ class ByteBuffer:
         0
     """
 
-    def __init__(self, chunk_size=io.DEFAULT_BUFFER_SIZE):
+    def __init__(self, chunk_size: int = io.DEFAULT_BUFFER_SIZE) -> None:
         self._chunk_size = chunk_size
         self.empty()
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Return the number of unread bytes in the buffer as an int."""
         return len(self._bytes) - self._pos
 
-    def read(self, size=-1):
+    def read(self, size: int = -1) -> bytes:
         """Read bytes from the buffer and advance the read position.
 
         Args:
@@ -73,7 +79,7 @@ class ByteBuffer:
         self._pos += len(part)
         return part
 
-    def peek(self, size=-1):
+    def peek(self, size: int = -1) -> bytes:
         """Get bytes from the buffer without advancing the read position.
 
         Args:
@@ -88,12 +94,12 @@ class ByteBuffer:
 
         return bytes(self._bytes[self._pos : self._pos + size])
 
-    def empty(self):
+    def empty(self) -> None:
         """Remove all bytes from the buffer."""
         self._bytes = bytearray()
         self._pos = 0
 
-    def fill(self, source, size=-1):
+    def fill(self, source: IO[bytes] | Iterable[bytes], size: int = -1) -> int:
         """Fill the buffer with bytes from source.
 
         Reads from ``source`` until one of these conditions is met:
@@ -128,7 +134,7 @@ class ByteBuffer:
             self._pos = 0
 
         if hasattr(source, "read"):
-            new_bytes = source.read(size)
+            new_bytes = cast("IO[bytes]", source).read(size)
         else:
             new_bytes = bytearray()
             for more_bytes in source:
@@ -139,7 +145,7 @@ class ByteBuffer:
         self._bytes += new_bytes
         return len(new_bytes)
 
-    def readline(self, terminator):
+    def readline(self, terminator: bytes) -> bytes:
         """Read a line from this buffer efficiently.
 
         A line is a contiguous sequence of bytes that ends with either:

--- a/smart_open/compression.py
+++ b/smart_open/compression.py
@@ -6,13 +6,19 @@
 #
 """Implements the compression layer of the `smart_open` library."""
 
+from __future__ import annotations
+
 import io
 import logging
 from pathlib import Path
+from typing import IO, TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from smart_open._typing import CompressionKwargs, Compressor
 
 logger = logging.getLogger(__name__)
 
-_COMPRESSOR_REGISTRY = {}
+_COMPRESSOR_REGISTRY: dict[str, Compressor] = {}
 
 NO_COMPRESSION = "disable"
 """Use no compression. Read/write the data as-is."""
@@ -23,7 +29,7 @@ See get_supported_extensions().
 """
 
 
-def get_supported_compression_types():
+def get_supported_compression_types() -> list[str]:
     """Return the list of supported compression types available to open.
 
     See compression paratemeter to smart_open.open().
@@ -31,12 +37,12 @@ def get_supported_compression_types():
     return [NO_COMPRESSION, INFER_FROM_EXTENSION, *get_supported_extensions()]
 
 
-def get_supported_extensions():
+def get_supported_extensions() -> list[str]:
     """Return the list of file extensions for which we have registered compressors."""
     return sorted(_COMPRESSOR_REGISTRY.keys())
 
 
-def register_compressor(ext, callback):
+def register_compressor(ext: str, callback: Compressor) -> None:
     """Register a callback for transparently decompressing files with a specific extension.
 
     Args:
@@ -73,7 +79,7 @@ def register_compressor(ext, callback):
     _COMPRESSOR_REGISTRY[ext] = callback
 
 
-def _maybe_wrap_buffered(file_obj, mode):
+def _maybe_wrap_buffered(file_obj: Any, mode: str) -> IO[bytes]:
     # https://github.com/piskvorky/smart_open/issues/760#issuecomment-1553971657
     result = file_obj
     if "b" in mode and "w" in mode:
@@ -83,39 +89,41 @@ def _maybe_wrap_buffered(file_obj, mode):
     return result
 
 
-def _handle_bz2(file_obj, mode, **kwargs):
+def _handle_bz2(file_obj: IO[bytes], mode: str, **kwargs: Any) -> IO[Any]:
     import bz2
 
     result = bz2.open(filename=file_obj, mode=mode, **kwargs)  # noqa: SIM115  # returns the file object to caller
     return _maybe_wrap_buffered(result, mode)
 
 
-def _handle_gzip(file_obj, mode, **kwargs):
+def _handle_gzip(file_obj: IO[bytes], mode: str, **kwargs: Any) -> IO[Any]:
     import gzip
 
     result = gzip.open(filename=file_obj, mode=mode, **kwargs)  # noqa: SIM115  # returns the file object to caller
     return _maybe_wrap_buffered(result, mode)
 
 
-def _handle_zstd(file_obj, mode, **kwargs):
+def _handle_zstd(file_obj: IO[bytes], mode: str, **kwargs: Any) -> IO[Any]:
     import sys
 
     if sys.version_info >= (3, 14):
         from compression import zstd
     else:
         from backports import zstd
-    result = zstd.open(file_obj, mode=mode, **kwargs)
+    # dynamic **kwargs cannot be matched against zstd.open()'s overloads, so go through Any
+    zstd_open: Any = zstd.open
+    result = zstd_open(file_obj, mode=mode, **kwargs)
     return _maybe_wrap_buffered(result, mode)
 
 
-def _handle_xz(file_obj, mode, **kwargs):
+def _handle_xz(file_obj: IO[bytes], mode: str, **kwargs: Any) -> IO[Any]:
     import lzma
 
     result = lzma.open(filename=file_obj, mode=mode, **kwargs)  # noqa: SIM115  # returns the file object to caller
     return _maybe_wrap_buffered(result, mode)
 
 
-def _handle_lz4(file_obj, mode, **kwargs):
+def _handle_lz4(file_obj: IO[bytes], mode: str, **kwargs: Any) -> IO[Any]:
     import lz4.frame
 
     result = lz4.frame.open(file_obj, mode=mode, **kwargs)
@@ -123,12 +131,12 @@ def _handle_lz4(file_obj, mode, **kwargs):
 
 
 def compression_wrapper(
-    file_obj,
-    mode,
-    compression=INFER_FROM_EXTENSION,
-    filename=None,
-    compression_kwargs=None,
-):
+    file_obj: IO[Any],
+    mode: str,
+    compression: str = INFER_FROM_EXTENSION,
+    filename: str | None = None,
+    compression_kwargs: CompressionKwargs | None = None,
+) -> IO[Any]:
     """Wrap `file_obj` with an appropriate [de]compression mechanism based on its file extension.
 
     If the filename extension isn't recognized, simply return the original `file_obj` unchanged.
@@ -145,13 +153,13 @@ def compression_wrapper(
         return file_obj
     if compression == INFER_FROM_EXTENSION:
         try:
-            filename = (filename or file_obj.name).lower()
+            inferred_name = (filename or file_obj.name).lower()
         except (AttributeError, TypeError):
             logger.warning(
                 "unable to transparently decompress %r because it seems to lack a string-like .name", file_obj
             )
             return file_obj
-        compression = Path(filename).suffix
+        compression = Path(inferred_name).suffix
 
     if compression in _COMPRESSOR_REGISTRY and mode.endswith("+"):
         msg = f"transparent (de)compression unsupported for mode {mode!r}"

--- a/smart_open/concurrency.py
+++ b/smart_open/concurrency.py
@@ -11,10 +11,15 @@ The main entry point is :class:`ThreadPoolExecutor`, which extends the
 standard library executor with a lazy ``imap`` method.
 """
 
+from __future__ import annotations
+
 import logging
 from collections import deque
-from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor as _ThreadPoolExecutor
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +27,13 @@ logger = logging.getLogger(__name__)
 class ThreadPoolExecutor(_ThreadPoolExecutor):
     """Subclass with a lazy consuming imap method."""
 
-    def imap(self, fn, *iterables, timeout=None, queued_tasks_per_worker=2) -> Iterator:
+    def imap(
+        self,
+        fn: Callable[..., Any],
+        *iterables: Iterable[Any],
+        timeout: float | None = None,
+        queued_tasks_per_worker: int = 2,
+    ) -> Iterator[Any]:
         """Ordered imap that consumes iterables just-in-time.
 
         References:
@@ -53,7 +64,7 @@ class ThreadPoolExecutor(_ThreadPoolExecutor):
         futures, maxlen = deque(), self._max_workers * (queued_tasks_per_worker + 1)
         popleft, append, submit = futures.popleft, futures.append, self.submit
 
-        def get():
+        def get() -> Any:
             """Block until the next task is done and return the result."""
             return popleft().result(timeout)
 

--- a/smart_open/constants.py
+++ b/smart_open/constants.py
@@ -7,21 +7,25 @@
 
 """Some universal constants that are common to I/O operations."""
 
-READ_BINARY = "rb"
+from __future__ import annotations
 
-WRITE_BINARY = "wb"
+from typing import Final
 
-APPEND_BINARY = "ab"
+READ_BINARY: Final = "rb"
+
+WRITE_BINARY: Final = "wb"
+
+APPEND_BINARY: Final = "ab"
 
 # APPEND_BINARY intentionally excluded: only Azure supports it, other transports should error.
-BINARY_MODES = (READ_BINARY, WRITE_BINARY)
+BINARY_MODES: Final = (READ_BINARY, WRITE_BINARY)
 
-BINARY_NEWLINE = b"\n"
+BINARY_NEWLINE: Final = b"\n"
 
-WHENCE_START = 0
+WHENCE_START: Final = 0
 
-WHENCE_CURRENT = 1
+WHENCE_CURRENT: Final = 1
 
-WHENCE_END = 2
+WHENCE_END: Final = 2
 
-WHENCE_CHOICES = (WHENCE_START, WHENCE_CURRENT, WHENCE_END)
+WHENCE_CHOICES: Final = (WHENCE_START, WHENCE_CURRENT, WHENCE_END)

--- a/smart_open/doctools.py
+++ b/smart_open/doctools.py
@@ -12,13 +12,19 @@ For internal use only.
 
 # ruff: noqa: T201  # this module builds the open()/parse_uri() docstrings by writing to sys.stdout
 
+from __future__ import annotations
+
 import contextlib
 import inspect
 import io
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
 
 from . import compression, transport
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 #
 # Python 3.13+ automatically trims docstrings (like inspect.cleandoc),
@@ -32,7 +38,7 @@ else:
     LPAD = "    "
 
 
-def extract_kwargs(docstring):
+def extract_kwargs(docstring: str | None) -> list[list[Any]]:
     """Extract keyword argument documentation from a Google-style ``Args:`` section.
 
     Args:
@@ -75,7 +81,7 @@ def extract_kwargs(docstring):
     else:
         return []
 
-    kwargs = []
+    kwargs: list[list[Any]] = []
     for line in lines:
         if not line.strip():  # stop at the first empty line encountered
             break
@@ -94,7 +100,7 @@ def extract_kwargs(docstring):
     return kwargs
 
 
-def to_docstring(kwargs, lpad=""):
+def to_docstring(kwargs: list[Any], lpad: str = "") -> str:
     """Reconstruct a docstring from keyword argument info.
 
     Basically reverses :func:`extract_kwargs`.
@@ -128,7 +134,7 @@ def to_docstring(kwargs, lpad=""):
     return buf.getvalue()
 
 
-def extract_examples_from_readme(indent=None):
+def extract_examples_from_readme(indent: str | None = None) -> str:
     """Extract examples from this project's README.md file.
 
     Args:
@@ -157,7 +163,7 @@ def extract_examples_from_readme(indent=None):
         return indent + "See README.md"
 
 
-def tweak_open_docstring(f):
+def tweak_open_docstring(f: Callable[..., Any]) -> None:
     """Inject transport, compression and example sections into ``f``'s docstring."""
     buf = io.StringIO()
     seen = set()
@@ -178,11 +184,11 @@ def tweak_open_docstring(f):
             except AttributeError:
                 schemes = [scheme]
 
-            relpath = Path(submodule.__file__).relative_to(root_path)
+            relpath = Path(cast("str", submodule.__file__)).relative_to(root_path)
             heading = "{} ({})".format("/".join(schemes), relpath)
             print(f"{body_pad}{heading}")
             print(f"{body_pad}{'~' * len(heading)}")
-            print(f"{body_pad}{submodule.__doc__.split(chr(10))[0]}")
+            print(f"{body_pad}{(submodule.__doc__ or '').split(chr(10))[0]}")
             print()
 
             kwargs = extract_kwargs(submodule.open.__doc__)
@@ -210,7 +216,7 @@ def tweak_open_docstring(f):
         f.__doc__ = f.__doc__.replace(PLACEHOLDER, buf.getvalue())
 
 
-def tweak_parse_uri_docstring(f):
+def tweak_parse_uri_docstring(f: Callable[..., Any]) -> None:
     """Inject supported schemes and example URIs into ``f``'s docstring."""
     buf = io.StringIO()
     seen = set()

--- a/smart_open/ftp.py
+++ b/smart_open/ftp.py
@@ -7,13 +7,19 @@
 
 """Implements I/O streams over FTP."""
 
+from __future__ import annotations
+
 import logging
 import ssl
 import types
 import urllib.parse
 from ftplib import FTP, FTP_TLS, error_reply
+from typing import IO, TYPE_CHECKING, Any, TypedDict, cast
 
 import smart_open.utils
+
+if TYPE_CHECKING:
+    from smart_open._typing import TransportParams
 
 logger = logging.getLogger(__name__)
 
@@ -33,11 +39,20 @@ URI_EXAMPLES = (
 )
 
 
-def _unquote(text):
+class _FTPUri(TypedDict):
+    scheme: str
+    uri_path: str | None
+    user: str | None
+    host: str | None
+    port: int
+    password: str | None
+
+
+def _unquote(text: str | None) -> str | None:
     return text and urllib.parse.unquote(text)
 
 
-def parse_uri(uri_as_string):
+def parse_uri(uri_as_string: str) -> _FTPUri:
     """Parse an ``ftp://`` or ``ftps://`` URI into connection components."""
     split_uri = urllib.parse.urlsplit(uri_as_string)
     assert split_uri.scheme in SCHEMES  # noqa: S101  # internal precondition; misuse should crash loudly
@@ -51,10 +66,10 @@ def parse_uri(uri_as_string):
     }
 
 
-def open_uri(uri, mode, transport_params):
+def open_uri(uri: str, mode: str, transport_params: TransportParams) -> IO[Any]:
     """Open an FTP/FTPS URI using the given mode and transport params."""
     smart_open.utils.check_kwargs(open, transport_params)
-    parsed_uri = parse_uri(uri)
+    parsed_uri: dict[str, Any] = dict(parse_uri(uri))
     uri_path = parsed_uri.pop("uri_path")
     scheme = parsed_uri.pop("scheme")
     secure_conn = scheme == "ftps"
@@ -67,7 +82,7 @@ def open_uri(uri, mode, transport_params):
     )
 
 
-def convert_transport_params_to_args(transport_params):
+def convert_transport_params_to_args(transport_params: TransportParams) -> dict[str, Any]:
     """Return the subset of `transport_params` that the FTP client accepts."""
     supported_keywords = [
         "timeout",
@@ -83,8 +98,16 @@ def convert_transport_params_to_args(transport_params):
     return kwargs
 
 
-def _connect(hostname, username, port, password, secure_connection, transport_params):  # noqa: PLR0913  # legacy internal helper; refactor in a dedicated PR
+def _connect(  # noqa: PLR0913  # legacy internal helper; refactor in a dedicated PR
+    hostname: str,
+    username: str | None,
+    port: int,
+    password: str | None,
+    secure_connection: bool,  # noqa: FBT001  # legacy internal helper
+    transport_params: TransportParams,
+) -> FTP | FTP_TLS:
     kwargs = convert_transport_params_to_args(transport_params)
+    ftp: FTP | FTP_TLS
     if secure_connection:
         ssl_context = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
         ftp = FTP_TLS(context=ssl_context, **kwargs)  # noqa: S321  # this module's purpose
@@ -96,25 +119,25 @@ def _connect(hostname, username, port, password, secure_connection, transport_pa
         logger.exception("Unable to connect to FTP server: try checking the host and port!")
         raise
     try:
-        ftp.login(username, password)
+        ftp.login(cast("str", username), cast("str", password))
     except error_reply:
         logger.exception("Unable to login to FTP server: try checking the username and password!")
         raise
-    if secure_connection:
+    if isinstance(ftp, FTP_TLS):
         ftp.prot_p()
     return ftp
 
 
 def open(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
-    path,
-    mode="rb",
-    host=None,
-    user=None,
-    password=None,
-    port=DEFAULT_PORT,
-    secure_connection=False,  # noqa: FBT002  # public API
-    transport_params=None,
-):
+    path: str | None,
+    mode: str = "rb",
+    host: str | None = None,
+    user: str | None = None,
+    password: str | None = None,
+    port: int = DEFAULT_PORT,
+    secure_connection: bool = False,  # noqa: FBT001, FBT002  # public API
+    transport_params: TransportParams | None = None,
+) -> IO[Any]:
     """Open a file for reading or writing via FTP/FTPS.
 
     Args:
@@ -156,9 +179,9 @@ def open(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
     ftp_mode, file_obj_mode = mode_to_ftp_cmds[mode]
     conn.voidcmd("TYPE I")
     socket = conn.transfercmd(f"{ftp_mode} {path}")
-    fobj = socket.makefile(file_obj_mode)
+    fobj: Any = socket.makefile(cast("Any", file_obj_mode))
 
-    def full_close(self):
+    def full_close(self: Any) -> None:
         self.orig_close()
         self.socket.close()
         self.conn.close()

--- a/smart_open/gcs.py
+++ b/smart_open/gcs.py
@@ -6,7 +6,10 @@
 #
 """Implements file-like objects for reading and writing to/from GCS."""
 
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING, Any, TypedDict
 
 try:
     import google.auth.transport.requests
@@ -19,6 +22,11 @@ import smart_open.bytebuffer
 import smart_open.utils
 from smart_open import constants
 
+if TYPE_CHECKING:
+    import io
+
+    from smart_open._typing import TransportParams
+
 logger = logging.getLogger(__name__)
 
 SCHEMES = ("gcs", "gs")
@@ -30,7 +38,13 @@ _DEFAULT_MIN_PART_SIZE = 50 * 1024**2
 _DEFAULT_WRITE_OPEN_KWARGS = {"ignore_flush": True}
 
 
-def parse_uri(uri_as_string):
+class _GCSUri(TypedDict):
+    scheme: str
+    bucket_id: str
+    blob_id: str
+
+
+def parse_uri(uri_as_string: str) -> _GCSUri:
     """Parse a ``gcs://`` or ``gs://`` URI into its bucket and blob components."""
     sr = smart_open.utils.safe_urlsplit(uri_as_string)
     assert sr.scheme in SCHEMES  # noqa: S101  # internal precondition; misuse should crash loudly
@@ -39,7 +53,7 @@ def parse_uri(uri_as_string):
     return {"scheme": sr.scheme, "bucket_id": bucket_id, "blob_id": blob_id}
 
 
-def open_uri(uri, mode, transport_params):
+def open_uri(uri: str, mode: str, transport_params: TransportParams) -> io.IOBase:
     """Open a GCS URI using the given mode and transport params."""
     parsed_uri = parse_uri(uri)
     kwargs = smart_open.utils.check_kwargs(open, transport_params)
@@ -47,15 +61,15 @@ def open_uri(uri, mode, transport_params):
 
 
 def open(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
-    bucket_id,
-    blob_id,
-    mode,
-    min_part_size=_DEFAULT_MIN_PART_SIZE,
-    client=None,  # type: google.cloud.storage.Client
-    get_blob_kwargs=None,
-    blob_properties=None,
-    blob_open_kwargs=None,
-):
+    bucket_id: str,
+    blob_id: str,
+    mode: str,
+    min_part_size: int = _DEFAULT_MIN_PART_SIZE,
+    client: google.cloud.storage.Client | None = None,
+    get_blob_kwargs: dict[str, Any] | None = None,
+    blob_properties: dict[str, Any] | None = None,
+    blob_open_kwargs: dict[str, Any] | None = None,
+) -> io.IOBase:
     """Open an GCS blob for reading or writing.
 
     Args:
@@ -105,7 +119,13 @@ def open(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
     return _blob
 
 
-def Reader(bucket, key, client=None, get_blob_kwargs=None, blob_open_kwargs=None):  # noqa: N802  # factory function named after returned class
+def Reader(  # noqa: N802  # factory function named after returned class
+    bucket: str,
+    key: str,
+    client: google.cloud.storage.Client | None = None,
+    get_blob_kwargs: dict[str, Any] | None = None,
+    blob_open_kwargs: dict[str, Any] | None = None,
+) -> io.IOBase:
     """Return a file-like object for reading the GCS blob `key` from `bucket`."""
     if get_blob_kwargs is None:
         get_blob_kwargs = {}
@@ -124,7 +144,14 @@ def Reader(bucket, key, client=None, get_blob_kwargs=None, blob_open_kwargs=None
     return blob.open("rb", **blob_open_kwargs)
 
 
-def Writer(bucket, blob, min_part_size=None, client=None, blob_properties=None, blob_open_kwargs=None):  # noqa: N802, PLR0913  # factory function named after returned class; legacy public API
+def Writer(  # noqa: N802, PLR0913  # factory function named after returned class; legacy public API
+    bucket: str,
+    blob: str,
+    min_part_size: int | None = None,
+    client: google.cloud.storage.Client | None = None,
+    blob_properties: dict[str, Any] | None = None,
+    blob_open_kwargs: dict[str, Any] | None = None,
+) -> io.IOBase:
     """Return a file-like object for writing to GCS blob `blob` in `bucket`."""
     if blob_open_kwargs is None:
         blob_open_kwargs = {}

--- a/smart_open/hdfs.py
+++ b/smart_open/hdfs.py
@@ -7,12 +7,20 @@
 
 """Implements reading and writing to/from HDFS."""
 
+from __future__ import annotations
+
 import io
 import logging
 import subprocess
 import urllib.parse
+from typing import TYPE_CHECKING, TypedDict
 
-from smart_open import utils
+import smart_open.utils
+
+if TYPE_CHECKING:
+    from _typeshed import ReadableBuffer, WriteableBuffer
+
+    from smart_open._typing import TransportParams
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +35,12 @@ URI_EXAMPLES = (
 )
 
 
-def parse_uri(uri_as_string):
+class _HDFSUri(TypedDict):
+    scheme: str
+    uri_path: str
+
+
+def parse_uri(uri_as_string: str) -> _HDFSUri:
     """Parse an ``hdfs://`` or ``viewfs://`` URI into its path component."""
     split_uri = urllib.parse.urlsplit(uri_as_string)
     assert split_uri.scheme in SCHEMES  # noqa: S101  # internal precondition; misuse should crash loudly
@@ -43,9 +56,9 @@ def parse_uri(uri_as_string):
     return {"scheme": split_uri.scheme, "uri_path": uri_path}
 
 
-def open_uri(uri, mode, transport_params):
+def open_uri(uri: str, mode: str, transport_params: TransportParams) -> CliRawInputBase | CliRawOutputBase:
     """Open an HDFS URI using the given mode and transport params."""
-    utils.check_kwargs(open, transport_params)
+    smart_open.utils.check_kwargs(open, transport_params)
 
     parsed_uri = parse_uri(uri)
     fobj = open(parsed_uri["uri_path"], mode)
@@ -53,7 +66,7 @@ def open_uri(uri, mode, transport_params):
     return fobj
 
 
-def open(uri, mode):
+def open(uri: str, mode: str) -> CliRawInputBase | CliRawOutputBase:
     """Open an HDFS `uri` for reading (``"rb"``) or writing (``"wb"``)."""
     if mode == "rb":
         return CliRawInputBase(uri)
@@ -69,56 +82,64 @@ class CliRawInputBase(io.RawIOBase):
     Implements the io.RawIOBase interface of the standard library.
     """
 
-    _sub = None  # so `closed` property works in case __init__ fails and __del__ is called
+    name: str
+    _sub: subprocess.Popen[bytes] | None = None  # so `closed` works if __init__ fails and __del__ runs
 
-    def __init__(self, uri):
+    def __init__(self, uri: str) -> None:
         self._uri = uri
         self._sub = subprocess.Popen(["hdfs", "dfs", "-cat", self._uri], stdout=subprocess.PIPE)  # noqa: S603, S607  # invokes local hdfs CLI
 
     #
     # Override some methods from io.IOBase.
     #
-    def close(self):
+    def close(self) -> None:
         """Flush and close this stream."""
         logger.debug("close: called")
-        if not self.closed:
-            self._sub.terminate()
+        sub = self._sub
+        if sub is not None:
+            sub.terminate()
             self._sub = None
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         """Return True if the stream is closed."""
         return self._sub is None
 
-    def readable(self):
+    def readable(self) -> bool:
         """Return True if the stream can be read from."""
         return self._sub is not None
 
-    def seekable(self):
+    def seekable(self) -> bool:
         """Return False; HDFS streams do not support seeking."""
         return False
 
     #
     # io.RawIOBase methods.
     #
-    def detach(self):
+    def detach(self) -> io.RawIOBase:
         """Unsupported."""
         raise io.UnsupportedOperation
 
-    def read(self, size=-1):
+    def read(self, size: int | None = -1) -> bytes:
         """Read up to size bytes from the object and return them."""
-        return self._sub.stdout.read(size)
+        sub = self._sub
+        assert sub is not None  # noqa: S101  # subprocess started in __init__
+        assert sub.stdout is not None  # noqa: S101  # stdout=PIPE set in __init__
+        if size is None:
+            size = -1
+        return sub.stdout.read(size)
 
-    def read1(self, size=-1):
+    def read1(self, size: int | None = -1) -> bytes:
         """This is the same as read()."""
         return self.read(size=size)
 
-    def readinto(self, b):
+    def readinto(self, b: WriteableBuffer) -> int:
         """Read up to ``len(b)`` bytes into `b` and return the number of bytes read."""
-        data = self.read(len(b))
+        mv = memoryview(b).cast("B")
+        data = self.read(len(mv))
         if not data:
             return 0
-        b[: len(data)] = data
+        mv[: len(data)] = data
         return len(data)
 
 
@@ -128,39 +149,45 @@ class CliRawOutputBase(io.RawIOBase):
     Implements the io.RawIOBase interface of the standard library.
     """
 
-    _sub = None  # so `closed` property works in case __init__ fails and __del__ is called
+    name: str
+    _sub: subprocess.Popen[bytes] | None = None  # so `closed` works if __init__ fails and __del__ runs
 
-    def __init__(self, uri):
+    def __init__(self, uri: str) -> None:
         self._uri = uri
         self._sub = subprocess.Popen(["hdfs", "dfs", "-put", "-f", "-", self._uri], stdin=subprocess.PIPE)  # noqa: S603, S607  # invokes local hdfs CLI
 
-    def close(self):
+    def close(self) -> None:
         """Flush and close this stream."""
         logger.debug("close: called")
-        if not self.closed:
+        sub = self._sub
+        if sub is not None:
+            assert sub.stdin is not None  # noqa: S101  # stdin=PIPE set in __init__
             self.flush()
-            self._sub.stdin.close()
-            self._sub.wait()
+            sub.stdin.close()
+            sub.wait()
             self._sub = None
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         """Return True if the stream is closed."""
         return self._sub is None
 
-    def flush(self):
+    def flush(self) -> None:
         """Flush the underlying ``hdfs dfs -put`` subprocess stdin."""
-        self._sub.stdin.flush()
+        sub = self._sub
+        assert sub is not None  # noqa: S101  # subprocess started in __init__
+        assert sub.stdin is not None  # noqa: S101  # stdin=PIPE set in __init__
+        sub.stdin.flush()
 
-    def writeable(self):
+    def writeable(self) -> bool:
         """Return True if this object is writeable."""
         return self._sub is not None
 
-    def seekable(self):
+    def seekable(self) -> bool:
         """Return False; HDFS streams do not support seeking."""
         return False
 
-    def write(self, b):
+    def write(self, b: ReadableBuffer) -> int:
         """Write the given buffer to the underlying raw stream.
 
         Returns the number of bytes written, as required by
@@ -171,12 +198,15 @@ class CliRawOutputBase(io.RawIOBase):
         ``AssertionError`` because ``write`` would otherwise implicitly
         return ``None``.
         """
-        return self._sub.stdin.write(b)
+        sub = self._sub
+        assert sub is not None  # noqa: S101  # subprocess started in __init__
+        assert sub.stdin is not None  # noqa: S101  # stdin=PIPE set in __init__
+        return sub.stdin.write(b)
 
     #
     # io.IOBase methods.
     #
-    def detach(self):
+    def detach(self) -> io.RawIOBase:
         """Unsupported."""
         msg = "detach() not supported"
         raise io.UnsupportedOperation(msg)

--- a/smart_open/http.py
+++ b/smart_open/http.py
@@ -6,10 +6,13 @@
 #
 """Implements file-like objects for reading from http."""
 
+from __future__ import annotations
+
 import io
 import logging
 import posixpath
 import urllib.parse
+from typing import TYPE_CHECKING, TypedDict
 
 try:
     import requests
@@ -19,10 +22,20 @@ except ImportError:
 import smart_open.utils
 from smart_open import bytebuffer, constants
 
+if TYPE_CHECKING:
+    from _typeshed import WriteableBuffer
+
+    from smart_open._typing import TransportParams
+
 DEFAULT_BUFFER_SIZE = 128 * 1024
 SCHEMES = ("http", "https")
 
 logger = logging.getLogger(__name__)
+
+
+class _HTTPUri(TypedDict):
+    scheme: str
+    uri_path: str
 
 
 _HEADERS = {"Accept-Encoding": "identity"}
@@ -34,7 +47,7 @@ the client (us) has to decompress them with the appropriate algorithm.
 """
 
 
-def parse_uri(uri_as_string):
+def parse_uri(uri_as_string: str) -> _HTTPUri:
     """Parse an ``http://`` or ``https://`` URI into its path component."""
     split_uri = urllib.parse.urlsplit(uri_as_string)
     assert split_uri.scheme in SCHEMES  # noqa: S101  # internal precondition; misuse should crash loudly
@@ -44,24 +57,24 @@ def parse_uri(uri_as_string):
     return {"scheme": split_uri.scheme, "uri_path": uri_path}
 
 
-def open_uri(uri, mode, transport_params):
+def open_uri(uri: str, mode: str, transport_params: TransportParams) -> BufferedInputBase:
     """Open an HTTP/HTTPS URI using the given mode and transport params."""
     kwargs = smart_open.utils.check_kwargs(open, transport_params)
     return open(uri, mode, **kwargs)
 
 
 def open(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
-    uri,
-    mode,
-    kerberos=False,  # noqa: FBT002  # public API
-    user=None,
-    password=None,
-    cert=None,
-    headers=None,
-    timeout=None,
-    session=None,
-    buffer_size=DEFAULT_BUFFER_SIZE,
-):
+    uri: str,
+    mode: str,
+    kerberos: bool = False,  # noqa: FBT001, FBT002  # public API
+    user: str | None = None,
+    password: str | None = None,
+    cert: str | tuple[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: float | None = None,
+    session: requests.Session | None = None,
+    buffer_size: int = DEFAULT_BUFFER_SIZE,
+) -> BufferedInputBase:
     """Implement streamed reader from a web site.
 
     Supports Kerberos and Basic HTTP authentication.
@@ -114,28 +127,29 @@ def open(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
 class BufferedInputBase(io.BufferedIOBase):
     """Buffered HTTP reader implementing the `io.BufferedIOBase` interface."""
 
-    response = None  # so `closed` property works in case __init__ fails and __del__ is called
+    name: str
+    response: requests.Response | None = None  # so `closed` works if __init__ fails and __del__ runs
 
     def __init__(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
         self,
-        url,
-        mode="r",
-        buffer_size=DEFAULT_BUFFER_SIZE,
-        kerberos=False,  # noqa: FBT002  # public API
-        user=None,
-        password=None,
-        cert=None,
-        headers=None,
-        session=None,
-        timeout=None,
-    ):
+        url: str,
+        mode: str = "r",
+        buffer_size: int = DEFAULT_BUFFER_SIZE,
+        kerberos: bool = False,  # noqa: FBT001, FBT002  # public API
+        user: str | None = None,
+        password: str | None = None,
+        cert: str | tuple[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+        session: requests.Session | None = None,
+        timeout: float | None = None,
+    ) -> None:
 
         self.url = url
         self.cert = cert
         self.session = session or requests
 
         if kerberos:
-            import requests_kerberos
+            import requests_kerberos  # ty: ignore[unresolved-import]  # optional, install separately for kerberos=True
 
             self.auth = requests_kerberos.HTTPKerberosAuth()
         elif user is not None and password is not None:
@@ -165,13 +179,13 @@ class BufferedInputBase(io.BufferedIOBase):
         if not self.response.ok:
             self.response.raise_for_status()
 
-        self._read_buffer = bytebuffer.ByteBuffer(buffer_size)
+        self._read_buffer: bytebuffer.ByteBuffer | None = bytebuffer.ByteBuffer(buffer_size)
         self._current_pos = 0
 
     #
     # Override some methods from io.IOBase.
     #
-    def close(self):
+    def close(self) -> None:
         """Flush and close this stream."""
         logger.debug("close: called")
         if not self.closed:
@@ -179,60 +193,64 @@ class BufferedInputBase(io.BufferedIOBase):
             self._read_buffer = None
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         """Return True if the stream is closed."""
         return self.response is None
 
-    def readable(self):
+    def readable(self) -> bool:
         """Return True if the stream can be read from."""
         return True
 
-    def seekable(self):
+    def seekable(self) -> bool:
         """Return False; the base HTTP reader does not support seeking."""
         return False
 
     #
     # io.BufferedIOBase methods.
     #
-    def detach(self):
+    def detach(self) -> io.RawIOBase:
         """Unsupported."""
         raise io.UnsupportedOperation
 
-    def read(self, size=-1):
+    def read(self, size: int | None = -1) -> bytes:
         """Mimic the read call to a filehandle object."""
+        if size is None:
+            size = -1
         if size < -1:
             msg = f"size must be >= -1, got {size}"
             raise ValueError(msg)
 
         logger.debug("reading with size: %d", size)
-        if self.closed or size == 0:
+        buf, response = self._read_buffer, self.response
+        if buf is None or response is None or size == 0:
             return b""
 
         if size == -1:
-            if len(self._read_buffer):
-                retval = self._read_buffer.read() + self.response.raw.read()
-            else:  # Avoid unnecessary +
-                retval = self.response.raw.read()
+            if len(buf):  # noqa: SIM108  # avoid the unnecessary + when the buffer is empty
+                retval = buf.read() + response.raw.read()
+            else:
+                retval = response.raw.read()
         else:
             # Fill _read_buffer until it contains enough bytes
-            while len(self._read_buffer) < size:
-                if self._read_buffer.fill(self.response.raw) == 0:
+            while len(buf) < size:
+                if buf.fill(response.raw) == 0:
                     break  # EOF reached
-            retval = self._read_buffer.read(size)
+            retval = buf.read(size)
 
         self._current_pos += len(retval)
         return retval
 
-    def read1(self, size=-1):
+    def read1(self, size: int | None = -1) -> bytes:
         """This is the same as read()."""
         return self.read(size=size)
 
-    def readinto(self, b):
+    def readinto(self, b: WriteableBuffer) -> int:
         """Read up to ``len(b)`` bytes into ``b``, and return the number of bytes read."""
-        data = self.read(len(b))
+        mv = memoryview(b).cast("B")
+        data = self.read(len(mv))
         if not data:
             return 0
-        b[: len(data)] = data
+        mv[: len(data)] = data
         return len(data)
 
 
@@ -248,18 +266,19 @@ class SeekableBufferedInputBase(BufferedInputBase):
 
     def __init__(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
         self,
-        url,
-        mode="r",
-        buffer_size=DEFAULT_BUFFER_SIZE,
-        kerberos=False,  # noqa: FBT002  # public API
-        user=None,
-        password=None,
-        cert=None,
-        headers=None,
-        session=None,
-        timeout=None,
-    ):
+        url: str,
+        mode: str = "r",
+        buffer_size: int = DEFAULT_BUFFER_SIZE,
+        kerberos: bool = False,  # noqa: FBT001, FBT002  # public API
+        user: str | None = None,
+        password: str | None = None,
+        cert: str | tuple[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+        session: requests.Session | None = None,
+        timeout: float | None = None,
+    ) -> None:
         super().__init__(url, mode, buffer_size, kerberos, user, password, cert, headers, session, timeout)
+        assert self.response is not None  # noqa: S101  # set by super().__init__
         self.content_length = int(self.response.headers.get("Content-Length", -1))
         #
         # We assume the HTTP stream is seekable unless the server explicitly
@@ -269,7 +288,7 @@ class SeekableBufferedInputBase(BufferedInputBase):
         #
         self._seekable = self.response.headers.get("Accept-Ranges", "").lower() != "none"
 
-    def seek(self, offset, whence=0):  # noqa: C901, PLR0912  # legacy public API; refactor in a dedicated PR
+    def seek(self, offset: int, whence: int = 0) -> int:  # noqa: C901, PLR0912  # legacy public API; refactor in a dedicated PR
         """Seek to the specified position.
 
         Args:
@@ -292,11 +311,16 @@ class SeekableBufferedInputBase(BufferedInputBase):
             msg = "stream is not seekable"
             raise OSError(msg)
 
+        buf = self._read_buffer
+        if buf is None:
+            msg = "seek on closed stream"
+            raise OSError(msg)
+
         if whence == constants.WHENCE_START:
             new_pos = offset
         elif whence == constants.WHENCE_CURRENT:
             new_pos = self._current_pos + offset
-        elif whence == constants.WHENCE_END:
+        else:  # constants.WHENCE_END
             new_pos = self.content_length + offset
 
         if self.content_length == -1:
@@ -308,8 +332,8 @@ class SeekableBufferedInputBase(BufferedInputBase):
             return self._current_pos
 
         # Check if we can satisfy the seek from buffer (forward seek within buffered data)
-        if new_pos > self._current_pos and new_pos - self._current_pos <= len(self._read_buffer):
-            self._read_buffer.read(new_pos - self._current_pos)
+        if new_pos > self._current_pos and new_pos - self._current_pos <= len(buf):
+            buf.read(new_pos - self._current_pos)
             self._current_pos = new_pos
             return self._current_pos
 
@@ -319,30 +343,30 @@ class SeekableBufferedInputBase(BufferedInputBase):
 
         if new_pos == self.content_length:
             self.response = None
-            self._read_buffer.empty()
+            buf.empty()
         else:
             response = self._partial_request(new_pos)
             if response.ok:
                 self.response = response
-                self._read_buffer.empty()
+                buf.empty()
             else:
                 self.response = None
 
         return self._current_pos
 
-    def tell(self):
+    def tell(self) -> int:
         """Return the current stream position."""
         return self._current_pos
 
-    def seekable(self, *args, **kwargs):
+    def seekable(self, *args: object, **kwargs: object) -> bool:
         """Return True if the server reports it accepts byte-range requests."""
         return self._seekable
 
-    def truncate(self, size=None):
+    def truncate(self, size: int | None = None) -> int:
         """Unsupported."""
         raise io.UnsupportedOperation
 
-    def _partial_request(self, start_pos=None):
+    def _partial_request(self, start_pos: int | None = None) -> requests.Response:
         headers = self.headers.copy()
         if start_pos is not None:
             headers["range"] = smart_open.utils.make_range_string(start_pos)

--- a/smart_open/local_file.py
+++ b/smart_open/local_file.py
@@ -6,9 +6,15 @@
 #
 """Implements the transport for the file:// schema."""
 
+from __future__ import annotations
+
 import builtins
 import io
 import os.path
+from typing import IO, TYPE_CHECKING, Any, TypedDict
+
+if TYPE_CHECKING:
+    from smart_open._typing import TransportParams
 
 SCHEME = "file"
 
@@ -22,22 +28,27 @@ URI_EXAMPLES = (
 )
 
 
+class _LocalUri(TypedDict):
+    scheme: str
+    uri_path: str
+
+
 open = io.open
 
 
-def parse_uri(uri_as_string):
+def parse_uri(uri_as_string: str) -> _LocalUri:
     """Parse a ``file://`` URI (or bare local path) into its path component."""
     local_path = extract_local_path(uri_as_string)
     return {"scheme": SCHEME, "uri_path": local_path}
 
 
-def open_uri(uri_as_string, mode, transport_params):  # noqa: ARG001  # interface conformance
+def open_uri(uri_as_string: str, mode: str, transport_params: TransportParams) -> IO[Any]:  # noqa: ARG001  # interface conformance
     """Open a local file URI using the given mode."""
     parsed_uri = parse_uri(uri_as_string)
     return builtins.open(parsed_uri["uri_path"], mode)  # noqa: PTH123  # mirrors builtins.open signature exactly
 
 
-def extract_local_path(uri_as_string):
+def extract_local_path(uri_as_string: str) -> str:
     """Return the user-expanded local filesystem path from `uri_as_string`."""
     if uri_as_string.startswith("file://"):
         local_path = uri_as_string.replace("file://", "", 1)

--- a/smart_open/s3.py
+++ b/smart_open/s3.py
@@ -20,10 +20,15 @@ from collections.abc import Callable, Iterator
 from math import inf
 from typing import (
     TYPE_CHECKING,
+    Any,
+    TypedDict,
+    cast,
 )
 
 try:
     import boto3
+    import boto3.s3.transfer
+    import boto3.session
     import botocore.client
     import botocore.exceptions
     import urllib3.exceptions
@@ -36,8 +41,15 @@ import smart_open.utils
 from smart_open import constants
 
 if TYPE_CHECKING:
+    from types import TracebackType
+
+    from _typeshed import WriteableBuffer
+    from botocore.response import StreamingBody
     from mypy_boto3_s3.client import S3Client
-    from typing_extensions import Buffer
+    from mypy_boto3_s3.type_defs import CompletedMultipartUploadTypeDef
+    from typing_extensions import Buffer, Self
+
+    from smart_open._typing import TransportParams
 
 logger = logging.getLogger(__name__)
 
@@ -80,16 +92,25 @@ _OUT_OF_RANGE = "InvalidRange"
 _VERSION_ID_RE = re.compile(r"(?P<sep>[?&])versionId=(?P<value>[^&]*)")
 
 
+class _S3Uri(TypedDict):
+    scheme: str
+    bucket_id: str
+    key_id: str
+    access_id: str | None
+    access_secret: str | None
+    version_id: str | None
+
+
 class Retry:
     """Retry policy used by the S3 transport for transient client/network errors."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.attempts: int = 6
         self.sleep_seconds: int = 10
-        self.exceptions: list[Exception] = [botocore.exceptions.EndpointConnectionError]
+        self.exceptions: list[type[BaseException]] = [botocore.exceptions.EndpointConnectionError]
         self.client_error_codes: list[str] = ["NoSuchUpload"]
 
-    def _do(self, fn: Callable):
+    def _do(self, fn: functools.partial[Any]) -> Any:
         for attempt in range(self.attempts):
             try:
                 return fn()
@@ -136,17 +157,17 @@ class _ClientWrapper:
     This wrapper behaves identically to the client otherwise.
     """
 
-    def __init__(self, client, kwargs):
+    def __init__(self, client: S3Client, kwargs: dict[str, Any]) -> None:
         self.client = client
         self.kwargs = kwargs
 
-    def __getattr__(self, method_name):
+    def __getattr__(self, method_name: str) -> Callable[..., Any]:
         method = getattr(self.client, method_name)
         kwargs = self.kwargs.get(f"S3.Client.{method_name}", {})
         return functools.partial(method, **kwargs)
 
 
-def parse_uri(uri_as_string):
+def parse_uri(uri_as_string: str) -> _S3Uri:
     """Parse an ``s3://`` URI into bucket, key, credential, and version components."""
     #
     # Restrictions on bucket names and labels:
@@ -221,7 +242,7 @@ def parse_uri(uri_as_string):
     }
 
 
-def _consolidate_params(uri, transport_params):
+def _consolidate_params(uri: _S3Uri, transport_params: TransportParams) -> tuple[_S3Uri, TransportParams]:
     """Consolidates the parsed Uri with the additional parameters.
 
     This is necessary because the user can pass some of the parameters can in
@@ -236,7 +257,7 @@ def _consolidate_params(uri, transport_params):
     """
     transport_params = dict(transport_params)
 
-    def inject(**kwargs):
+    def inject(**kwargs: Any) -> None:
         try:
             client_kwargs = transport_params["client_kwargs"]
         except KeyError:
@@ -278,7 +299,7 @@ def _consolidate_params(uri, transport_params):
     return uri, transport_params
 
 
-def open_uri(uri, mode, transport_params):
+def open_uri(uri: str, mode: str, transport_params: TransportParams) -> io.BufferedIOBase:
     """Open an S3 URI using the given mode and transport params."""
     parsed_uri = parse_uri(uri)
     parsed_uri, transport_params = _consolidate_params(parsed_uri, transport_params)
@@ -287,19 +308,19 @@ def open_uri(uri, mode, transport_params):
 
 
 def open(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
-    bucket_id,
-    key_id,
-    mode,
-    version_id=None,
-    buffer_size=DEFAULT_BUFFER_SIZE,
-    min_part_size=DEFAULT_PART_SIZE,
-    multipart_upload=True,  # noqa: FBT002  # public API
-    defer_seek=False,  # noqa: FBT002  # public API
-    client=None,
-    client_kwargs=None,
-    writebuffer=None,
-    range_chunk_size=None,
-):
+    bucket_id: str,
+    key_id: str,
+    mode: str,
+    version_id: str | None = None,
+    buffer_size: int = DEFAULT_BUFFER_SIZE,
+    min_part_size: int = DEFAULT_PART_SIZE,
+    multipart_upload: bool = True,  # noqa: FBT001, FBT002  # public API
+    defer_seek: bool = False,  # noqa: FBT001, FBT002  # public API
+    client: S3Client | None = None,
+    client_kwargs: dict[str, Any] | None = None,
+    writebuffer: io.BytesIO | None = None,
+    range_chunk_size: int | None = None,
+) -> io.BufferedIOBase:
     """Open an S3 object for reading or writing.
 
     Args:
@@ -420,27 +441,33 @@ def open(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
     return fileobj
 
 
-def _get(client, bucket, key, version, range_string):
+def _get(
+    client: S3Client,
+    bucket: str,
+    key: str,
+    version: str | None,
+    range_string: str | None,
+) -> dict[str, Any]:
     try:
-        params = {"Bucket": bucket, "Key": key}
+        params: dict[str, Any] = {"Bucket": bucket, "Key": key}
         if version:
             params["VersionId"] = version
         if range_string:
             params["Range"] = range_string
 
-        return client.get_object(**params)
+        return cast("dict[str, Any]", client.get_object(**params))
     except botocore.client.ClientError as error:
         wrapped_error = OSError(
             f"unable to access bucket: {bucket!r} key: {key!r} version: {version!r} error: {error}"
         )
-        wrapped_error.backend_error = error
+        wrapped_error.backend_error = error  # ty: ignore[unresolved-attribute]  # smuggle the botocore error through
         raise wrapped_error from error
 
 
-def _unwrap_ioerror(ioe):
+def _unwrap_ioerror(ioe: OSError) -> dict[str, Any] | None:
     """Given an IOError from _get, return the 'Error' dictionary from botocore."""
     try:
-        return ioe.backend_error.response["Error"]
+        return ioe.backend_error.response["Error"]  # ty: ignore[unresolved-attribute]  # set by _get
     except (AttributeError, KeyError):
         return None
 
@@ -453,32 +480,33 @@ class _SeekableRawReader:
 
     def __init__(
         self,
-        client,
-        bucket,
-        key,
-        version_id=None,
-        range_chunk_size=None,
-    ):
+        client: S3Client,
+        bucket: str,
+        key: str,
+        version_id: str | None = None,
+        range_chunk_size: int | None = None,
+    ) -> None:
         self._client = client
         self._bucket = bucket
         self._key = key
         self._version_id = version_id
         self._range_chunk_size = range_chunk_size
 
-        self._content_length = None
+        self._content_length: int | None = None
         self._position = 0
-        self._body = None
+        self._body: StreamingBody | io.BytesIO | None = None
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         return self._body is None
 
-    def close(self):
-        if not self.closed:
-            self._body.close()
+    def close(self) -> None:
+        body = self._body
+        if body is not None:
+            body.close()
             self._body = None
 
-    def seek(self, offset, whence=constants.WHENCE_START):
+    def seek(self, offset: int, whence: int = constants.WHENCE_START) -> int:
         """Seek to the specified position.
 
         Args:
@@ -529,13 +557,14 @@ class _SeekableRawReader:
 
         if reached_eof:
             self._body = io.BytesIO()
+            assert self._content_length is not None  # noqa: S101  # reached_eof implies _content_length is set
             self._position = self._content_length
         else:
             self._open_body(start, stop)
 
         return self._position
 
-    def _open_body(self, start=None, stop=None):  # noqa: C901, PLR0912  # legacy internal helper; refactor in a dedicated PR
+    def _open_body(self, start: int | None = None, stop: int | None = None) -> None:  # noqa: C901, PLR0912  # legacy internal helper; refactor in a dedicated PR
         """Open a connection to download the specified range of bytes.
 
         Store the open file handle in self._body.
@@ -556,6 +585,7 @@ class _SeekableRawReader:
 
         # Apply chunking: limit the stop position if range_chunk_size is set
         if stop is None and self._range_chunk_size is not None:
+            assert start is not None  # noqa: S101  # stop is None implies start was set above
             stop = start + self._range_chunk_size - 1
             # Don't request beyond known content length
             if self._content_length is not None:
@@ -615,17 +645,19 @@ class _SeekableRawReader:
             self._body = response["Body"]
         elif status_code == http.HTTPStatus.OK:
             # 200 guarantees the response body contains the full file (server ignored range header)
+            content_length = response["ContentLength"]
+            body = response["Body"]
             self._position = 0
-            self._content_length = response["ContentLength"]
-            self._body = response["Body"]
+            self._content_length = content_length
+            self._body = body
             #
             # If we got a full request when we were actually expecting a range, we need to
             # read some data to ensure that the body starts in the place that the caller expects
             #
             if start is not None:
-                expected_position = min(self._content_length, start)
+                expected_position = min(content_length, start)
             elif start is None and stop is not None:
-                expected_position = max(0, self._content_length - stop)
+                expected_position = max(0, content_length - stop)
             else:
                 expected_position = 0
             if expected_position > 0:
@@ -634,19 +666,18 @@ class _SeekableRawReader:
                     self,
                     expected_position,
                 )
-                self._position = len(self._body.read(expected_position))
+                self._position = len(body.read(expected_position))
         else:
             msg = f"Unexpected status code {status_code!r}"
             raise ValueError(msg)
 
-    def read(self, size=-1):
+    def read(self, size: int = -1) -> bytes:
         """Read from the continuous connection with the remote peer."""
         if size < -1:
             msg = f"size must be >= -1, got {size}"
             raise ValueError(msg)
 
-        if size == -1:
-            size = inf  # makes for a simple while-condition below
+        size_limit: int | float = inf if size == -1 else size  # makes for a simple while-condition below
 
         binary_collected = io.BytesIO()
 
@@ -663,14 +694,16 @@ class _SeekableRawReader:
         # HTTP connection and try again.  Usually, a single retry attempt is
         # enough to recover, but we try multiple times "just in case".
         #
-        def retry_read(attempts=(1, 2, 4, 8, 16)) -> bytes:
+        def retry_read(attempts: tuple[int, ...] = (1, 2, 4, 8, 16)) -> bytes:
             for seconds in attempts:
                 if self.closed:
                     self._open_body()
+                body = self._body
+                assert body is not None  # noqa: S101  # _open_body (re)opens the body when closed
                 try:
-                    if size == inf:
-                        return self._body.read()
-                    return self._body.read(size - binary_collected.tell())
+                    if size_limit == inf:
+                        return body.read()
+                    return body.read(size - binary_collected.tell())
                 except (
                     ConnectionResetError,
                     botocore.exceptions.BotoCoreError,
@@ -680,12 +713,12 @@ class _SeekableRawReader:
                         "%s: caught %r while reading %d bytes, sleeping %ds before retry",
                         self,
                         err,
-                        -1 if size == inf else size,
+                        -1 if size_limit == inf else size,
                         seconds,
                     )
                     self.close()
                     time.sleep(seconds)
-            msg = f"{self}: failed to read {-1 if size == inf else size} bytes after {len(attempts)} attempts"
+            msg = f"{self}: failed to read {-1 if size_limit == inf else size} bytes after {len(attempts)} attempts"
             raise OSError(
                 msg,
             )
@@ -694,7 +727,7 @@ class _SeekableRawReader:
             self._content_length is None  # very first read call
             or (
                 self._position < self._content_length  # not yet end of file
-                and binary_collected.tell() < size  # not yet read enough
+                and binary_collected.tell() < size_limit  # not yet read enough
             )
         ):
             binary = retry_read()
@@ -705,12 +738,18 @@ class _SeekableRawReader:
 
         return binary_collected.getvalue()
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return a short human-readable description of the seekable reader."""
         return f"smart_open.s3._SeekableReader({self._bucket!r}, {self._key!r})"
 
 
-def _initialize_boto3(rw, client, client_kwargs, bucket, key):
+def _initialize_boto3(
+    rw: Reader | MultipartWriter | SinglepartWriter,
+    client: S3Client | None,
+    client_kwargs: dict[str, Any] | None,
+    bucket: str,
+    key: str,
+) -> None:
     """Create the boto3 client/bucket/key wrappers required for accessing S3."""
     if client_kwargs is None:
         client_kwargs = {}
@@ -728,7 +767,9 @@ def _initialize_boto3(rw, client, client_kwargs, bucket, key):
         client = boto3.client("s3", **init_kwargs)
     assert client  # noqa: S101  # internal precondition; misuse should crash loudly
 
-    rw._client = _ClientWrapper(client, client_kwargs)  # noqa: SLF001  # intra-package coupling
+    # _ClientWrapper delegates to a real S3Client via __getattr__; present it as
+    # S3Client so callers type-check against the genuine boto3 method signatures.
+    rw._client = cast("S3Client", _ClientWrapper(client, client_kwargs))  # noqa: SLF001  # intra-package coupling
     rw._bucket = bucket  # noqa: SLF001  # intra-package coupling
     rw._key = key  # noqa: SLF001  # intra-package coupling
 
@@ -739,18 +780,23 @@ class Reader(io.BufferedIOBase):
     Implements the io.BufferedIOBase interface of the standard library.
     """
 
+    name: str
+    _client: S3Client
+    _bucket: str
+    _key: str
+
     def __init__(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
         self,
-        bucket,
-        key,
-        version_id=None,
-        buffer_size=DEFAULT_BUFFER_SIZE,
-        line_terminator=constants.BINARY_NEWLINE,
-        defer_seek=False,  # noqa: FBT002  # public API
-        client=None,
-        client_kwargs=None,
-        range_chunk_size=None,
-    ):
+        bucket: str,
+        key: str,
+        version_id: str | None = None,
+        buffer_size: int = DEFAULT_BUFFER_SIZE,
+        line_terminator: bytes = constants.BINARY_NEWLINE,
+        defer_seek: bool = False,  # noqa: FBT001, FBT002  # public API
+        client: S3Client | None = None,
+        client_kwargs: dict[str, Any] | None = None,
+        range_chunk_size: int | None = None,
+    ) -> None:
         self._version_id = version_id
         self._buffer_size = buffer_size
 
@@ -776,22 +822,26 @@ class Reader(io.BufferedIOBase):
     # io.BufferedIOBase methods.
     #
 
-    def close(self):
+    def close(self) -> None:
         """Flush and close this stream."""
         logger.debug("close: called")
 
-    def readable(self):
+    def readable(self) -> bool:
         """Return True if the stream can be read from."""
         return True
 
-    def read(self, size=-1):
+    def read(self, size: int | None = -1) -> bytes:
         """Read up to size bytes from the object and return them."""
+        if size is None:
+            size = -1
         if size == 0:
             return b""
         if size < 0:
             # call read() before setting _current_pos to make sure _content_length is set
             out = self._read_from_buffer() + self._raw_reader.read()
-            self._current_pos = self._raw_reader._content_length  # noqa: SLF001  # intra-package coupling
+            content_length = self._raw_reader._content_length  # noqa: SLF001  # intra-package coupling
+            assert content_length is not None  # noqa: S101  # read() populates _content_length
+            self._current_pos = content_length
             return out
 
         #
@@ -809,11 +859,11 @@ class Reader(io.BufferedIOBase):
         self._fill_buffer(size)
         return self._read_from_buffer(size)
 
-    def read1(self, size=-1):
+    def read1(self, size: int | None = -1) -> bytes:
         """This is the same as read()."""
         return self.read(size=size)
 
-    def readinto(self, b):
+    def readinto(self, b: WriteableBuffer) -> int:
         """Read up to len(b) bytes into b, and return the number of bytes read.
 
         Args:
@@ -822,13 +872,14 @@ class Reader(io.BufferedIOBase):
         Returns:
             The number of bytes read.
         """
-        data = self.read(len(b))
+        mv = memoryview(b).cast("B")
+        data = self.read(len(mv))
         if not data:
             return 0
-        b[: len(data)] = data
+        mv[: len(data)] = data
         return len(data)
 
-    def readline(self, limit=-1):
+    def readline(self, limit: int | None = -1) -> bytes:
         """Read up to and including the next newline.  Returns the bytes read."""
         if limit != -1:
             msg = "limits other than -1 not implemented yet"
@@ -849,14 +900,14 @@ class Reader(io.BufferedIOBase):
 
         return line.getvalue()
 
-    def seekable(self):
+    def seekable(self) -> bool:
         """If False, seek(), tell() and truncate() will raise IOError.
 
         We offer only seek support, and no truncate support.
         """
         return True
 
-    def seek(self, offset, whence=constants.WHENCE_START):
+    def seek(self, offset: int, whence: int = constants.WHENCE_START) -> int:
         """Seek to the specified position.
 
         Args:
@@ -892,22 +943,22 @@ class Reader(io.BufferedIOBase):
         self._seek_initialized = True
         return self._current_pos
 
-    def tell(self):
+    def tell(self) -> int:
         """Return the current position within the file."""
         return self._current_pos
 
-    def truncate(self, size=None):
+    def truncate(self, size: int | None = None) -> int:
         """Unsupported."""
         raise io.UnsupportedOperation
 
-    def detach(self):
+    def detach(self) -> io.RawIOBase:
         """Unsupported."""
         raise io.UnsupportedOperation
 
-    def terminate(self):
+    def terminate(self) -> None:
         """Do nothing."""
 
-    def to_boto3(self, resource):
+    def to_boto3(self, resource: Any) -> Any:
         """Create an **independent** `boto3.s3.Object` instance.
 
         The returned object points to the same S3 object as this instance.
@@ -928,26 +979,27 @@ class Reader(io.BufferedIOBase):
     #
     # Internal methods.
     #
-    def _read_from_buffer(self, size=-1):
+    def _read_from_buffer(self, size: int = -1) -> bytes:
         """Remove at most size bytes from our buffer and return them."""
         size = size if size >= 0 else len(self._buffer)
         part = self._buffer.read(size)
         self._current_pos += len(part)
         return part
 
-    def _fill_buffer(self, size=-1):
+    def _fill_buffer(self, size: int = -1) -> None:
         size = max(size, self._buffer._chunk_size)  # noqa: SLF001  # intra-package coupling
         while len(self._buffer) < size and not self._eof:
-            bytes_read = self._buffer.fill(self._raw_reader)
+            # _SeekableRawReader is duck-typed to ByteBuffer.fill's read-based protocol
+            bytes_read = self._buffer.fill(cast("io.IOBase", self._raw_reader))
             if bytes_read == 0:
                 logger.debug("%s: reached EOF while filling buffer", self)
                 self._eof = True
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return a short human-readable description of the reader."""
         return f"smart_open.s3.Reader({self._bucket!r}, {self._key!r})"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return an unambiguous representation of the reader."""
         return f"smart_open.s3.Reader(bucket={self._bucket!r}, key={self._key!r}, version_id={self._version_id!r}, buffer_size={self._buffer_size!r}, line_terminator={self._line_terminator!r})"
 
@@ -958,17 +1010,21 @@ class MultipartWriter(io.BufferedIOBase):
     Implements the io.BufferedIOBase interface of the standard library.
     """
 
-    _upload_id = None  # so `closed` property works in case __init__ fails and __del__ is called
+    name: str
+    _client: S3Client
+    _bucket: str
+    _key: str
+    _upload_id: str | None = None  # so `closed` property works in case __init__ fails and __del__ is called
 
     def __init__(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
         self,
-        bucket,
-        key,
-        part_size=DEFAULT_PART_SIZE,
-        client=None,
-        client_kwargs=None,
+        bucket: str,
+        key: str,
+        part_size: int = DEFAULT_PART_SIZE,
+        client: S3Client | None = None,
+        client_kwargs: dict[str, Any] | None = None,
         writebuffer: io.BytesIO | None = None,
-    ):
+    ) -> None:
         adjusted_ps = smart_open.utils.clamp(part_size, MIN_PART_SIZE, MAX_PART_SIZE)
         if part_size != adjusted_ps:
             logger.warning("adjusting part_size from %s to %s", part_size, adjusted_ps)
@@ -976,9 +1032,6 @@ class MultipartWriter(io.BufferedIOBase):
         self._part_size = part_size
 
         _initialize_boto3(self, client, client_kwargs, bucket, key)
-        self._client: S3Client
-        self._bucket: str
-        self._key: str
 
         try:
             partial = functools.partial(
@@ -998,15 +1051,15 @@ class MultipartWriter(io.BufferedIOBase):
 
         self._total_bytes = 0
         self._total_parts = 0
-        self._parts: list[dict[str, object]] = []
+        self._parts: list[dict[str, Any]] = []
 
-    def flush(self):
+    def flush(self) -> None:
         """No-op flush; data is buffered until ``close`` or ``_upload_next_part``."""
 
     #
     # Override some methods from io.IOBase.
     #
-    def close(self):
+    def close(self) -> None:
         """Complete the multipart upload (or abort) and close the stream."""
         logger.debug("close: called")
         if self.closed:
@@ -1022,7 +1075,7 @@ class MultipartWriter(io.BufferedIOBase):
                 Bucket=self._bucket,
                 Key=self._key,
                 UploadId=self._upload_id,
-                MultipartUpload={"Parts": self._parts},
+                MultipartUpload=cast("CompletedMultipartUploadTypeDef", {"Parts": self._parts}),
             )
             RETRY._do(partial)  # noqa: SLF001  # intra-package coupling
             logger.debug("%s: completed multipart upload", self)
@@ -1048,34 +1101,34 @@ class MultipartWriter(io.BufferedIOBase):
         self._upload_id = None
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         """Return True if the stream is closed."""
         return self._upload_id is None
 
-    def writable(self):
+    def writable(self) -> bool:
         """Return True if the stream supports writing."""
         return True
 
-    def seekable(self):
+    def seekable(self) -> bool:
         """Return True; we support `tell` but not `seek` or `truncate`."""
         return True
 
-    def seek(self, offset, whence=constants.WHENCE_START):
+    def seek(self, offset: int, whence: int = constants.WHENCE_START) -> int:
         """Unsupported."""
         raise io.UnsupportedOperation
 
-    def truncate(self, size=None):
+    def truncate(self, size: int | None = None) -> int:
         """Unsupported."""
         raise io.UnsupportedOperation
 
-    def tell(self):
+    def tell(self) -> int:
         """Return the current stream position."""
         return self._total_bytes
 
     #
     # io.BufferedIOBase methods.
     #
-    def detach(self):
+    def detach(self) -> io.RawIOBase:
         """Unsupported."""
         msg = "detach() not supported"
         raise io.UnsupportedOperation(msg)
@@ -1115,20 +1168,21 @@ class MultipartWriter(io.BufferedIOBase):
             offset = end
         return len(mv)
 
-    def terminate(self):
+    def terminate(self) -> None:
         """Cancel the underlying multipart upload."""
-        if self.closed:
+        upload_id = self._upload_id
+        if upload_id is None:
             return
         logger.debug("%s: terminating multipart upload", self)
         self._client.abort_multipart_upload(
             Bucket=self._bucket,
             Key=self._key,
-            UploadId=self._upload_id,
+            UploadId=upload_id,
         )
         self._upload_id = None
         logger.debug("%s: terminated multipart upload", self)
 
-    def to_boto3(self, resource):
+    def to_boto3(self, resource: Any) -> Any:
         """Create an **independent** `boto3.s3.Object` instance.
 
         The returned object points to the same S3 object as this instance.
@@ -1147,6 +1201,7 @@ class MultipartWriter(io.BufferedIOBase):
     # Internal methods.
     #
     def _upload_next_part(self) -> None:
+        assert self._upload_id is not None  # noqa: S101  # only called during an active upload
         part_num = self._total_parts + 1
         logger.info(
             "%s: uploading part_num: %i, %i bytes (total %.3fGB)",
@@ -1182,22 +1237,27 @@ class MultipartWriter(io.BufferedIOBase):
         self._buf.seek(0)
         self._buf.truncate(0)
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         """Enter the multipart writer context manager."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Close or terminate the multipart writer on context exit."""
         if exc_type is not None:
             self.terminate()
         else:
             self.close()
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return a short human-readable description of the writer."""
         return f"smart_open.s3.MultipartWriter({self._bucket!r}, {self._key!r})"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return an unambiguous representation of the writer."""
         return f"smart_open.s3.MultipartWriter(bucket={self._bucket!r}, key={self._key!r}, part_size={self._part_size!r})"
 
@@ -1211,16 +1271,20 @@ class SinglepartWriter(io.BufferedIOBase):
     the data be written to S3 and the buffer is released.
     """
 
-    _buf = None  # so `closed` property works in case __init__ fails and __del__ is called
+    name: str
+    _client: S3Client
+    _bucket: str
+    _key: str
+    _buf: io.BytesIO | None = None  # so `closed` property works in case __init__ fails and __del__ is called
 
     def __init__(
         self,
-        bucket,
-        key,
-        client=None,
-        client_kwargs=None,
-        writebuffer=None,
-    ):
+        bucket: str,
+        key: str,
+        client: S3Client | None = None,
+        client_kwargs: dict[str, Any] | None = None,
+        writebuffer: io.BytesIO | None = None,
+    ) -> None:
         _initialize_boto3(self, client, client_kwargs, bucket, key)
 
         if writebuffer is None:
@@ -1231,13 +1295,20 @@ class SinglepartWriter(io.BufferedIOBase):
         else:
             self._buf = writebuffer
 
-    def flush(self):
+    @property
+    def _writebuffer(self) -> io.BytesIO:
+        """Return the active write buffer, asserting the stream is still open."""
+        buf = self._buf
+        assert buf is not None  # noqa: S101  # buffer is set in __init__ and only cleared on close
+        return buf
+
+    def flush(self) -> None:
         """No-op flush; data is buffered until `close`."""
 
     #
     # Override some methods from io.IOBase.
     #
-    def close(self):
+    def close(self) -> None:
         """Upload the buffered bytes as a single-part PUT and close the stream."""
         logger.debug("close: called")
         if self.closed:
@@ -1245,11 +1316,12 @@ class SinglepartWriter(io.BufferedIOBase):
 
         self.seek(0)
 
+        buf = self._writebuffer
         try:
             self._client.put_object(
                 Bucket=self._bucket,
                 Key=self._key,
-                Body=self._buf,
+                Body=buf,
             )
         except botocore.client.ClientError as e:
             msg = f"the bucket {self._bucket!r} does not exist, or is forbidden for access"
@@ -1257,38 +1329,38 @@ class SinglepartWriter(io.BufferedIOBase):
         else:
             logger.debug("%s: direct upload finished", self)
         finally:
-            self._buf.close()
+            buf.close()
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         """Return True if the stream is closed."""
         return self._buf is None or self._buf.closed
 
-    def readable(self):
+    def readable(self) -> bool:
         """Propagate."""
-        return self._buf.readable()
+        return self._writebuffer.readable()
 
-    def writable(self):
+    def writable(self) -> bool:
         """Propagate."""
-        return self._buf.writable()
+        return self._writebuffer.writable()
 
-    def seekable(self):
+    def seekable(self) -> bool:
         """Propagate."""
-        return self._buf.seekable()
+        return self._writebuffer.seekable()
 
-    def seek(self, offset, whence=constants.WHENCE_START):
+    def seek(self, offset: int, whence: int = constants.WHENCE_START) -> int:
         """Propagate."""
-        return self._buf.seek(offset, whence)
+        return self._writebuffer.seek(offset, whence)
 
-    def truncate(self, size=None):
+    def truncate(self, size: int | None = None) -> int:
         """Propagate."""
-        return self._buf.truncate(size)
+        return self._writebuffer.truncate(size)
 
-    def tell(self):
+    def tell(self) -> int:
         """Propagate."""
-        return self._buf.tell()
+        return self._writebuffer.tell()
 
-    def write(self, b):
+    def write(self, b: Buffer) -> int:
         """Write the given buffer into the in-memory buffer.
 
         The buffer can be bytes, bytearray, memoryview or any buffer interface
@@ -1302,58 +1374,63 @@ class SinglepartWriter(io.BufferedIOBase):
         Returns:
             The number of bytes written.
         """
-        return self._buf.write(b)
+        return self._writebuffer.write(b)
 
-    def read(self, size=-1):
+    def read(self, size: int | None = -1) -> bytes:
         """Propagate."""
-        return self._buf.read(size)
+        return self._writebuffer.read(size)
 
-    def read1(self, size=-1):
+    def read1(self, size: int | None = -1) -> bytes:
         """Propagate."""
-        return self._buf.read1(size)
+        return self._writebuffer.read1(size)
 
-    def terminate(self):
+    def terminate(self) -> None:
         """Close buffer and skip upload."""
-        self._buf.close()
+        self._writebuffer.close()
         logger.debug("%s: terminated singlepart upload", self)
 
     #
     # Internal methods.
     #
-    def __enter__(self):
+    def __enter__(self) -> Self:
         """Enter the singlepart writer context manager."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Close or terminate the singlepart writer on context exit."""
         if exc_type is not None:
             self.terminate()
         else:
             self.close()
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return a short human-readable description of the writer."""
         return f"smart_open.s3.SinglepartWriter({self._bucket!r}, {self._key!r})"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return an unambiguous representation of the writer."""
         return f"smart_open.s3.SinglepartWriter(bucket={self._bucket!r}, key={self._key!r})"
 
 
-def _accept_all(key):  # noqa: ARG001  # interface conformance
+def _accept_all(key: str) -> bool:  # noqa: ARG001  # interface conformance
     return True
 
 
 def iter_bucket(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
-    bucket_name,
-    prefix="",
-    accept_key=None,
-    key_limit=None,
-    workers=16,
-    retries=3,
-    max_threads_per_fileobj=4,
-    client_kwargs=None,
-    session_kwargs=None,
+    bucket_name: str,
+    prefix: str = "",
+    accept_key: Callable[[str], bool] | None = None,
+    key_limit: int | None = None,
+    workers: int = 16,
+    retries: int = 3,
+    max_threads_per_fileobj: int = 4,
+    client_kwargs: dict[str, Any] | None = None,
+    session_kwargs: dict[str, Any] | None = None,
 ) -> Iterator[tuple[str, bytes]]:
     """Iterate and download all S3 objects under `s3://bucket_name/prefix`.
 
@@ -1408,12 +1485,14 @@ def iter_bucket(  # noqa: PLR0913  # legacy public API; refactor in a dedicated 
     # If people insist on giving us bucket instances, silently extract the name
     # before moving on.  Works for boto3 as well as boto.
     #
+    bucket: Any = bucket_name
     with contextlib.suppress(AttributeError):
-        bucket_name = bucket_name.name
+        bucket = bucket.name
 
-    if bucket_name is None:
+    if bucket is None:
         msg = "bucket_name may not be None"
         raise ValueError(msg)
+    bucket_name = bucket
 
     total_size, key_no = 0, 0
 
@@ -1478,36 +1557,39 @@ def iter_bucket(  # noqa: PLR0913  # legacy public API; refactor in a dedicated 
 
 def _list_bucket(
     *,
-    bucket_name,
-    client,
-    prefix="",
-    accept_key=lambda k: True,  # noqa: ARG005  # interface conformance
-):
-    ctoken = None
+    bucket_name: str,
+    client: S3Client,
+    prefix: str = "",
+    accept_key: Callable[[str], bool] = lambda k: True,  # noqa: ARG005  # interface conformance
+) -> Iterator[str]:
+    ctoken: str | None = None
 
     while True:
         # list_objects_v2 doesn't like a None value for ContinuationToken
         # so we don't set it if we don't have one.
+        kwargs: dict[str, Any]
         if ctoken:
             kwargs = {"Bucket": bucket_name, "Prefix": prefix, "ContinuationToken": ctoken}
         else:
             kwargs = {"Bucket": bucket_name, "Prefix": prefix}
         response = client.list_objects_v2(**kwargs)
-        try:
-            content = response["Contents"]
-        except KeyError:
-            pass
-        else:
-            for c in content:
-                key = c["Key"]
-                if accept_key(key):
-                    yield key
+        for c in response.get("Contents", []):
+            key = c["Key"]
+            if accept_key(key):
+                yield key
         ctoken = response.get("NextContinuationToken", None)
         if not ctoken:
             break
 
 
-def _download_key(key_name, *, client, bucket_name, retries, transfer_config):
+def _download_key(
+    key_name: str,
+    *,
+    client: S3Client,
+    bucket_name: str,
+    retries: int,
+    transfer_config: Any,
+) -> tuple[str, bytes] | tuple[None, None] | None:
     # Sometimes, https://github.com/boto/boto/issues/2409 can happen
     # because of network issues on either side.
     # Retry up to 3 times to ensure its not a transient issue.
@@ -1536,7 +1618,13 @@ def _download_key(key_name, *, client, bucket_name, retries, transfer_config):
     return None
 
 
-def _download_fileobj(*, client, bucket_name, key_name, transfer_config):
+def _download_fileobj(
+    *,
+    client: S3Client,
+    bucket_name: str,
+    key_name: str,
+    transfer_config: Any,
+) -> bytes:
     #
     # This is a separate function only because it makes it easier to inject
     # exceptions during tests.

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -7,6 +7,8 @@
 
 """Implements the majority of smart_open's top-level API."""
 
+from __future__ import annotations
+
 import collections
 import contextlib
 import locale
@@ -15,6 +17,7 @@ import os
 import os.path
 import pathlib
 import urllib.parse
+from typing import IO, TYPE_CHECKING, Any, BinaryIO, Literal, TextIO, cast, overload
 
 import smart_open.compression as so_compression
 
@@ -26,12 +29,19 @@ import smart_open.local_file as so_file
 import smart_open.utils as so_utils
 from smart_open import doctools, transport
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from typing_extensions import Self
+
+    from smart_open._typing import CompressionKwargs, TransportParams, Uri
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_ENCODING = locale.getpreferredencoding(do_setlocale=False)
 
 
-def _sniff_scheme(uri_as_string):
+def _sniff_scheme(uri_as_string: str) -> str:
     """Returns the scheme of the URL only, as a string."""
     #
     # urlsplit doesn't work on Windows -- it parses the drive as the scheme...
@@ -43,7 +53,7 @@ def _sniff_scheme(uri_as_string):
     return urllib.parse.urlsplit(uri_as_string).scheme
 
 
-def parse_uri(uri_as_string):
+def parse_uri(uri_as_string: str) -> tuple[Any, ...]:
     """Parse the given URI from a string.
 
     Args:
@@ -74,19 +84,68 @@ _parse_uri = parse_uri
 _builtin_open = open
 
 
+@overload
+def open(
+    uri: Uri,
+    mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "rt", "wt", "at", "xt"] = ...,
+    buffering: int = ...,
+    encoding: str | None = ...,
+    errors: str | None = ...,
+    newline: str | None = ...,
+    closefd: bool = ...,  # noqa: FBT001  # public API
+    opener: Callable[[str, int], int] | None = ...,
+    compression: str = ...,
+    compression_kwargs: CompressionKwargs | None = ...,
+    transport_params: TransportParams | None = ...,
+) -> TextIO: ...
+
+
+@overload
+def open(
+    uri: Uri,
+    mode: Literal["rb", "wb", "ab", "xb", "rb+", "wb+", "ab+", "br", "bw", "ba"],
+    buffering: int = ...,
+    *,
+    encoding: None = ...,
+    errors: str | None = ...,
+    newline: str | None = ...,
+    closefd: bool = ...,
+    opener: Callable[[str, int], int] | None = ...,
+    compression: str = ...,
+    compression_kwargs: CompressionKwargs | None = ...,
+    transport_params: TransportParams | None = ...,
+) -> BinaryIO: ...
+
+
+@overload
+def open(
+    uri: Uri,
+    mode: str = ...,
+    buffering: int = ...,
+    encoding: str | None = ...,
+    errors: str | None = ...,
+    newline: str | None = ...,
+    closefd: bool = ...,  # noqa: FBT001  # public API
+    opener: Callable[[str, int], int] | None = ...,
+    compression: str = ...,
+    compression_kwargs: CompressionKwargs | None = ...,
+    transport_params: TransportParams | None = ...,
+) -> IO[Any]: ...
+
+
 def open(  # noqa: C901, PLR0913  # legacy public API; refactor in a dedicated PR
-    uri,
-    mode="r",
-    buffering=-1,
-    encoding=None,
-    errors=None,
-    newline=None,
-    closefd=True,  # noqa: FBT002  # public API
-    opener=None,
-    compression=so_compression.INFER_FROM_EXTENSION,
-    compression_kwargs=None,
-    transport_params=None,
-):
+    uri: Uri,
+    mode: str = "r",
+    buffering: int = -1,
+    encoding: str | None = None,
+    errors: str | None = None,
+    newline: str | None = None,
+    closefd: bool = True,  # noqa: FBT001, FBT002  # public API
+    opener: Callable[[str, int], int] | None = None,
+    compression: str = so_compression.INFER_FROM_EXTENSION,
+    compression_kwargs: CompressionKwargs | None = None,
+    transport_params: TransportParams | None = None,
+) -> IO[Any]:
     r"""Open the URI object, returning a file-like object.
 
     The URI is usually a string in a variety of formats.
@@ -202,13 +261,9 @@ def open(  # noqa: C901, PLR0913  # legacy public API; refactor in a dedicated P
         raise NotImplementedError(ve.args[0]) from ve
 
     binary = _open_binary_stream(uri, binary_mode, transport_params)
-    filename = (
-        binary.name
-        # if name attribute is not string-like (e.g. ftp socket fileno)...
-        if isinstance(getattr(binary, "name", None), str | bytes)
-        # ...fall back to uri
-        else uri
-    )
+    name = getattr(binary, "name", None)
+    # prefer the stream's own name; if it's not string-like (e.g. ftp socket fileno), fall back to uri
+    filename = name if isinstance(name, str) else uri if isinstance(uri, str) else None
     decompressed = so_compression.compression_wrapper(
         binary,
         binary_mode,
@@ -239,10 +294,10 @@ def open(  # noqa: C901, PLR0913  # legacy public API; refactor in a dedicated P
             with contextlib.suppress(AttributeError):
                 setattr(decoded, attr, getattr(binary, attr))
 
-    return so_utils.FileLikeProxy(decoded, binary)
+    return cast("IO[Any]", so_utils.FileLikeProxy(decoded, binary))
 
 
-def _get_binary_mode(mode_str):  # noqa: C901  # legacy internal helper; refactor in a dedicated PR
+def _get_binary_mode(mode_str: str) -> str:  # noqa: C901  # legacy internal helper; refactor in a dedicated PR
     #
     # https://docs.python.org/3/library/functions.html#open
     #
@@ -261,7 +316,7 @@ def _get_binary_mode(mode_str):  # noqa: C901  # legacy internal helper; refacto
         msg = "must have exactly one of create/read/write/append mode"
         raise ValueError(msg)
 
-    def transfer(char):
+    def transfer(char: str) -> None:
         binmode.append(mode.pop(mode.index(char)))
 
     if "a" in mode:
@@ -298,14 +353,14 @@ def _get_binary_mode(mode_str):  # noqa: C901  # legacy internal helper; refacto
 
 
 def _shortcut_open(  # noqa: PLR0913  # legacy internal helper; refactor in a dedicated PR
-    uri,
-    mode,
-    compression,
-    buffering=-1,
-    encoding=None,
-    errors=None,
-    newline=None,
-):
+    uri: Uri,
+    mode: str,
+    compression: str,
+    buffering: int = -1,
+    encoding: str | None = None,
+    errors: str | None = None,
+    newline: str | None = None,
+) -> IO[Any] | None:
     """Try to open the URI using the standard library io.open function.
 
     This can be much faster than the alternative of opening in binary mode and
@@ -346,7 +401,7 @@ def _shortcut_open(  # noqa: PLR0913  # legacy internal helper; refactor in a de
     elif compression != so_compression.NO_COMPRESSION:
         return None
 
-    open_kwargs = {}
+    open_kwargs: dict[str, Any] = {}
     if encoding is not None:
         open_kwargs["encoding"] = encoding
         mode = mode.replace("b", "")
@@ -362,7 +417,7 @@ def _shortcut_open(  # noqa: PLR0913  # legacy internal helper; refactor in a de
     return _builtin_open(local_path, mode, buffering=buffering, **open_kwargs)
 
 
-def _open_binary_stream(uri, mode, transport_params):
+def _open_binary_stream(uri: Uri, mode: str, transport_params: TransportParams) -> IO[bytes]:
     """Open an arbitrary URI in the specified binary mode.
 
     Not all modes are supported for all protocols.
@@ -410,7 +465,13 @@ def _open_binary_stream(uri, mode, transport_params):
     return fobj
 
 
-def _encoding_wrapper(fileobj, mode, encoding=None, errors=None, newline=None):
+def _encoding_wrapper(
+    fileobj: IO[Any],
+    mode: str,
+    encoding: str | None = None,
+    errors: str | None = None,
+    newline: str | None = None,
+) -> IO[Any]:
     """Decode bytes into text, if necessary.
 
     If mode specifies binary access, does nothing, unless the encoding is
@@ -455,20 +516,20 @@ def _encoding_wrapper(fileobj, mode, encoding=None, errors=None, newline=None):
 class patch_pathlib:  # noqa: N801  # function-shaped name in public API
     """Replace `Path.open` with `smart_open.open`."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.old_impl = _patch_pathlib(open)
 
-    def __enter__(self):  # noqa: D105
+    def __enter__(self) -> Self:  # noqa: D105
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):  # noqa: D105
+    def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:  # noqa: D105
         _patch_pathlib(self.old_impl)
 
 
-def _patch_pathlib(func):
+def _patch_pathlib(func: Callable[..., Any]) -> Callable[..., Any]:
     """Replace `Path.open` with `func`."""
     old_impl = pathlib.Path.open
-    pathlib.Path.open = func
+    pathlib.Path.open = func  # ty: ignore[invalid-assignment]  # intentional monkeypatch
     return old_impl
 
 

--- a/smart_open/ssh.py
+++ b/smart_open/ssh.py
@@ -18,12 +18,14 @@ Example:
         b'Ubuntu 4.4.0-1061.70-aws 4.4.131'
 """
 
+from __future__ import annotations
+
 import contextlib
 import getpass
 import logging
 import urllib.parse
-from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING, Any, TypedDict
 
 try:
     import paramiko
@@ -32,12 +34,17 @@ except ImportError:
 
 import smart_open.utils
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from smart_open._typing import TransportParams
+
 logger = logging.getLogger(__name__)
 
 #
 # Global storage for SSH connections.
 #
-_SSH = {}
+_SSH: dict[tuple[str, str], paramiko.SSHClient] = {}
 
 SCHEMES = ("ssh", "scp", "sftp")
 """Supported URL schemes."""
@@ -57,11 +64,11 @@ URI_EXAMPLES = (
 _SSH_CONFIG_FILES = [str(Path("~/.ssh/config").expanduser())]
 
 
-def _unquote(text):
+def _unquote(text: str | None) -> str | None:
     return text and urllib.parse.unquote(text)
 
 
-def _str2bool(string):
+def _str2bool(string: str) -> bool:
     if string == "no":
         return False
     if string == "yes":
@@ -90,7 +97,16 @@ _PARAMIKO_CONFIG_MAP: dict[str, tuple[str, Callable]] = {
 }
 
 
-def parse_uri(uri_as_string):
+class _SSHUri(TypedDict):
+    scheme: str
+    uri_path: str | None
+    user: str | None
+    host: str | None
+    port: int | None
+    password: str | None
+
+
+def parse_uri(uri_as_string: str) -> _SSHUri:
     """Parse an ``ssh://``/``scp://``/``sftp://`` URI into connection components."""
     split_uri = urllib.parse.urlsplit(uri_as_string)
     assert split_uri.scheme in SCHEMES  # noqa: S101  # internal precondition; misuse should crash loudly
@@ -104,17 +120,23 @@ def parse_uri(uri_as_string):
     }
 
 
-def open_uri(uri, mode, transport_params):
+def open_uri(uri: str, mode: str, transport_params: TransportParams) -> paramiko.SFTPFile:
     """Open an SSH/SCP/SFTP URI using the given mode and transport params."""
     kwargs = smart_open.utils.check_kwargs(open, transport_params)
-    parsed_uri = parse_uri(uri)
+    parsed_uri: dict[str, Any] = dict(parse_uri(uri))
     uri_path = parsed_uri.pop("uri_path")
     parsed_uri.pop("scheme")
     final_params = {**parsed_uri, **kwargs}  # transport_params takes precedence over uri
     return open(uri_path, mode, **final_params)
 
 
-def _connect_ssh(hostname, username, port, password, connect_kwargs):
+def _connect_ssh(
+    hostname: str,
+    username: str | None,
+    port: int | None,
+    password: str | None,
+    connect_kwargs: dict[str, Any] | None,
+) -> paramiko.SSHClient:
     ssh = paramiko.SSHClient()
     ssh.load_system_host_keys()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())  # noqa: S507  # documented smart_open default
@@ -122,11 +144,17 @@ def _connect_ssh(hostname, username, port, password, connect_kwargs):
     if "key_filename" not in kwargs:
         kwargs.setdefault("password", password)
     kwargs.setdefault("username", username)
-    ssh.connect(hostname, port, **kwargs)
+    ssh.connect(hostname, port if port is not None else DEFAULT_PORT, **kwargs)
     return ssh
 
 
-def _maybe_fetch_config(host, username=None, password=None, port=None, connect_kwargs=None):  # noqa: C901, PLR0912  # legacy internal helper; refactor in a dedicated PR
+def _maybe_fetch_config(  # noqa: C901, PLR0912  # legacy internal helper; refactor in a dedicated PR
+    host: str | None,
+    username: str | None = None,
+    password: str | None = None,
+    port: int | None = None,
+    connect_kwargs: dict[str, Any] | None = None,
+) -> tuple[str | None, str | None, str | None, int | None, dict[str, Any] | None]:
     # If all fields are set, return as-is.
     if not any(arg is None for arg in (host, username, password, port, connect_kwargs)):
         return host, username, password, port, connect_kwargs
@@ -211,16 +239,16 @@ def _maybe_fetch_config(host, username=None, password=None, port=None, connect_k
 
 
 def open(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
-    path,
-    mode="r",
-    host=None,
-    user=None,
-    password=None,
-    port=None,
-    connect_kwargs=None,
-    prefetch_kwargs=None,
-    buffer_size=-1,
-):
+    path: str | None,
+    mode: str = "r",
+    host: str | None = None,
+    user: str | None = None,
+    password: str | None = None,
+    port: int | None = None,
+    connect_kwargs: dict[str, Any] | None = None,
+    prefetch_kwargs: dict[str, Any] | None = None,
+    buffer_size: int = -1,
+) -> paramiko.SFTPFile:
     """Open a file on a remote machine over SSH.
 
     Expects authentication to be already set up via existing keys on the local machine.
@@ -255,16 +283,22 @@ def open(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
     host, user, password, port, connect_kwargs = _maybe_fetch_config(
         host, user, password, port, connect_kwargs
     )
+    assert host is not None  # noqa: S101  # _maybe_fetch_config raises if host is falsy
+    assert user is not None  # noqa: S101  # _maybe_fetch_config defaults user via getpass.getuser()
+    assert path is not None  # noqa: S101  # callers always provide a remote path to open
 
     key = (host, user)
 
+    sftp_client: paramiko.SFTPClient | None = None
     attempts = 2
     for attempt in range(attempts):
         try:
             ssh = _SSH[key]
             # Validate that the cached connection is still an active connection
             #   and if not, refresh the connection
-            if not ssh.get_transport().active:
+            transport = ssh.get_transport()
+            assert transport is not None  # noqa: S101  # a cached connection has a transport
+            if not transport.active:
                 ssh.close()
                 ssh = _SSH[key] = _connect_ssh(host, user, port, password, connect_kwargs)
         except KeyError:
@@ -272,6 +306,7 @@ def open(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
 
         try:
             transport = ssh.get_transport()
+            assert transport is not None  # noqa: S101  # _connect_ssh established an active transport
             sftp_client = transport.open_sftp_client()
             break
         except paramiko.SSHException as ex:
@@ -285,6 +320,7 @@ def open(  # noqa: PLR0913  # legacy public API; refactor in a dedicated PR
             #
             del _SSH[key]
 
+    assert sftp_client is not None  # noqa: S101  # the loop above either sets this or raises
     fobj = sftp_client.open(path, mode=mode, bufsize=buffer_size)
     fobj.name = path
     if prefetch_kwargs is not None:

--- a/smart_open/transport.py
+++ b/smart_open/transport.py
@@ -10,17 +10,23 @@ The main entrypoint is :func:`get_transport`.  See also :file:`extending.md`.
 
 """
 
+from __future__ import annotations
+
 import importlib
 import logging
+from typing import TYPE_CHECKING
 
 import smart_open.local_file
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 logger = logging.getLogger(__name__)
 
 NO_SCHEME = ""
 
-_REGISTRY = {NO_SCHEME: smart_open.local_file}
-_ERRORS = {}
+_REGISTRY: dict[str, ModuleType] = {NO_SCHEME: smart_open.local_file}
+_ERRORS: dict[str, str] = {}
 _MISSING_DEPS_ERROR = """You are trying to use the %(module)s functionality of smart_open
 but you do not have the correct %(module)s dependencies installed. Try:
 
@@ -29,7 +35,7 @@ but you do not have the correct %(module)s dependencies installed. Try:
 """
 
 
-def register_transport(submodule):
+def register_transport(submodule: str | ModuleType) -> None:
     """Register a submodule as a transport mechanism for ``smart_open``.
 
     This module **must** have:
@@ -42,8 +48,8 @@ def register_transport(submodule):
     Once registered, you can get the submodule by calling :func:`get_transport`.
 
     """
-    module_name = submodule
     if isinstance(submodule, str):
+        module_name = submodule
         try:
             submodule = importlib.import_module(submodule)
         except ImportError:
@@ -72,7 +78,7 @@ def register_transport(submodule):
             _REGISTRY[scheme] = submodule
 
 
-def get_transport(scheme):
+def get_transport(scheme: str) -> ModuleType:
     """Get the submodule that handles transport for the specified scheme.
 
     This submodule must have been previously registered via :func:`register_transport`.

--- a/smart_open/utils.py
+++ b/smart_open/utils.py
@@ -7,12 +7,19 @@
 
 """Helper functions for documentation, etc."""
 
+from __future__ import annotations
+
 import inspect
 import io
 import logging
 import urllib.parse
+from typing import IO, TYPE_CHECKING, Any
 
 import wrapt
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from types import TracebackType
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +27,7 @@ WORKAROUND_SCHEMES = ["s3", "s3n", "s3a", "gcs", "gs"]
 QUESTION_MARK_PLACEHOLDER = "///smart_open.utils.QUESTION_MARK_PLACEHOLDER///"
 
 
-def inspect_kwargs(kallable):
+def inspect_kwargs(kallable: Callable[..., Any]) -> dict[str, Any]:
     """Return a ``{name: default}`` mapping for every default-valued kwarg of `kallable`."""
     signature = inspect.signature(kallable)
     return {
@@ -30,7 +37,7 @@ def inspect_kwargs(kallable):
     }
 
 
-def check_kwargs(kallable, kwargs):
+def check_kwargs(kallable: Callable[..., Any], kwargs: dict[str, Any]) -> dict[str, Any]:
     """Check which keyword arguments the callable supports.
 
     Args:
@@ -51,7 +58,7 @@ def check_kwargs(kallable, kwargs):
     return supported_kwargs
 
 
-def clamp(value, minval=0, maxval=None):
+def clamp(value: int, minval: int = 0, maxval: int | None = None) -> int:
     """Clamp a numeric value to a specific range.
 
     Args:
@@ -67,7 +74,7 @@ def clamp(value, minval=0, maxval=None):
     return max(value, minval)
 
 
-def make_range_string(start=None, stop=None):
+def make_range_string(start: int | None = None, stop: int | None = None) -> str:
     """Create a byte range specifier in accordance with RFC-2616.
 
     Args:
@@ -91,7 +98,7 @@ def make_range_string(start=None, stop=None):
     return f"bytes={start_str}-{stop_str}"
 
 
-def parse_content_range(content_range):
+def parse_content_range(content_range: str) -> tuple[str, int, int, int]:
     """Extract units, start, stop, and length from a content range header like "bytes 0-846981/846982".
 
     Assumes a properly formatted content-range header from S3.
@@ -110,7 +117,7 @@ def parse_content_range(content_range):
     return units, int(start), int(stop), int(length)
 
 
-def safe_urlsplit(url):
+def safe_urlsplit(url: str) -> urllib.parse.SplitResult:
     """This is a hack to prevent the regular urlsplit from splitting around question marks.
 
     A question mark (?) in a URL typically indicates the start of a
@@ -153,7 +160,12 @@ def safe_urlsplit(url):
 class TextIOWrapper(io.TextIOWrapper):
     """`io.TextIOWrapper` subclass that does not close the buffer on exceptions."""
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Call close on underlying buffer only when there was no exception.
 
         Without this patch, TextIOWrapper would call self.buffer.close() during
@@ -168,28 +180,33 @@ class TextIOWrapper(io.TextIOWrapper):
 class FileLikeProxy(wrapt.ObjectProxy):
     """Wrap an `outer` file-like object so that closing it also closes `inner`."""
 
-    __inner = ...  # initialized before wrapt disallows __setattr__ on certain objects
+    __inner: Any = ...  # initialized before wrapt disallows __setattr__ on certain objects
 
-    def __init__(self, outer, inner):
+    def __init__(self, outer: IO[Any], inner: IO[Any]) -> None:
         super().__init__(outer)
         self.__inner = inner
 
-    def __enter__(self):
+    def __enter__(self) -> Any:
         """This explicit proxy method is only required for pylance ref #916."""
         return self.__wrapped__.__enter__()
 
-    def __exit__(self, *args, **kwargs):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> Any:
         """Exit inner after exiting outer."""
         try:
-            return super().__exit__(*args, **kwargs)
+            return super().__exit__(exc_type, exc_value, traceback)
         finally:
-            self.__inner.__exit__(*args, **kwargs)
+            self.__inner.__exit__(exc_type, exc_value, traceback)
 
-    def __next__(self):
+    def __next__(self) -> Any:
         """Delegate iteration to the wrapped file-like object."""
         return self.__wrapped__.__next__()
 
-    def close(self):
+    def close(self) -> None:
         """Close both the wrapped object and the inner object."""
         try:
             return self.__wrapped__.close()

--- a/smart_open/webhdfs.py
+++ b/smart_open/webhdfs.py
@@ -11,18 +11,26 @@ The main entry point is the :func:`~smart_open.webhdfs.open` function.
 
 """
 
+from __future__ import annotations
+
+import http.client as httplib
 import io
 import logging
 import urllib.parse
+from typing import TYPE_CHECKING, Any, TypedDict
 
 try:
     import requests
 except ImportError:
     MISSING_DEPS = True
 
-import http.client as httplib
+import smart_open.utils
+from smart_open import constants
 
-from smart_open import constants, utils
+if TYPE_CHECKING:
+    from _typeshed import ReadableBuffer, WriteableBuffer
+
+    from smart_open._typing import TransportParams
 
 logger = logging.getLogger(__name__)
 
@@ -33,18 +41,27 @@ URI_EXAMPLES = ("webhdfs://host:port/path/file",)
 MIN_PART_SIZE = 50 * 1024**2  # minimum part size for HDFS multipart uploads
 
 
-def parse_uri(uri_as_str):
+class _WebHDFSUri(TypedDict):
+    scheme: str
+    uri: str
+
+
+def parse_uri(uri_as_str: str) -> _WebHDFSUri:
     """Return the WebHDFS URI as a dict with `scheme` and `uri` keys."""
     return {"scheme": SCHEME, "uri": uri_as_str}
 
 
-def open_uri(uri, mode, transport_params):
+def open_uri(
+    uri: str, mode: str, transport_params: TransportParams
+) -> BufferedInputBase | BufferedOutputBase:
     """Open a WebHDFS URI using the given mode and transport params."""
-    kwargs = utils.check_kwargs(open, transport_params)
+    kwargs = smart_open.utils.check_kwargs(open, transport_params)
     return open(uri, mode, **kwargs)
 
 
-def open(http_uri, mode, min_part_size=MIN_PART_SIZE):
+def open(
+    http_uri: str, mode: str, min_part_size: int = MIN_PART_SIZE
+) -> BufferedInputBase | BufferedOutputBase:
     """Open a WebHDFS URI for reading or writing.
 
     Args:
@@ -61,6 +78,7 @@ def open(http_uri, mode, min_part_size=MIN_PART_SIZE):
     if http_uri.startswith(SCHEME):
         http_uri = _convert_to_http_uri(http_uri)
 
+    fobj: BufferedInputBase | BufferedOutputBase
     if mode == constants.READ_BINARY:
         fobj = BufferedInputBase(http_uri)
     elif mode == constants.WRITE_BINARY:
@@ -73,7 +91,7 @@ def open(http_uri, mode, min_part_size=MIN_PART_SIZE):
     return fobj
 
 
-def _convert_to_http_uri(webhdfs_url):
+def _convert_to_http_uri(webhdfs_url: str) -> str:
     """Convert webhdfs uri to http url and return it as text.
 
     Args:
@@ -83,7 +101,7 @@ def _convert_to_http_uri(webhdfs_url):
         The converted HTTP URL as a string.
     """
     split_uri = urllib.parse.urlsplit(webhdfs_url)
-    netloc = split_uri.hostname
+    netloc = split_uri.hostname or ""
     if split_uri.port:
         netloc += f":{split_uri.port}"
     query = split_uri.query
@@ -96,7 +114,7 @@ def _convert_to_http_uri(webhdfs_url):
 #
 # For old unit tests.
 #
-def convert_to_http_uri(parsed_uri):
+def convert_to_http_uri(parsed_uri: Any) -> str:
     """Convert a parsed webhdfs URI to its HTTP REST URL (compat wrapper)."""
     return _convert_to_http_uri(parsed_uri.uri)
 
@@ -104,9 +122,10 @@ def convert_to_http_uri(parsed_uri):
 class BufferedInputBase(io.BufferedIOBase):
     """Buffered WebHDFS reader implementing the `io.BufferedIOBase` interface."""
 
-    _buf = None  # so `closed` property works in case __init__ fails and __del__ is called
+    name: str
+    _buf: bytes | None = None  # so `closed` property works in case __init__ fails and __del__ is called
 
-    def __init__(self, uri):
+    def __init__(self, uri: str) -> None:
         self._uri = uri
 
         payload = {"op": "OPEN", "offset": 0}
@@ -118,43 +137,45 @@ class BufferedInputBase(io.BufferedIOBase):
     #
     # Override some methods from io.IOBase.
     #
-    def close(self):
+    def close(self) -> None:
         """Flush and close this stream."""
         logger.debug("close: called")
         if not self.closed:
             self._buf = None
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         """Return True if the stream is closed."""
         return self._buf is None
 
-    def readable(self):
+    def readable(self) -> bool:
         """Return True if the stream can be read from."""
         return True
 
-    def seekable(self):
+    def seekable(self) -> bool:
         """Return False; the WebHDFS reader does not support seeking."""
         return False
 
     #
     # io.BufferedIOBase methods.
     #
-    def detach(self):
+    def detach(self) -> io.RawIOBase:
         """Unsupported."""
         raise io.UnsupportedOperation
 
-    def read(self, size=None):
+    def read(self, size: int | None = None) -> bytes:
         """Read up to `size` bytes (or all remaining bytes if `size` is None)."""
-        if size is None:
-            self._buf, retval = b"", self._buf + self._response.raw.read()
+        buf = self._buf
+        assert buf is not None  # noqa: S101  # read on a closed stream is unsupported
+        if size is None or size < 0:
+            self._buf, retval = b"", buf + self._response.raw.read()
             return retval
-        if size < len(self._buf):
-            self._buf, retval = self._buf[size:], self._buf[:size]
+        if size < len(buf):
+            self._buf, retval = buf[size:], buf[:size]
             return retval
 
+        buffers = [buf]
         try:
-            buffers = [self._buf]
             total_read = 0
             while total_read < size:
                 raw_data = self._response.raw.read(io.DEFAULT_BUFFER_SIZE)
@@ -168,25 +189,28 @@ class BufferedInputBase(io.BufferedIOBase):
         except StopIteration:
             pass
 
-        self._buf = b"".join(buffers)
-        self._buf, retval = self._buf[size:], self._buf[:size]
+        merged = b"".join(buffers)
+        self._buf, retval = merged[size:], merged[:size]
         return retval
 
-    def read1(self, size=-1):
+    def read1(self, size: int | None = -1) -> bytes:
         """This is the same as read()."""
         return self.read(size=size)
 
-    def readinto(self, b):
+    def readinto(self, b: WriteableBuffer) -> int:
         """Read up to ``len(b)`` bytes into `b` and return the number of bytes read."""
-        data = self.read(len(b))
+        mv = memoryview(b).cast("B")
+        data = self.read(len(mv))
         if not data:
             return 0
-        b[: len(data)] = data
+        mv[: len(data)] = data
         return len(data)
 
-    def readline(self):
+    def readline(self) -> bytes:  # ty: ignore[invalid-method-override]  # never accepted a size argument
         """Read and return one line from the WebHDFS stream."""
-        self._buf, retval = b"", self._buf + self._response.raw.readline()
+        buf = self._buf
+        assert buf is not None  # noqa: S101  # readline on a closed stream is unsupported
+        self._buf, retval = b"", buf + self._response.raw.readline()
         return retval
 
 
@@ -203,7 +227,9 @@ class BufferedOutputBase(io.BufferedIOBase):
             code when creating the file.
     """
 
-    def __init__(self, uri, min_part_size=MIN_PART_SIZE):
+    name: str
+
+    def __init__(self, uri: str, min_part_size: int = MIN_PART_SIZE) -> None:
         self._uri = uri
         self._closed = False
         self.min_part_size = min_part_size
@@ -216,7 +242,7 @@ class BufferedOutputBase(io.BufferedIOBase):
         response = requests.put(uri, data="", headers={"content-type": "application/octet-stream"})  # noqa: S113  # WebHDFS server-side timeouts apply
         if not response.status_code == httplib.CREATED:
             raise WebHdfsException.from_response(response)
-        self.lines = []
+        self.lines: list[bytes] = []
         self.parts = 0
         self.chunk_bytes = 0
         self.total_size = 0
@@ -224,19 +250,19 @@ class BufferedOutputBase(io.BufferedIOBase):
     #
     # Override some methods from io.IOBase.
     #
-    def writable(self):
+    def writable(self) -> bool:
         """Return True if the stream supports writing."""
         return True
 
     #
     # io.BufferedIOBase methods.
     #
-    def detach(self):
+    def detach(self) -> io.RawIOBase:
         """Unsupported."""
         msg = "detach() not supported"
         raise io.UnsupportedOperation(msg)
 
-    def _upload(self, data):
+    def _upload(self, data: bytes) -> None:
         payload = {"op": "APPEND"}
         init_response = requests.post(self._uri, params=payload, allow_redirects=False)  # noqa: S113  # WebHDFS server-side timeouts apply
         if not init_response.status_code == httplib.TEMPORARY_REDIRECT:
@@ -246,7 +272,7 @@ class BufferedOutputBase(io.BufferedIOBase):
         if not response.status_code == httplib.OK:
             raise WebHdfsException.from_response(response)
 
-    def write(self, b):
+    def write(self, b: ReadableBuffer) -> int:
         """Write the given bytes (binary string) into the WebHDFS file from constructor."""
         if self._closed:
             msg = "I/O operation on closed file"
@@ -273,7 +299,9 @@ class BufferedOutputBase(io.BufferedIOBase):
             self.parts += 1
             self.lines, self.chunk_bytes = [], 0
 
-    def close(self):
+        return len(b)
+
+    def close(self) -> None:
         """Flush any remaining buffered bytes to WebHDFS and close the stream."""
         buff = b"".join(self.lines)
         if buff:
@@ -288,7 +316,7 @@ class BufferedOutputBase(io.BufferedIOBase):
         self._closed = True
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         """Return True if the stream is closed."""
         return self._closed
 
@@ -296,16 +324,16 @@ class BufferedOutputBase(io.BufferedIOBase):
 class WebHdfsException(Exception):  # noqa: N818  # public name
     """Exception raised when WebHDFS returns an unexpected HTTP status code."""
 
-    def __init__(self, msg="", status_code=None):
+    def __init__(self, msg: str = "", status_code: int | None = None) -> None:
         self.msg = msg
         self.status_code = status_code
         super().__init__(repr(self))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return an unambiguous representation of the exception."""
         return f"{self.__class__.__name__}(status_code={self.status_code}, msg={self.msg!r})"
 
     @classmethod
-    def from_response(cls, response):
+    def from_response(cls, response: requests.Response) -> WebHdfsException:
         """Build a `WebHdfsException` from a failed `requests.Response`."""
         return cls(msg=response.text, status_code=response.status_code)


### PR DESCRIPTION
Closes #518.

Types the entire public and private API, ships `py.typed` (PEP 561), and enforces the `ty` (astral) type checker via the `astral-sh/ty-pre-commit` hook — which CI already runs through `make lint`.

## What's in here
- **`py.typed`** marker + setuptools `package-data` (verified present in the built sdist and wheel).
- **`smart_open/_typing.py`** with shared aliases: `Uri`, `TransportParams`, `CompressionKwargs`, `Compressor`, `FileObj`.
- **Every module annotated.** `open()` gets `@overload`s (text → `TextIO`, binary → `BinaryIO`, `str`-mode fallback → `IO[Any]`) mirroring the stdlib/xopen pattern; the single real return is `cast(...)` since the `wrapt.ObjectProxy` is opaque.
- **Per-backend `TypedDict`** for each `parse_uri` return (`_S3Uri`, `_AzureUri`, `_GCSUri`, `_HTTPUri`, `_WebHDFSUri`, `_FTPUri`, `_HDFSUri`, `_SSHUri`, `_LocalUri`).
- `from __future__ import annotations` everywhere; optional-dependency types live under `TYPE_CHECKING`, so importing without extras still works.
- **pyproject:** add `[tool.ty]`; drop `"ANN"` from ruff's ignore list (keep `ANN002/003/401`, and ignore `ANN` for tests/scripts); remove pydoclint's `arg-type-hints-in-signature = false` so types live in signatures, and disable its class-attribute check (we document constructor `Args`, not class attributes).
- **`.pre-commit-config.yaml`:** add the `ty` hook with `args: [--isolated, --all-extras]` so CI type-checks against the *real* optional libraries (boto3/azure/google/requests/paramiko), not unresolved stubs.
- `help.txt` regenerated with the typed signatures.

## Behaviour
This is intended to be a **behaviour-neutral typing change** — the annotations don't alter runtime behaviour, with two small, deliberate exceptions where the type checker surfaced non-conformance with `io.BufferedIOBase`:

- `read(None)` (s3/azure/http) and azure `readline(None)` now read to EOF instead of raising `TypeError`/`NotImplementedError`, per the stdlib `io` contract.
- webhdfs `read(size)` with a negative `size` now reads to EOF instead of negative-slicing the buffer.

Where the checker's LSP or third-party stub rules clashed with long-standing runtime behaviour, the behaviour is **preserved** and the diagnostic is suppressed with a targeted `# ty: ignore` — e.g. the Azure SDK accepts a `bytes` block id even though its stub says `str`, and the webhdfs `readline()` keeps its historical no-argument signature. No other reader/writer/`parse_uri` semantics change.

## Verification
- `pre-commit run --all-files` → all hooks pass (ruff, ruff-format, **ty** with `--all-extras`, pydoclint, …).
- `pytest tests` → green (450 passed); `import smart_open` works with all optional deps absent; `py.typed` ships in the wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
