### PR TITLE
Surface transport external dependencies in help.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ Or, if you don't mind installing a large number of third party libraries, you ca
 pip install 'smart_open[all]'
 ```
 
+Some transports have external dependencies that are not `smart_open` extras:
+
+- HTTP Kerberos auth (`kerberos=True`) needs the `requests-kerberos` package: `pip install requests-kerberos`
+- SSH GSSAPI/Kerberos auth (`gss_*` options) needs paramiko's GSSAPI support: `pip install 'paramiko[gssapi]'`
+- The `hdfs://` and `viewfs://` transports shell out to the Hadoop `hdfs` command-line client, which must be installed separately and available on `$PATH`
+
 ### Built-in help
 
 To view the API reference, use the `help` python builtin:

--- a/help.txt
+++ b/help.txt
@@ -168,11 +168,16 @@ FUNCTIONS
 
             hdfs/viewfs (smart_open/hdfs.py)
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            Implements reading and writing to/from HDFS.
+            Implements reading and writing to/from HDFS via the Hadoop ``hdfs`` CLI (must be on your ``$PATH``).
+
+            uri:
+                The HDFS path to open.
+            mode:
+                The mode for opening the object. Must be either "rb" or "wb".
 
             http/https (smart_open/http.py)
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            Implements file-like objects for reading from http.
+            Implements file-like objects for reading from http; ``kerberos=True`` needs the ``requests-kerberos`` package.
 
             uri:
                 The URL to open.
@@ -280,7 +285,7 @@ FUNCTIONS
 
             ssh/scp/sftp (smart_open/ssh.py)
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            Implements I/O streams over SSH.
+            Implements I/O streams over SSH; GSSAPI auth (``gss_*`` options) needs ``paramiko[gssapi]``.
 
             path:
                 The path to the file to open on the remote machine.

--- a/smart_open/hdfs.py
+++ b/smart_open/hdfs.py
@@ -5,7 +5,7 @@
 # from the MIT License (MIT).
 #
 
-"""Implements reading and writing to/from HDFS."""
+"""Implements reading and writing to/from HDFS via the Hadoop ``hdfs`` CLI (must be on your ``$PATH``)."""
 
 from __future__ import annotations
 
@@ -67,7 +67,18 @@ def open_uri(uri: str, mode: str, transport_params: TransportParams) -> CliRawIn
 
 
 def open(uri: str, mode: str) -> CliRawInputBase | CliRawOutputBase:
-    """Open an HDFS `uri` for reading (``"rb"``) or writing (``"wb"``)."""
+    """Open an HDFS `uri` for reading or writing.
+
+    Args:
+        uri: The HDFS path to open.
+        mode: The mode for opening the object. Must be either "rb" or "wb".
+
+    Returns:
+        A file-like object for reading from or writing to the HDFS file.
+
+    Raises:
+        NotImplementedError: If ``mode`` is not supported.
+    """
     if mode == "rb":
         return CliRawInputBase(uri)
     if mode == "wb":

--- a/smart_open/http.py
+++ b/smart_open/http.py
@@ -4,7 +4,7 @@
 # This code is distributed under the terms and conditions
 # from the MIT License (MIT).
 #
-"""Implements file-like objects for reading from http."""
+"""Implements file-like objects for reading from http; ``kerberos=True`` needs the ``requests-kerberos`` package."""
 
 from __future__ import annotations
 
@@ -149,7 +149,7 @@ class BufferedInputBase(io.BufferedIOBase):
         self.session = session or requests
 
         if kerberos:
-            import requests_kerberos  # ty: ignore[unresolved-import]  # optional, install separately for kerberos=True
+            import requests_kerberos  # ty: ignore[unresolved-import]  # optional, install requests-kerberos for kerberos=True
 
             self.auth = requests_kerberos.HTTPKerberosAuth()
         elif user is not None and password is not None:

--- a/smart_open/ssh.py
+++ b/smart_open/ssh.py
@@ -5,7 +5,7 @@
 # from the MIT License (MIT).
 #
 
-"""Implements I/O streams over SSH.
+"""Implements I/O streams over SSH; GSSAPI auth (``gss_*`` options) needs ``paramiko[gssapi]``.
 
 Example:
     >>> with open("/proc/version_signature", host="1.2.3.4") as conn:


### PR DESCRIPTION
Render hdfs `open()` kwargs in help.txt and note each transport's external (non-pip) dependency — the Hadoop `hdfs` CLI, `requests-kerberos`, and `paramiko[gssapi]` — in its module docstring (so it shows in help.txt) and the README.